### PR TITLE
Release Kinematic Benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ tasks/
 upstream/claslib/
 upstream/madocalib/
 upstream/MALIB/
+
+# PPC benchmark dataset, L6 data, and positioning results (large; download on demand)
+data/benchmark/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,71 @@ All notable changes to MRTKLIB are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.3.3] - 2026-03-07
+
+Minor release — kinematic positioning benchmark for urban driving evaluation.
+No functional changes to the library.
+
+### Added
+
+- **Kinematic benchmark infrastructure** (`scripts/benchmark/`) — End-to-end
+  pipeline evaluating CLAS PPP-RTK, MADOCA PPP, and kinematic RTK against the
+  PPC-Dataset urban driving data:
+  - `cases.py` — Metadata for 6 PPC-Dataset runs (GPS week/TOW, city/run IDs)
+  - `download_l6.py` — Auto-download QZSS L6D (CLAS) and L6E (MADOCA) archive
+    files; MADOCA PRN auto-probed from candidates `[209, 193, 194, 195, 196, 199]`
+  - `compare_ppc.py` — NMEA vs `reference.csv` comparison; three-tier accuracy
+    breakdown (FIX/FF/ALL for CLAS & RTK; PPP for MADOCA); computes 2D/3D RMS,
+    1σ, 95%, TTFF, mean satellite count; optional PNG plots
+  - `run_benchmark.py` — Orchestrator with result caching, layered `-k` conf
+    support, and summary table; `--mode clas|madoca|rtk|both|all`
+    (`both`=clas+madoca, `all`=clas+madoca+rtk, default `all`)
+- **Benchmark configurations** (`conf/benchmark/`):
+  - `clas.conf` — CLAS PPP-RTK: `ant1-anttype=*`, `pos2-isb=off`, NMEA output
+  - `madoca.conf` — MADOCA PPP: `pos1-dynamics=on`, `ant1-postype=single`, NMEA
+  - `rtk.conf` — Kinematic RTK: `pos1-frequency=l1+2+3`, `pos1-ionoopt=off`,
+    `pos1-snrmask_r=on` (enables genuine triple-frequency AR)
+  - `nagoya.conf` — City overrides: precise base LLH, antenna types, `ant2-antdelu`
+  - `tokyo.conf` — City overrides: precise base LLH, antenna types, `ant2-antdelu`
+- **Benchmark documentation** ([docs/benchmark.md](docs/benchmark.md)) —
+  Dataset download instructions, L6 auto-download, three-mode execution walkthrough,
+  three-tier metric definitions, result tables, and known limitations.
+
+### Changed
+
+- `.gitignore` — Added `data/benchmark/` exclusion (large L6/NMEA files).
+- `ruff.toml` — Added `scripts/benchmark/*.py` to `D103` per-file-ignores.
+- **PPC-Dataset attribution** — Corrected to credit the contest organiser:
+  Precise Positioning Challenge 2024 (高精度測位チャレンジ2024) by the
+  Institute of Navigation Japan (測位航法学会); data published by Prof. Taro
+  Suzuki (Chiba Institute of Technology).
+- **Benchmark disclaimer** — Added note that parameters are not tuned and
+  results are for reference only.
+
+### Fixed
+
+- **`rnx2rtkp` multi-`-k` conf loading** — `resetsysopts()` was called inside
+  the `-k` processing loop, resetting values already loaded by earlier conf files.
+  Moved to before the loop so layered city overrides (`nagoya.conf`, `tokyo.conf`)
+  take effect correctly.
+- **`loadopts()` leading whitespace** — Values after the `=` separator now have
+  leading whitespace stripped, preventing key lookup failures for entries like
+  `ant1-anttype       = *`.
+- **MADOCA `misc-timeinterp`** — Was inadvertently `off` in the benchmark conf;
+  restored to `on`, matching upstream MADOCALIB behaviour.
+
+### Dataset
+
+The benchmark uses the **PPC-Dataset** from the Precise Positioning Challenge 2024
+(高精度測位チャレンジ2024), organised by the Institute of Navigation Japan
+(測位航法学会). Data published by Prof. Taro Suzuki (Chiba Institute of Technology):
+<https://github.com/taroz/PPC-Dataset>
+
+Six urban vehicle runs (Nagoya × 3, Tokyo × 3) with 5 Hz triple-frequency
+multi-GNSS, 100 Hz IMU, and sub-centimetre Applanix POS LV 220 ground truth.
+
+---
+
 ## [v0.3.2] - 2026-03-06
 
 Patch release — three-tier test methodology with absolute accuracy and position
@@ -311,6 +376,7 @@ Initial release — MALIB structural migration complete.
 - **MALIB integration** — Structural base from JAXA MALIB feature/1.2.0
   (directory layout, threading, stream I/O).
 
+[v0.3.3]: https://github.com/h-shiono/MRTKLIB/compare/v0.3.2...v0.3.3
 [v0.3.2]: https://github.com/h-shiono/MRTKLIB/compare/v0.3.1...v0.3.2
 [v0.3.1]: https://github.com/h-shiono/MRTKLIB/compare/v0.3.0...v0.3.1
 [v0.3.0]: https://github.com/h-shiono/MRTKLIB/compare/v0.2.0...v0.3.0

--- a/apps/rnx2rtkp/rnx2rtkp.c
+++ b/apps/rnx2rtkp/rnx2rtkp.c
@@ -149,10 +149,12 @@ int main(int argc, char **argv)
     sprintf(solopt.prog ,"%s(%s ver.%s)",PROGNAME,MRTKLIB_SOFTNAME,MRTKLIB_VERSION_STRING);
     sprintf(filopt.trace,"%s.trace",PROGNAME);
     
-    /* load options from configuration file */
+    /* load options from configuration file(s)
+     * resetsysopts() is called once before the loop so that multiple -k flags
+     * are layered: each subsequent file overrides only the keys it specifies. */
+    resetsysopts();
     for (i=1;i<argc;i++) {
         if (!strcmp(argv[i],"-k")&&i+1<argc) {
-            resetsysopts();
             if (!loadopts(argv[++i],sysopts)) return -1;
             getsysopts(&prcopt,&solopt,&filopt);
             apply_pppsig(prcopt.pppsig);

--- a/conf/benchmark/clas.conf
+++ b/conf/benchmark/clas.conf
@@ -1,0 +1,144 @@
+# conf/benchmark/clas.conf : CLAS PPP-RTK configuration for PPC-Dataset benchmark
+#
+# Based on conf/claslib/rnx2rtkp.conf with the following changes:
+#   - ant1-anttype = *      (rover RINEX header has "Unknown" antenna)
+#   - pos2-isb = off        (no ISB table entry for Septentrio mosaic-X5)
+#   - out-solformat = nmea  (NMEA output; compare_ppc.py parses GGA sentences)
+#
+# All other parameters inherit from conf/claslib/rnx2rtkp.conf.
+#
+pos1-posmode       =ppp-rtk     # (9:ppp-rtk)
+pos1-frequency     =l1+2+3      # GPS/QZSS L1+L2+L5, Galileo E1+E5
+pos1-soltype       =forward     # (0:forward)
+pos1-elmask        =15          # (deg)
+pos1-snrmask_r     =on          # (0:off,1:on)
+pos1-snrmask_L1    =10,10,10,10,30,30,30,30,30
+pos1-snrmask_L2    =10,10,10,10,30,30,30,30,30
+pos1-snrmask_L5    =10,10,10,10,30,30,30,30,30
+pos1-dynamics      =on          # kinematic
+pos1-tidecorr      =3           # solid+otl-clasgrid+pole
+pos1-ionoopt       =est-adaptive
+pos1-tropopt       =off
+pos1-sateph        =brdc+ssrapc
+pos1-posopt1       =on
+pos1-posopt2       =on          # receiver antenna pco/pcv
+pos1-posopt3       =on          # phase windup
+pos1-posopt4       =on          # exclude eclipsing satellites
+pos1-posopt5       =on          # raim fde
+pos1-posopt6       =meas        # iono time-variation compensation
+pos1-posopt7       =on          # partial ambiguity resolution
+pos1-posopt8       =on          # shapiro delay
+pos1-posopt9       =on          # exclude QZS as reference satellite
+pos1-posopt10      =off
+pos1-posopt11      =l1+l2       # GPS/QZS freq
+pos1-exclsats      =
+pos1-navsys        =25          # GPS+GAL+QZS
+pos1-gridsel       =1000        # [m]
+pos1-rectype       =Septentrio mosaic-X5
+misc-rnxopt1       =
+#
+# Rover antenna: "Unknown" in RINEX header — use wildcard
+ant1-anttype       = *
+ant1-postype       =single
+ant1-antdele       =0.0000
+ant1-antdeln       =0.0000
+ant1-antdelu       =0.0000
+#
+# Base: not used for CLAS PPP-RTK
+ant2-postype       =llh
+ant2-pos1          =0
+ant2-pos2          =0
+ant2-pos3          =0
+ant2-anttype       =*
+ant2-antdele       =0.0000
+ant2-antdeln       =0.0000
+ant2-antdelu       =0.0000
+#
+# Ambiguity resolution
+pos2-armode        =fix-and-hold
+pos2-qzsarmode     =on
+pos2-aralpha       =10%
+pos2-arlockcnt     =5
+pos2-arelmask      =20
+pos2-elmaskhold    =30
+pos2-aroutcnt      =1
+pos2-arminfix      =0
+pos2-varholdamb    =0.001
+pos2-slipthres     =0.05
+pos2-rejionno1     =2.0
+pos2-rejionno2     =3.0
+pos2-rejionno3     =3.0
+pos2-rejionno4     =0.5
+pos2-rejionno5     =5.0
+pos2-niter         =1
+pos2-baselen       =0
+pos2-basesig       =0
+pos2-arminamb      =6
+pos2-armaxdelsat   =4
+pos2-maxage        =30
+pos2-rejdiffpse    =10
+pos2-poserrcnt     =5
+pos2-forgetion     =0.3
+pos2-afgainion     =3.0
+pos2-prnadpt       =off
+pos2-forgetpva     =0.3
+pos2-afgainpva     =1.0
+pos2-isb           =off         # no ISB table entry for Septentrio mosaic-X5
+pos2-rectype       =CLAS
+pos2-phasshft      =table
+#
+# Kalman filter
+stats-eratio1      =50
+stats-errphase     =0.010
+stats-errphaseel   =0.005
+stats-errphasebl   =0.000
+stats-errdoppler   =10
+stats-stdbias      =100
+stats-stdiono      =0.010
+stats-stdtrop      =0.005
+stats-prnaccelh    =0.2
+stats-prnaccelv    =0.1
+stats-prnposith    =0.0000
+stats-prnpositv    =0.0000
+stats-prnbias      =0.00100
+stats-prniono      =0.00100
+stats-prnionomax   =0.05000
+stats-prntrop      =0.00100
+stats-tconstiono   =10.0
+stats-clkstab      =5.00e-12
+#
+# Output: NMEA GGA (compare_ppc.py parses GGA sentences)
+out-solformat      =nmea
+out-outhead        =on
+out-outopt         =on
+out-timesys        =gpst
+out-timeform       =tow
+out-timendec       =3
+out-degform        =deg
+out-fieldsep       =
+out-height         =ellipsoidal
+out-geoid          =internal
+out-solstatic      =all
+out-nmeaintv1      =0
+out-nmeaintv2      =0
+out-outstat        =off
+#
+# Auxiliary files (paths relative to MRTKLIB project root)
+misc-timeinterp    =on
+misc-sbasatsel     =all
+misc-maxobsloss    =90
+misc-floatcnt      =15
+file-cssrgridfile  =./tests/data/claslib/clas_grid.def
+file-blqfile       =./tests/data/claslib/clas_grid.blq
+file-eopfile       =./tests/data/claslib/igu00p01.erp
+file-rcvantfile    =./tests/data/claslib/igs14_L5copy.atx
+file-isbfile       =./tests/data/claslib/isb.tbl
+file-phacycfile    =./tests/data/claslib/l2csft.tbl
+file-satantfile    =
+file-staposfile    =
+file-geoidfile     =
+file-dcbfile       =
+file-tempdir       =
+file-geexefile     =
+file-solstatfile   =
+file-tracefile     =

--- a/conf/benchmark/madoca.conf
+++ b/conf/benchmark/madoca.conf
@@ -1,0 +1,115 @@
+# conf/benchmark/madoca.conf : MADOCA-PPP configuration for PPC-Dataset benchmark
+#
+# Based on conf/madocalib/rnx2rtkp.conf with the following changes:
+#   - pos1-dynamics = on    (kinematic mode)
+#   - ant1-postype = single (no known initial position)
+#   - ant1-anttype = *      (rover RINEX header has "Unknown" antenna)
+#   - out-solformat = nmea  (NMEA output; compare_ppc.py parses GGA sentences)
+#   - out-timeform = tow    (GPS TOW for non-NMEA outputs; NMEA GGA time field is always UTC HHMMSS)
+#
+pos1-posmode       =ppp-kine
+pos1-frequency     =l1+2
+pos1-soltype       =forward
+pos1-elmask        =10
+pos1-snrmask_r     =off
+pos1-snrmask_b     =off
+pos1-snrmask_L1    =0,0,0,0,0,0,0,0,0
+pos1-snrmask_L2    =0,0,0,0,0,0,0,0,0
+pos1-snrmask_L5    =0,0,0,0,0,0,0,0,0
+pos1-dynamics      =on          # kinematic
+pos1-tidecorr      =on
+pos1-ionoopt       =dual-freq
+pos1-tropopt       =est-ztd
+pos1-sateph        =brdc+ssrapc
+pos1-posopt1       =on
+pos1-posopt2       =on
+pos1-posopt3       =on
+pos1-posopt5       =off
+pos1-exclsats      =
+pos1-navsys        =29          # GPS+GLO+GAL+QZS
+pos2-ionocorr      =off
+pos2-armode        =off
+pos2-arsys         =57
+pos2-arthres       =1.5
+pos2-arthres1      =1.5
+pos2-arelmask      =15
+pos2-arminfix      =600
+pos2-armaxiter     =10
+pos2-slipthres     =0.15
+pos2-rejionno      =50
+pos2-rejgdop       =30
+pos2-niter         =1
+pos2-siggps        =L1/L2/L5
+pos2-sigqzs        =L1/L5/L2
+pos2-siggal        =E1/E5a/E5b/E6
+pos2-sigbds2       =B1I/B3I/B2I
+pos2-sigbds3       =B1I/B3I/B2a
+#
+# Output: NMEA GGA (compare_ppc.py parses GGA sentences)
+out-solformat      =nmea
+out-outhead        =on
+out-outopt         =on
+out-outvel         =off
+out-timesys        =gpst
+out-timeform       =tow         # GPS TOW for time matching
+out-timendec       =3
+out-degform        =deg
+out-fieldsep       =
+out-outsingle      =off
+out-maxsolstd      =0
+out-height         =ellipsoidal
+out-geoid          =internal
+out-solstatic      =all
+out-nmeaintv1      =0
+out-nmeaintv2      =0
+out-outstat        =0
+#
+stats-eratio1      =300
+stats-eratio2      =300
+stats-uraratio     =0.1
+stats-errphase     =0.003
+stats-errphaseel   =0.003
+stats-prnbias      =1e-4
+stats-prniono      =0.01
+stats-prntrop      =1e-4
+stats-prnpos       =0
+stats-prnifb       =1e-5
+#
+# Rover: kinematic, no known initial position
+ant1-postype       =single
+ant1-anttype       =*
+ant1-antdele       =0
+ant1-antdeln       =0
+ant1-antdelu       =0
+#
+ant2-postype       =llh
+ant2-pos1          =90
+ant2-pos2          =0
+ant2-pos3          =-6335367.6285
+ant2-anttype       =
+ant2-antdele       =0
+ant2-antdeln       =0
+ant2-antdelu       =0
+ant2-maxaveep      =0
+ant2-initrst       =off
+#
+misc-timeinterp    =on
+misc-sbasatsel     =0
+misc-rnxopt1       =
+misc-rnxopt2       =
+misc-pppopt        =
+misc-rtcmopt       =
+#
+# Auxiliary files (paths relative to MRTKLIB project root)
+file-satantfile    =
+file-rcvantfile    =./tests/data/madocalib/igs20.atx
+file-staposfile    =
+file-geoidfile     =
+file-ionofile      =
+file-dcbfile       =
+file-eopfile       =
+file-blqfile       =
+file-tempdir       =
+file-geexefile     =
+file-solstatfile   =
+file-tracefile     =

--- a/conf/benchmark/nagoya.conf
+++ b/conf/benchmark/nagoya.conf
@@ -1,0 +1,23 @@
+# conf/benchmark/nagoya.conf : Nagoya-specific overrides for PPC-Dataset benchmark
+#
+# Applied AFTER the mode conf (clas.conf / madoca.conf / rtk.conf) via a second
+# -k flag, so these settings override any matching keys in the mode conf.
+#
+# Rover antenna: Trimble TRM105000.10 NONE (per equipment manifest).
+#   Enables per-frequency PCV correction for all three modes.
+ant1-anttype       = TRM105000.10    NONE
+ant1-antdele       = 0.0000
+ant1-antdeln       = 0.0000
+ant1-antdelu       = 0.0000
+#
+# Base station: Meijo University (MEIJOBASE)
+#   Precise marker coordinates (geodetic BLH, WGS-84).
+#   ant2-antdelu = ANTENNA DELTA H from base.obs (ARP below marker).
+ant2-postype       = llh
+ant2-pos1          = 35.13470947      # latitude  (deg)
+ant2-pos2          = 136.97757427     # longitude (deg)
+ant2-pos3          = 104.718          # ellipsoidal height (m)
+ant2-anttype       = TRM115000.00    NONE
+ant2-antdele       = 0.0000
+ant2-antdeln       = 0.0000
+ant2-antdelu       = -0.0652

--- a/conf/benchmark/rtk.conf
+++ b/conf/benchmark/rtk.conf
@@ -1,0 +1,91 @@
+# conf/benchmark/rtk.conf : Standard RTK configuration for PPC-Dataset benchmark
+#
+# GNSS-only kinematic RTK using rover.obs + base.obs.
+# City-specific antenna and base coordinate overrides are applied via a second
+# -k flag (nagoya.conf / tokyo.conf) by run_benchmark.py.
+#
+# Default base position (ant2-postype=rinexhead) is used if no city conf is
+# supplied.  The city conf overrides to precise llh coordinates.
+#
+pos1-posmode       =kinematic   # (2:kinematic)
+pos1-frequency     =l1+2+3      # triple-freq
+pos1-soltype       =forward
+pos1-elmask        =15          # (deg)
+pos1-snrmask_r     =on
+pos1-snrmask_b     =off
+pos1-snrmask_L1    =10,10,10,10,30,30,30,30,30
+pos1-snrmask_L2    =10,10,10,10,30,30,30,30,30
+pos1-snrmask_L5    =10,10,10,10,30,30,30,30,30
+pos1-dynamics      =on          # kinematic
+pos1-tidecorr      =on          # solid earth tides
+pos1-ionoopt       =off
+pos1-tropopt       =off
+pos1-sateph        =brdc
+pos1-posopt1       =on          # satellite antenna (off: no precise eph)
+pos1-posopt2       =on          # receiver antenna PCV (city conf sets antenna type)
+pos1-posopt3       =on          # phase windup
+pos1-posopt4       =on          # eclipsing satellite exclusion
+pos1-posopt5       =on          # RAIM FDE
+pos1-exclsats      =
+pos1-navsys        =57          # GPS+SBS+GLO+GAL+QZS (matches rover observation constellations)
+#
+# Rover
+ant1-postype       =single
+ant1-anttype       =*
+ant1-antdele       =0.0000
+ant1-antdeln       =0.0000
+ant1-antdelu       =0.0000
+#
+# Base: read coordinates from RINEX header APPROX POSITION XYZ
+ant2-postype       =rinexhead
+ant2-anttype       =*
+ant2-antdele       =0.0000
+ant2-antdeln       =0.0000
+ant2-antdelu       =0.0000
+#
+# Ambiguity resolution
+pos2-armode        =fix-and-hold
+pos2-arthres       =3.0
+pos2-arthres1      =0.9999
+pos2-arthres2      =0.25
+pos2-arlockcnt     =0
+pos2-arelmask      =15
+pos2-arminfix      =10
+pos2-armaxiter     =99
+pos2-elmaskhold    =0
+pos2-aroutcnt      =5
+pos2-maxage        =30          # (s)
+pos2-slipthres     =0.05        # (m)
+pos2-rejionno      =30          # (m)
+pos2-rejgdop       =30
+pos2-niter         =1
+pos2-baselen       =0
+pos2-basesig       =0
+#
+# Output: NMEA GGA (compare_ppc.py parses GGA sentences)
+out-solformat      =nmea
+out-outhead        =on
+out-outopt         =on
+out-timesys        =gpst
+out-timeform       =tow
+out-timendec       =3
+out-degform        =deg
+out-fieldsep       =
+out-height         =ellipsoidal
+out-geoid          =internal
+out-solstatic      =all
+out-nmeaintv1      =0
+out-nmeaintv2      =0
+out-outstat        =off
+#
+misc-timeinterp    =on
+misc-sbasatsel     =all
+file-rcvantfile    =./tests/data/madocalib/igs20.atx
+file-satantfile    =
+file-staposfile    =
+file-geoidfile     =
+file-dcbfile       =
+file-tempdir       =
+file-geexefile     =
+file-solstatfile   =
+file-tracefile     =

--- a/conf/benchmark/tokyo.conf
+++ b/conf/benchmark/tokyo.conf
@@ -1,0 +1,22 @@
+# conf/benchmark/tokyo.conf : Tokyo-specific overrides for PPC-Dataset benchmark
+#
+# Applied AFTER the mode conf (clas.conf / madoca.conf / rtk.conf) via a second
+# -k flag, so these settings override any matching keys in the mode conf.
+#
+# Rover antenna: type unknown for the Tokyo dataset — wildcard disables PCV
+#   correction.  This overrides any rover antenna set in the mode conf.
+ant1-anttype       = *
+#
+# Base station: Tokyo reference (CREF0001)
+#   Precise marker coordinates (geodetic BLH, WGS-84).
+#   ant2-anttype: TRM55971.00 NONE (identified from equipment manifest;
+#     base.obs header incorrectly records TRM57971.00).
+#   ant2-antdelu = ANTENNA DELTA H from base.obs (ARP below marker).
+ant2-postype       = llh
+ant2-pos1          = 35.66633426      # latitude  (deg)
+ant2-pos2          = 139.79220181     # longitude (deg)
+ant2-pos3          = 59.82            # ellipsoidal height (m)
+ant2-anttype       = TRM55971.00     NONE
+ant2-antdele       = 0.0000
+ant2-antdeln       = 0.0000
+ant2-antdelu       = -0.0855

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,352 @@
+# Kinematic Positioning Benchmark (PPC-Dataset)
+
+This benchmark evaluates MRTKLIB's kinematic (vehicle-mounted) positioning
+performance using the open-data [PPC2024 (Precise Positioning Challenge)][ppc]
+dataset collected for the contest organised by the Institute of Navigation Japan
+(測位航法学会).  It covers six urban driving runs
+(Nagoya × 3, Tokyo × 3) and supports three positioning modes:
+
+| Mode | Engine | Correction |
+|------|--------|------------|
+| CLAS | PPP-RTK | QZSS L6D (IS-QZSS-L6-003) |
+| MADOCA | PPP | QZSS L6E (MADOCA-PPP) |
+| RTK | Kinematic RTK | Rover + base station RINEX |
+
+> **Note:** This benchmark is intentionally excluded from the regular CTest
+> suite because it requires large external datasets.  Run it on demand.
+
+> **Disclaimer:** The configuration parameters used here have not been tuned or
+> optimised for maximum accuracy.  Results are provided for reference only and
+> should not be taken as representative of the best achievable performance.
+
+---
+
+## Dataset
+
+### Overview
+
+- **Vehicle receiver**: Septentrio mosaic-X5, 5 Hz, RINEX 3.04
+- **Reference station**: Trimble NetR9/Alloy, 1 Hz, RINEX 3.04
+- **Ground truth**: Applanix POS LV 220, provided as `reference.csv`
+
+| Run | City | Date | Duration |
+|-----|------|------|----------|
+| nagoya/run1 | Nagoya | 2024-08-03 | ~26 min |
+| nagoya/run2 | Nagoya | 2024-07-20 | ~32 min |
+| nagoya/run3 | Nagoya | 2024-08-03 | ~17 min |
+| tokyo/run1  | Tokyo  | 2024-07-23 | ~40 min |
+| tokyo/run2  | Tokyo  | 2024-07-23 | ~30 min |
+| tokyo/run3  | Tokyo  | 2024-07-23 | ~51 min |
+
+### Manual Download
+
+The PPC-Dataset (~200 MB) must be downloaded manually:
+
+1. Visit the dataset page or use the direct SharePoint link provided by the
+   PPC2024 organiser.
+2. Download and unzip the archive.
+3. Place the contents so that the layout matches:
+
+```
+data/benchmark/
+  nagoya/
+    run1/
+      rover.obs
+      base.nav
+      base.obs
+      reference.csv
+      ...
+    run2/ ...
+    run3/ ...
+  tokyo/
+    run1/ ...
+    ...
+```
+
+The `data/benchmark/` directory is listed in `.gitignore` and will not be
+committed.
+
+### reference.csv Format
+
+```
+GPS TOW (s), GPS Week, Latitude (deg), Longitude (deg), Ellipsoid Height (m),
+ECEF X (m), ECEF Y (m), ECEF Z (m), Roll (deg), Pitch (deg), Heading (deg),
+East Velocity (m/s), North Velocity (m/s), Up Velocity (m/s)
+```
+
+---
+
+## Prerequisites
+
+1. **Build MRTKLIB** (rnx2rtkp binary):
+
+   ```bash
+   cmake --preset default
+   cmake --build build
+   ```
+
+2. **Extract test data** (ATX, ISB, ERP, etc. required by the CLAS conf):
+
+   ```bash
+   cd build && ctest -R setup --output-on-failure
+   ```
+
+3. **Install Python dependencies**:
+
+   ```bash
+   cd scripts && python -m venv .venv && source .venv/bin/activate
+   pip install numpy matplotlib
+   ```
+
+---
+
+## Quick Start
+
+### Step 1 — Download L6 correction data
+
+```bash
+cd scripts/benchmark
+python download_l6.py --mode both
+```
+
+This downloads the CLAS L6D and MADOCA L6E files for all six runs into
+`data/benchmark/l6/`.  Use `--dry-run` to preview the URLs without downloading.
+
+Options:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--l6-dir DIR` | `data/benchmark/l6` | Where to store L6 files |
+| `--mode clas\|madoca\|both` | `both` | Which correction type |
+| `--case ID[,ID...]` | all | Restrict to specific run IDs |
+| `--dry-run` | off | Print URLs without downloading |
+
+### Step 2 — Run the benchmark
+
+```bash
+python scripts/benchmark/run_benchmark.py
+```
+
+This calls `rnx2rtkp` for each run × mode combination, saves NMEA output to
+`data/benchmark/results/`, and prints a summary table.
+
+Results are cached: if the NMEA output file is newer than all its inputs,
+the positioning step is skipped.  Use `--force` to re-run.
+
+Full options:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--dataset-dir DIR` | `data/benchmark` | PPC-Dataset root |
+| `--l6-dir DIR` | `data/benchmark/l6` | L6 file cache |
+| `--out-dir DIR` | `data/benchmark/results` | NMEA output dir |
+| `--mode clas\|madoca\|rtk\|both\|all` | `all` | Positioning mode (`both`=clas+madoca, `all`=all three) |
+| `--case ID[,ID...]` | all | Run specific cases only |
+| `--rnx2rtkp PATH` | auto | Path to rnx2rtkp binary |
+| `--skip-download` | off | Skip L6 download |
+| `--force` | off | Re-run even if cached |
+| `--skip-epochs N` | 60 | Epochs excluded from metrics |
+| `--plot` | off | Save ENU PNG per case |
+| `-v / --verbose` | off | Show rnx2rtkp output |
+
+### Step 3 — Compare a single result (optional)
+
+```bash
+cd scripts/benchmark
+python compare_ppc.py \
+    --ref ../../data/benchmark/nagoya/run1/reference.csv \
+    ../../data/benchmark/results/nagoya_run1_clas.nmea
+```
+
+---
+
+## v0.3.3 Benchmark Results
+
+Results recorded on MRTKLIB v0.3.3, GNSS-only (no IMU), `--skip-epochs 60`.
+
+### Solution Quality Tiers
+
+CLAS and RTK produce integer-fix solutions and are broken down into three tiers.
+MADOCA-PPP never produces an integer fix and is reported as a single **PPP** tier.
+
+| Tier | Modes | GGA quality | Description |
+|------|-------|-------------|-------------|
+| **FIX** | CLAS, RTK | Q=4 | Integer ambiguity fix epochs only |
+| **FF** | CLAS, RTK | Q=4, 5 | Fix + float; excludes SPP fallback (Q=1) |
+| **ALL** | CLAS, RTK | any | Every matched epoch including SPP |
+| **PPP** | MADOCA | Q=3 | All valid PPP-float epochs (Q=0 already filtered) |
+
+**Rate% column:**
+- FIX / FF rows: fraction of that tier among all matched epochs
+- PPP row: fraction of epochs with 2D horizontal error < 30 cm
+
+**TTFF column:**
+- CLAS / RTK: first epoch of a ≥30-consecutive Q=4 run (shown on FIX row)
+- MADOCA: first epoch of a ≥30-consecutive sub-30 cm run (shown on PPP row)
+
+### Nagoya
+
+| Case | Mode | Tier | N | nSV | Rate% | RMS 2D | 1σ (68%) | 95% | TTFF (s) |
+|------|------|------|--:|----:|------:|-------:|---------:|----:|---------:|
+| nagoya_run1 | CLAS   | FIX |  1 276 |  7.9 | 17.0% |   1.105 m | 0.402 m |  0.452 m |   0 |
+|             |        | FF  |  1 828 |  7.2 | 24.3% |   2.870 m | 0.441 m |  8.409 m |   — |
+|             |        | ALL |  7 525 |  9.0 |     — |  42.784 m | 4.089 m | 53.212 m |   — |
+| nagoya_run1 | MADOCA | PPP |  1 968 | 15.0 |  0.0% |  17.428 m | 2.108 m |  4.684 m |   — |
+| nagoya_run1 | RTK    | FIX |  2 140 | 18.8 | 29.7% |   1.536 m | 0.112 m |  0.151 m | 799 |
+|             |        | FF  |  7 216 | 16.8 |100.0% |   5.953 m | 0.398 m |  4.809 m |   — |
+|             |        | ALL |  7 216 | 16.8 |     — |   5.953 m | 0.398 m |  4.809 m |   — |
+| nagoya_run2 | CLAS   | FIX |  2 522 |  6.5 | 26.9% |   1.088 m | 0.717 m |  0.826 m |   0 |
+|             |        | FF  |  6 002 |  5.6 | 63.9% |  15.903 m | 1.455 m | 36.589 m |   — |
+|             |        | ALL |  9 390 |  4.7 |     — | 305.610 m | 8.323 m | 73.892 m |   — |
+| nagoya_run2 | MADOCA | PPP |  7 494 | 11.9 |  0.2% |  39.299 m | 2.967 m | 19.443 m |   — |
+| nagoya_run2 | RTK    | FIX |  1 489 | 20.7 | 16.1% |   1.081 m | 0.154 m |  0.196 m |   0 |
+|             |        | FF  |  9 274 | 15.3 |100.0% |   6.588 m | 1.026 m | 11.809 m |   — |
+|             |        | ALL |  9 274 | 15.3 |     — |   6.588 m | 1.026 m | 11.809 m |   — |
+| nagoya_run3 | CLAS   | FIX |    325 |  6.9 |  6.3% |   0.318 m | 0.339 m |  0.397 m |   9 |
+|             |        | FF  |  1 973 |  5.7 | 38.4% |  12.026 m | 2.530 m | 38.241 m |   — |
+|             |        | ALL |  5 141 |  6.0 |     — |  12.746 m | 6.606 m | 27.890 m |   — |
+| nagoya_run3 | MADOCA | PPP |  2 753 | 10.8 |  2.1% |   2.649 m | 2.246 m |  4.285 m |   — |
+| nagoya_run3 | RTK    | FIX |    416 | 18.7 |  8.2% |   0.307 m | 0.128 m |  0.150 m |  72 |
+|             |        | FF  |  5 095 | 13.2 |100.0% |   3.832 m | 3.462 m |  8.016 m |   — |
+|             |        | ALL |  5 095 | 13.2 |     — |   3.832 m | 3.462 m |  8.016 m |   — |
+
+### Tokyo
+
+| Case | Mode | Tier | N | nSV | Rate% | RMS 2D | 1σ (68%) | 95% | TTFF (s) |
+|------|------|------|--:|----:|------:|-------:|---------:|----:|---------:|
+| tokyo_run1 | CLAS   | FIX |    612 |  7.6 |  5.2% |   0.868 m |  0.239 m |  2.483 m |  15 |
+|            |        | FF  |  9 235 |  6.4 | 77.8% | 119.243 m |  3.462 m | 25.545 m |   — |
+|            |        | ALL | 11 867 |  5.9 |     — | 627.063 m |  7.914 m |277.340 m |   — |
+| tokyo_run1 | MADOCA | PPP |  3 084 | 12.9 | 16.6% |   1.825 m |  0.979 m |  1.957 m |   0 |
+| tokyo_run1 | RTK    | FIX |    380 | 15.7 |  3.4% |   0.711 m |  0.027 m |  0.643 m |1840 |
+|            |        | FF  | 11 271 | 16.0 |100.0% |   8.272 m |  7.033 m | 19.674 m |   — |
+|            |        | ALL | 11 271 | 16.0 |     — |   8.272 m |  7.033 m | 19.674 m |   — |
+| tokyo_run2 | CLAS   | FIX |  1 972 |  7.2 | 21.7% |   0.590 m |  0.117 m |  1.041 m | 368 |
+|            |        | FF  |  6 841 |  6.3 | 75.3% |  22.988 m |  1.194 m | 14.921 m |   — |
+|            |        | ALL |  9 091 |  5.7 |     — |  33.433 m |  2.389 m | 33.465 m |   — |
+| tokyo_run2 | MADOCA | PPP |  8 159 | 13.7 |  6.7% |   2.894 m |  1.181 m |  4.580 m | 464 |
+| tokyo_run2 | RTK    | FIX |  1 517 | 24.3 | 18.3% |  17.993 m |  0.010 m |  0.059 m | 806 |
+|            |        | FF  |  8 304 | 19.2 |100.0% |  33.845 m |  4.521 m | 50.604 m |   — |
+|            |        | ALL |  8 304 | 19.2 |     — |  33.845 m |  4.521 m | 50.604 m |   — |
+| tokyo_run3 | CLAS   | FIX |  1 129 |  8.1 |  7.4% |   0.801 m |  0.075 m |  1.831 m |  28 |
+|            |        | FF  |  2 629 |  7.3 | 17.2% |   3.764 m |  0.628 m |  2.427 m |   — |
+|            |        | ALL | 15 241 | 11.4 |     — |  41.464 m |  3.737 m | 29.607 m |   — |
+| tokyo_run3 | MADOCA | PPP |  2 795 | 14.3 |  3.4% |   0.724 m |  0.750 m |  1.062 m |  26 |
+| tokyo_run3 | RTK    | FIX |  3 669 | 25.0 | 25.1% |   0.293 m |  0.013 m |  0.051 m | 335 |
+|            |        | FF  | 14 639 | 21.7 |100.0% |   4.178 m |  1.374 m | 10.761 m |   — |
+|            |        | ALL | 14 639 | 21.7 |     — |   4.178 m |  1.374 m | 10.761 m |   — |
+
+### Notes
+
+- **CLAS FIX accuracy** (Q=4 only): RMS 2D is **0.3–1.1 m** across all runs —
+  consistent PPP-RTK performance under urban multipath.
+- **CLAS FF vs ALL gap**: the large ALL RMS (13–627 m) reflects SPP fallback
+  epochs (Q=1) that dominate in dense canyons.  FF tier (24–78%) excludes these.
+- **RTK FF = ALL**: RTK outputs Q=4 (fix) or Q=5 (float) only — no SPP fallback
+  — so FF always equals ALL.
+- **RTK FIX quality**: with triple-frequency AR (`l1+2+3`, `ionoopt=off`), most
+  runs achieve sub-metre FIX RMS (e.g. nagoya_run3: 0.31 m, tokyo_run3: 0.29 m).
+  tokyo_run2 FIX RMS remains elevated (18 m) despite tiny 1σ/95% values, indicating
+  a small number of wrongly-fixed epochs that dominate the RMS at this ~27 km baseline.
+- **MADOCA PPP N**: outputs Q=3 (PPP float) or Q=0 (no solution); Q=0 is
+  filtered, so N reflects epochs where the filter produced a solution.  In
+  nagoya_run1, only 27% of rover epochs have a valid solution (heavy urban
+  multipath).  In nagoya_run2 and tokyo_run2 (more open sky), coverage is ~100%.
+  This is a real performance limitation — not a software or configuration issue.
+- **CLAS nagoya_run2 TTFF=0** means the very first epoch after the skip window
+  was already in a sustained fix run.
+- RTK baselines range from ~13 km (Nagoya) to ~27 km (Tokyo), which is long for
+  kinematic RTK; float solutions dominate accordingly.
+
+---
+
+## Metrics Definitions
+
+| Metric | Description |
+|--------|-------------|
+| **N** | Number of matched epochs (reference ↔ NMEA within 0.15 s) |
+| **nSV** | Mean number of satellites used in the solution for that tier |
+| **Fix%** | Percentage of epochs with GGA quality = 4 (integer AR fix) |
+| **RMS_2D (all)** | Horizontal RMS error across all matched epochs |
+| **RMS_3D (all)** | 3D RMS error across all matched epochs |
+| **RMS_2D (fix)** | Horizontal RMS for Q=4 epochs only; `nan` if no fix |
+| **Conv_s** | Seconds from first matched epoch to first run of ≥30 consecutive Q=4 |
+
+ENU errors are computed per-epoch using the corresponding ground-truth
+coordinate as the reference origin (moving-base projection).
+
+---
+
+## Configuration
+
+The benchmark uses layered configuration files.  Each run is processed with
+`rnx2rtkp -k <mode>.conf -k <city>.conf`, so the city conf overrides only
+the keys it specifies.
+
+**Mode confs** (common settings per algorithm):
+
+- `conf/benchmark/clas.conf` — CLAS PPP-RTK
+- `conf/benchmark/madoca.conf` — MADOCA PPP
+- `conf/benchmark/rtk.conf` — Baseline RTK
+
+**City confs** (antenna types and reference-station coordinates):
+
+- `conf/benchmark/nagoya.conf` — Nagoya overrides
+- `conf/benchmark/tokyo.conf` — Tokyo overrides
+
+Key differences from the standard test configurations:
+
+| Parameter | Value | Reason |
+|-----------|-------|--------|
+| `ant1-anttype` (Nagoya) | `TRM105000.10 NONE` | Trimble antenna per equipment manifest |
+| `ant1-anttype` (Tokyo) | `*` | rover antenna not yet identified |
+| `ant2-anttype` (Nagoya) | `TRM115000.00 NONE` | base antenna per equipment manifest |
+| `ant2-anttype` (Tokyo) | `TRM55971.00 NONE` | base antenna (RINEX header has wrong model) |
+| `pos2-isb` | `off` | no ISB calibration for Septentrio mosaic-X5 |
+| `pos1-dynamics` | `on` | kinematic mode (MADOCA, RTK) |
+| `pos1-frequency` (RTK) | `l1+2+3` | triple-frequency AR |
+| `pos1-ionoopt` (RTK) | `off` | raw observations on all 3 freq (DD cancels iono) |
+| `pos1-snrmask_r` (RTK) | `on` | SNR mask (≥30 dBHz above 25°) |
+| `out-solformat` | `nmea` | GGA parsed by `compare_ppc.py` |
+
+---
+
+## Known Limitations
+
+- **Urban multipath**: The Nagoya and Tokyo datasets include heavy shadowing and
+  multipath.  Fix rates and 3D accuracy will be lower than open-sky tests.
+- **No antenna calibration**: rover RINEX antenna field is "Unknown", so no PCV
+  correction is applied.  This may affect Up accuracy by a few centimetres.
+- **No ISB correction**: Septentrio mosaic-X5 is not in the ISB table.
+  QZSS inter-system biases will be slightly mis-corrected.
+- **MADOCA float only**: MADOCA-PPP mode does not produce integer AR fixes
+  (Q=4) — Fix% and RMS_2D(fix) will be `nan`.
+- **IMU not used**: Only GNSS-only positioning is evaluated.
+
+---
+
+## Acknowledgements
+
+The PPC-Dataset was collected for the **Precise Positioning Challenge 2024
+(高精度測位チャレンジ2024)** organised by the Institute of Navigation Japan
+(測位航法学会), and is kindly made available as open data by:
+
+> **Taro Suzuki**, Chiba Institute of Technology
+> *PPC-Dataset — GNSS/IMU driving data for precise positioning research*
+> <https://github.com/taroz/PPC-Dataset>
+
+We gratefully acknowledge the Institute of Navigation Japan for organising PPC2024
+and Prof. Suzuki for making the dataset publicly available.  Please cite the
+PPC2024 materials when publishing results derived from this dataset.
+
+---
+
+## References
+
+- [PPC2024 overview (Japanese)][ppc-pdf]
+- [PPC2024 results (Japanese)][ppc-res]
+- [PPC-Dataset GitHub][ppc]
+
+[ppc]: https://github.com/taroz/PPC-Dataset
+[ppc-pdf]: http://taroz.net/data/PPC2024.pdf
+[ppc-res]: http://taroz.net/data/PPC2024_results.pdf

--- a/docs/release-notes-v0.3.3.md
+++ b/docs/release-notes-v0.3.3.md
@@ -1,0 +1,213 @@
+# MRTKLIB v0.3.3 Release Notes
+
+**Release date:** 2026-03-07
+**Type:** Minor (benchmark tooling — no functional changes to the library)
+
+---
+
+## Overview
+
+v0.3.3 introduces a **kinematic positioning benchmark** for evaluating MRTKLIB's
+three positioning modes against real-world urban driving data from the PPC-Dataset
+(Precise Positioning Challenge 2024).  Six vehicle runs recorded in Nagoya and
+Tokyo are covered, with sub-centimetre ground truth from an Applanix POS LV 220
+GNSS/INS system.
+
+Three positioning modes are benchmarked:
+
+| Mode | Engine | Correction | Ambiguity |
+|------|--------|------------|-----------|
+| **CLAS** | PPP-RTK | QZSS L6D (IS-QZSS-L6-003) | Integer AR |
+| **MADOCA** | PPP | QZSS L6E (MADOCA-PPP) | Float only |
+| **RTK** | Kinematic RTK | Rover + base RINEX | Integer AR |
+
+No library code, positioning algorithms, or public API changed in this release.
+
+> **Disclaimer:** The configuration parameters used here have not been tuned or
+> optimised for maximum accuracy.  Results are provided for reference only and
+> should not be taken as representative of the best achievable performance.
+
+---
+
+## What Changed
+
+### Kinematic Benchmark Infrastructure (`scripts/benchmark/`)
+
+Four new Python scripts provide an end-to-end kinematic evaluation pipeline:
+
+| Script | Purpose |
+|--------|---------|
+| `cases.py` | Metadata for all 6 PPC-Dataset runs (GPS week/TOW, city/run IDs) |
+| `download_l6.py` | Auto-download QZSS L6D (CLAS) and L6E (MADOCA) archive files |
+| `compare_ppc.py` | Compare `rnx2rtkp` NMEA output against `reference.csv` ground truth |
+| `run_benchmark.py` | Orchestrator: download → run `rnx2rtkp` → compare → summary table |
+
+**Key features:**
+- Three positioning modes: `--mode clas|madoca|rtk|both|all`
+  (`both`=clas+madoca, `all`=clas+madoca+rtk, default `all`)
+- L6D archive: `https://sys.qzss.go.jp/archives/l6/` (CLAS)
+- L6E archive: `https://l6msg.go.gnss.go.jp/archives/` (MADOCA, PRN auto-probe)
+- Result caching: skips `rnx2rtkp` if output file is newer than all inputs
+- Per-case PNG plots (`--plot`) via matplotlib
+- Full CLI with `--mode`, `--case`, `--skip-epochs`, `--force`, `-v`
+
+### Three-Tier Accuracy Breakdown
+
+`compare_ppc.py` now reports **three solution-quality tiers** for CLAS and RTK,
+plus a separate **PPP** tier for MADOCA:
+
+| Tier | GGA Q | Description |
+|------|-------|-------------|
+| **FIX** | 4 | Integer ambiguity fix epochs only |
+| **FF** | 4, 5 | Fix + float; excludes SPP fallback |
+| **ALL** | any | Every matched epoch including SPP |
+| **PPP** | 3 | All valid PPP-float epochs (MADOCA) |
+
+Each row now also reports **nSV** (mean satellite count used in that tier).
+TTFF is defined as the first epoch of a ≥30-consecutive Q=4 run.
+
+### Benchmark Configurations (`conf/benchmark/`)
+
+Five configuration files cover all hardware/mode combinations:
+
+| File | Purpose | Key parameters |
+|------|---------|---------------|
+| `clas.conf` | CLAS PPP-RTK | `ant1-anttype=*`, `pos2-isb=off`, NMEA output |
+| `madoca.conf` | MADOCA PPP | `pos1-dynamics=on`, `ant1-postype=single`, NMEA output |
+| `rtk.conf` | Kinematic RTK | `pos1-frequency=l1+2+3`, `pos1-ionoopt=off`, `snrmask_r=on` |
+| `nagoya.conf` | Nagoya overrides | Precise base LLH, `ant1/ant2-anttype`, `ant2-antdelu` |
+| `tokyo.conf` | Tokyo overrides | Precise base LLH, `ant1/ant2-anttype`, `ant2-antdelu` |
+
+The mode conf and city conf are layered via two `-k` flags; city settings take
+precedence.  City confs supply the precise base-station marker coordinates and
+the `ANTENNA DELTA H` from each base.obs RINEX header (`ant2-antdelu`).
+
+**RTK triple-frequency AR:** With `pos1-ionoopt=off`, `NF(opt)=3` and all three
+raw frequencies (L1/L2/L5) participate in double-difference ambiguity resolution.
+This is effective for the PPC-Dataset baselines (13–27 km) because the rover and
+base are both open-sky stations with good L5 visibility.
+
+**Receiver-specific notes (CLAS/MADOCA):**
+- Rover RINEX files carry `Unknown Unknown` in `ANT # / TYPE` → `ant1-anttype = *`
+- Septentrio mosaic-X5 has no ISB table entry → `pos2-isb = off`
+
+### Bug Fixes (Benchmark Tooling)
+
+| Component | Fix |
+|-----------|-----|
+| `rnx2rtkp` multi-`-k` loading | `resetsysopts()` was called inside the `-k` loop, resetting values set by earlier conf files; moved to before the loop |
+| `loadopts()` leading whitespace | Value strings after the `=` separator now have leading whitespace stripped |
+| MADOCA `misc-timeinterp` | Was inadvertently set to `off` in the original conf; restored to `on` (matches upstream behaviour) |
+
+### Documentation (`docs/benchmark.md`)
+
+Updated benchmark guide covers:
+- PPC-Dataset manual download instructions
+- L6 archive auto-download (`python download_l6.py`)
+- Full benchmark execution walkthrough including RTK mode
+- Complete option reference
+- Three-tier metric definitions (FIX / FF / ALL / PPP)
+- Updated result tables for all three modes
+- Configuration notes explaining the layered conf approach
+- Known limitations (urban multipath, long RTK baselines, no ISB, etc.)
+
+---
+
+## Indicative Benchmark Results
+
+Results on all six PPC-Dataset runs, GNSS-only (no IMU), `--skip-epochs 60`.
+Parameters are not tuned; see the disclaimer at the top of this document.
+
+### Nagoya
+
+| Case | Mode | Tier | N | Fix% | RMS 2D | 1σ | 95% | TTFF (s) |
+|------|------|------|--:|-----:|-------:|---:|----:|---------:|
+| nagoya_run1 | CLAS   | FIX |  1 276 | 17% | 1.105 m | 0.402 m | 0.452 m |    0 |
+|             |        | ALL |  7 525 |  — | 42.8 m  | 4.089 m | 53.2 m  |    — |
+| nagoya_run1 | MADOCA | PPP |  1 968 |  — | 17.4 m  | 2.108 m | 4.684 m |    — |
+| nagoya_run1 | RTK    | FIX |  2 140 | 30% | 1.536 m | 0.112 m | 0.151 m |  799 |
+| nagoya_run2 | CLAS   | FIX |  2 522 | 27% | 1.088 m | 0.717 m | 0.826 m |    0 |
+|             |        | ALL |  9 390 |  — | 305.6 m | 8.323 m | 73.9 m  |    — |
+| nagoya_run2 | MADOCA | PPP |  7 494 |  — | 39.3 m  | 2.967 m | 19.4 m  |    — |
+| nagoya_run2 | RTK    | FIX |  1 489 | 16% | 1.081 m | 0.154 m | 0.196 m |    0 |
+| nagoya_run3 | CLAS   | FIX |    325 |  6% | 0.318 m | 0.339 m | 0.397 m |    9 |
+|             |        | ALL |  5 141 |  — | 12.7 m  | 6.606 m | 27.9 m  |    — |
+| nagoya_run3 | MADOCA | PPP |  2 753 |  — |  2.649 m | 2.246 m | 4.285 m |  — |
+| nagoya_run3 | RTK    | FIX |    416 |  8% | 0.307 m | 0.128 m | 0.150 m |   72 |
+
+### Tokyo
+
+| Case | Mode | Tier | N | Fix% | RMS 2D | 1σ | 95% | TTFF (s) |
+|------|------|------|--:|-----:|-------:|---:|----:|---------:|
+| tokyo_run1 | CLAS   | FIX |    612 |  5% |  0.868 m |  0.239 m |  2.483 m |   15 |
+|            |        | ALL | 11 867 |  — | 627.1 m  |  7.914 m | 277.3 m  |    — |
+| tokyo_run1 | MADOCA | PPP |  3 084 |  — |   1.825 m |  0.979 m |  1.957 m |    0 |
+| tokyo_run1 | RTK    | FIX |    380 |  3% |  0.711 m |  0.027 m |  0.643 m | 1840 |
+| tokyo_run2 | CLAS   | FIX |  1 972 | 22% |  0.590 m |  0.117 m |  1.041 m |  368 |
+|            |        | ALL |  9 091 |  — |  33.4 m  |  2.389 m |  33.5 m  |    — |
+| tokyo_run2 | MADOCA | PPP |  8 159 |  — |   2.894 m |  1.181 m |  4.580 m |  464 |
+| tokyo_run2 | RTK    | FIX |  1 517 | 18% | 17.993 m |  0.010 m |  0.059 m |  806 |
+| tokyo_run3 | CLAS   | FIX |  1 129 |  7% |  0.801 m |  0.075 m |  1.831 m |   28 |
+|            |        | ALL | 15 241 |  — |  41.5 m  |  3.737 m |  29.6 m  |    — |
+| tokyo_run3 | MADOCA | PPP |  2 795 |  — |   0.724 m |  0.750 m |  1.062 m |   26 |
+| tokyo_run3 | RTK    | FIX |  3 669 | 25% |  0.293 m |  0.013 m |  0.051 m |  335 |
+
+**Interpretation:**
+
+- **CLAS FIX accuracy:** 0.3–1.1 m RMS 2D across all runs — consistent with
+  PPP-RTK performance under urban multipath.  Fix rates of 5–27% are expected
+  given the dense canyon environments shown in the dataset's fisheye imagery.
+- **RTK FIX accuracy:** Most runs achieve sub-metre FIX RMS with triple-frequency
+  AR (`l1+2+3`, `ionoopt=off`), e.g. nagoya_run3: 0.31 m, tokyo_run3: 0.29 m.
+  tokyo_run2 FIX RMS is elevated (18 m) despite tiny 1σ/95% values — a small
+  number of wrongly-fixed epochs at this ~27 km baseline dominate the RMS.
+- **RTK FF = ALL:** RTK outputs Q=4 (fix) or Q=5 (float) only — no SPP fallback
+  — so the FF and ALL tiers are identical.
+- **CLAS ALL RMS:** The large ALL-epoch values (13–627 m) reflect Q=1 SPP fallback
+  epochs that dominate in the deepest canyons.  The FF tier (24–78%) removes these.
+- **MADOCA:** Float-only PPP; N reflects epochs with a valid filter solution.
+  In nagoya_run1 (heavy multipath) only 27% of epochs produce a solution.
+  In more open environments (tokyo_run2) coverage reaches ~100%.
+- These results establish a **baseline** for future improvements.
+
+> **Note:** Kinematic benchmark results are not part of the CTest regression
+> suite (PPC-Dataset requires a manual download). Run manually with
+> `python scripts/benchmark/run_benchmark.py`.
+
+---
+
+## Acknowledgements
+
+The kinematic benchmark relies on the **PPC-Dataset** from the Precise Positioning
+Challenge 2024 (高精度測位チャレンジ2024), organised by the
+[Institute of Navigation Japan (測位航法学会)](https://www.in-japan.org/):
+
+> Taro Suzuki, Chiba Institute of Technology.
+> *PPC-Dataset — GNSS/IMU driving data for precise positioning research.*
+> https://github.com/taroz/PPC-Dataset
+
+The dataset provides six urban vehicle runs (Nagoya × 3, Tokyo × 3) with
+5 Hz triple-frequency multi-GNSS observations, 100 Hz IMU data, and
+sub-centimetre ground truth from an Applanix POS LV 220.
+We gratefully acknowledge Prof. Suzuki for making this dataset publicly available.
+
+---
+
+## Test Suite (unchanged at 57 tests)
+
+No new CTest entries in this release. All 57 tests from v0.3.2 continue to pass.
+
+| Test Suite | Tests |
+|------------|-------|
+| Unit tests | 12 |
+| SPP regression | 2 |
+| Receiver bias | 2 |
+| rtkrcv real-time | 1 |
+| MADOCA PPP / PPP-AR / PPP-AR+iono | 10 |
+| CLAS PPP-RTK (single-ch / dual-ch / ST12 / L1CL5) | 10 |
+| CLAS VRS-RTK (single-ch / ST12 / dual-ch) | 9 |
+| ssr2obs / ssr2osr | 3 |
+| BINEX reading | 1 |
+| Tier 2 absolute accuracy | 2 |
+| Tier 3 position scatter | 2 |
+| Fixtures (setup/cleanup/download) | 3 |

--- a/readme.md
+++ b/readme.md
@@ -112,3 +112,13 @@ This project stands on the shoulders of giants:
 | **Lighthouse Technology & Consulting** | MADOCALIB — system integration and L6E/L6D decoder |
 
 For detailed licensing information, please refer to [LICENSE.txt](LICENSE.txt).
+
+## 🗄️ Benchmark Dataset
+
+The kinematic positioning benchmark uses the **PPC-Dataset** (Precise Positioning
+Challenge 2024), kindly released as open data by:
+
+> **Taro Suzuki**, Chiba Institute of Technology
+> <https://github.com/taroz/PPC-Dataset>
+
+See [docs/benchmark.md](docs/benchmark.md) for usage instructions.

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,10 +7,13 @@ select = ["E", "F", "W", "I", "D"]
 # main() in CLI scripts doesn't need a separate docstring (module docstring suffices).
 # One-time migration tools (apply_headers) are also excluded.
 [lint.per-file-ignores]
-"scripts/apply_headers.py"     = ["D103"]
-"scripts/tests/compare_pos.py" = ["D103"]
-"scripts/tests/check_pos_scatter.py" = ["D103"]
-"scripts/tests/compare_nmea.py"      = ["D103"]
+"scripts/apply_headers.py"              = ["D103"]
+"scripts/tests/compare_pos.py"          = ["D103"]
+"scripts/tests/check_pos_scatter.py"    = ["D103"]
+"scripts/tests/compare_nmea.py"         = ["D103"]
+"scripts/benchmark/run_benchmark.py"    = ["D103"]
+"scripts/benchmark/download_l6.py"      = ["D103"]
+"scripts/benchmark/compare_ppc.py"      = ["D103"]
 
 [lint.pydocstyle]
 convention = "google"

--- a/scripts/benchmark/cases.py
+++ b/scripts/benchmark/cases.py
@@ -1,0 +1,143 @@
+"""cases.py - PPC-Dataset benchmark run metadata.
+
+Defines the six PPC2024 driving runs (nagoya × 3, tokyo × 3) and helper
+functions for converting GPS time to UTC and computing the L6 archive
+session letters needed by download_l6.py.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+# GPS epoch and leap seconds
+_GPS_EPOCH = datetime(1980, 1, 6, tzinfo=timezone.utc)
+GPS_LEAP = 18  # GPS - UTC leap seconds (correct as of 2024)
+
+# ---------------------------------------------------------------------------
+# Run metadata
+# ---------------------------------------------------------------------------
+CASES: list[dict] = [
+    {
+        "id": "nagoya_run1",
+        "city": "nagoya",
+        "run": "run1",
+        "gps_week": 2325,
+        "tow_start": 550380.0,
+        "tow_end": 551910.0,
+    },
+    {
+        "id": "nagoya_run2",
+        "city": "nagoya",
+        "run": "run2",
+        "gps_week": 2323,
+        "tow_start": 555720.0,
+        "tow_end": 557610.0,
+    },
+    {
+        "id": "nagoya_run3",
+        "city": "nagoya",
+        "run": "run3",
+        "gps_week": 2325,
+        "tow_start": 553800.0,
+        "tow_end": 554840.0,
+    },
+    {
+        "id": "tokyo_run1",
+        "city": "tokyo",
+        "run": "run1",
+        "gps_week": 2324,
+        "tow_start": 187470.0,
+        "tow_end": 189860.0,
+    },
+    {
+        "id": "tokyo_run2",
+        "city": "tokyo",
+        "run": "run2",
+        "gps_week": 2324,
+        "tow_start": 177000.0,
+        "tow_end": 178830.0,
+    },
+    {
+        "id": "tokyo_run3",
+        "city": "tokyo",
+        "run": "run3",
+        "gps_week": 2324,
+        "tow_start": 179460.0,
+        "tow_end": 182520.0,
+    },
+]
+
+
+def tow_to_utc(week: int, tow: float) -> datetime:
+    """Convert GPS week + time-of-week to UTC datetime.
+
+    Args:
+        week: GPS week number.
+        tow: Time of week in seconds.
+
+    Returns:
+        Corresponding UTC datetime (timezone-aware).
+    """
+    gps_t = _GPS_EPOCH + timedelta(weeks=week, seconds=tow)
+    return gps_t - timedelta(seconds=GPS_LEAP)
+
+
+def l6_sessions(week: int, tow_start: float, tow_end: float) -> list[tuple[int, int, str]]:
+    """Return the L6 archive sessions (year, doy, letter) covering a run.
+
+    Session letters are A–X, one per UTC hour (A = 00:00–01:00, ...).
+    A 30-second margin is added on each side to ensure full coverage.
+
+    Args:
+        week: GPS week number.
+        tow_start: Run start TOW in seconds.
+        tow_end: Run end TOW in seconds.
+
+    Returns:
+        List of (year, doy, session_letter) tuples.  Typically 1–2 entries.
+    """
+    t_start = tow_to_utc(week, tow_start - 30)
+    t_end = tow_to_utc(week, tow_end + 30)
+
+    sessions = []
+    t = t_start.replace(minute=0, second=0, microsecond=0)
+    while t <= t_end:
+        doy = t.timetuple().tm_yday
+        letter = chr(ord("A") + t.hour)
+        entry = (t.year, doy, letter)
+        if entry not in sessions:
+            sessions.append(entry)
+        t += timedelta(hours=1)
+    return sessions
+
+
+def case_by_id(case_id: str) -> dict:
+    """Look up a case by its id string.
+
+    Args:
+        case_id: Case identifier (e.g. ``"nagoya_run1"``).
+
+    Returns:
+        Case metadata dict.
+
+    Raises:
+        KeyError: If no case with that id exists.
+    """
+    for c in CASES:
+        if c["id"] == case_id:
+            return c
+    raise KeyError(f"unknown case: {case_id!r}")
+
+
+# ---------------------------------------------------------------------------
+# Sanity check (python -m scripts.benchmark.cases)
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    for c in CASES:
+        t0 = tow_to_utc(c["gps_week"], c["tow_start"])
+        t1 = tow_to_utc(c["gps_week"], c["tow_end"])
+        dur = (c["tow_end"] - c["tow_start"]) / 60
+        sess = l6_sessions(c["gps_week"], c["tow_start"], c["tow_end"])
+        print(
+            f"{c['id']:18s}  {t0.strftime('%Y-%m-%d %H:%M')}"
+            f"–{t1.strftime('%H:%M')} UTC  {dur:.0f} min  "
+            f"sessions={[f'{y}-{d:03d}{s}' for y,d,s in sess]}"
+        )

--- a/scripts/benchmark/compare_ppc.py
+++ b/scripts/benchmark/compare_ppc.py
@@ -1,0 +1,471 @@
+"""compare_ppc.py - Compare rnx2rtkp NMEA output against PPC-Dataset reference.csv.
+
+Reads rnx2rtkp NMEA GGA output and the PPC-Dataset ground-truth reference.csv,
+matches epochs by UTC time-of-day, computes ENU positioning errors, and reports
+2D/3D RMS, fix rate, and convergence time.
+
+Usage
+-----
+    compare_ppc.py --ref <reference.csv> <result.nmea>
+                   [--skip-epochs N] [--plot] [--plot-out FILE]
+
+Output
+------
+    Per-epoch statistics printed to stdout.  Exit code 0.
+"""
+
+import argparse
+import bisect
+import math
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Locate scripts/tests/ to import shared geodetic helpers
+# ---------------------------------------------------------------------------
+_TESTS_DIR = Path(__file__).resolve().parent.parent / "tests"
+sys.path.insert(0, str(_TESTS_DIR))
+from _geo import blh2xyz, nmea_to_deg, xyz2enu  # noqa: E402
+from cases import GPS_LEAP  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Parsers
+# ---------------------------------------------------------------------------
+_GGA_TAGS = ("$GPGGA", "$GNGGA")
+
+
+def parse_reference(csv_path: str) -> list[tuple[float, float, float, float]]:
+    """Parse PPC-Dataset reference.csv into a list of timed position records.
+
+    Each record holds ``(utc_sod, lat_deg, lon_deg, h_ell)`` where
+    ``utc_sod`` is UTC seconds-of-day derived from the GPS TOW + Week fields.
+
+    Args:
+        csv_path: Path to ``reference.csv``.
+
+    Returns:
+        List of ``(utc_sod, lat_deg, lon_deg, h_ell)`` tuples, sorted by
+        ``utc_sod``.
+    """
+    rows = []
+    with open(csv_path) as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line or line.startswith("#") or line.startswith("GPS"):
+                continue
+            fields = line.split(",")
+            if len(fields) < 5:
+                continue
+            try:
+                tow = float(fields[0])
+                lat = float(fields[2])
+                lon = float(fields[3])
+                h = float(fields[4])
+            except ValueError:
+                continue
+            # GPS TOW → UTC seconds-of-day
+            utc_sod = (tow - GPS_LEAP) % 86400.0
+            rows.append((utc_sod, lat, lon, h))
+    rows.sort(key=lambda r: r[0])
+    return rows
+
+
+def parse_nmea(nmea_path: str) -> list[tuple[float, float, float, float, int, int]]:
+    """Parse rnx2rtkp NMEA GGA output into a list of timed position records.
+
+    Each record holds ``(utc_sod, lat_deg, lon_deg, h_ell, quality, n_sv)``
+    where ``utc_sod`` is UTC seconds-of-day from the GGA time field (HHMMSS.ss).
+    Ellipsoidal height is recovered as ``MSL + geoid_separation``.
+
+    Args:
+        nmea_path: Path to the NMEA file.
+
+    Returns:
+        List of ``(utc_sod, lat_deg, lon_deg, h_ell, quality, n_sv)`` tuples,
+        sorted by ``utc_sod``.
+    """
+    rows = []
+    with open(nmea_path) as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line:
+                continue
+            if "*" in line:
+                line = line[: line.index("*")]
+            fields = line.split(",")
+            if len(fields) < 10:
+                continue
+            if fields[0] not in _GGA_TAGS:
+                continue
+            try:
+                quality = int(fields[6])
+                if quality == 0 or not fields[2] or not fields[4]:
+                    continue
+                # GGA time field: HHMMSS.ss
+                t = fields[1]
+                hh, mm, ss = int(t[0:2]), int(t[2:4]), float(t[4:])
+                utc_sod = hh * 3600.0 + mm * 60.0 + ss
+
+                lat = nmea_to_deg(fields[2], fields[3])
+                lon = nmea_to_deg(fields[4], fields[5])
+                alt_msl = float(fields[9])
+                geoid_sep = 0.0
+                if len(fields) > 11 and fields[11]:
+                    try:
+                        geoid_sep = float(fields[11])
+                    except ValueError:
+                        pass
+                h_ell = alt_msl + geoid_sep
+                n_sv = 0
+                if len(fields) > 7 and fields[7]:
+                    try:
+                        n_sv = int(fields[7])
+                    except ValueError:
+                        pass
+                rows.append((utc_sod, lat, lon, h_ell, quality, n_sv))
+            except (ValueError, IndexError):
+                continue
+    rows.sort(key=lambda r: r[0])
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Time matching
+# ---------------------------------------------------------------------------
+def _match_epochs(
+    ref_rows: list[tuple[float, float, float, float]],
+    nmea_rows: list[tuple[float, float, float, float, int]],
+    tol: float = 0.15,
+) -> list[tuple[tuple, tuple]]:
+    """Pair reference and NMEA epochs by UTC seconds-of-day.
+
+    Handles runs that start near midnight by correcting |Δt| > 43200 s with ±86400 s.
+
+    Args:
+        ref_rows: Sorted list from ``parse_reference()``.
+        nmea_rows: Sorted list from ``parse_nmea()``.
+        tol: Maximum time difference in seconds to accept a match.
+
+    Returns:
+        List of ``(ref_row, nmea_row)`` pairs.
+    """
+    ref_sods = [r[0] for r in ref_rows]
+    pairs = []
+    for nrow in nmea_rows:
+        ns = nrow[0]
+        i = bisect.bisect_left(ref_sods, ns)
+        for j in (i - 1, i):
+            if 0 <= j < len(ref_rows):
+                dt = ns - ref_rows[j][0]
+                # Midnight wrap: if |dt| > half day, add/subtract 86400
+                if dt > 43200.0:
+                    dt -= 86400.0
+                elif dt < -43200.0:
+                    dt += 86400.0
+                if abs(dt) <= tol:
+                    pairs.append((ref_rows[j], nrow))
+                    break
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+def compute_metrics(
+    pairs: list[tuple[tuple, tuple]],
+    skip_epochs: int = 0,
+    threshold_2d: float = float("nan"),
+) -> dict | None:
+    """Compute positioning error statistics from matched epoch pairs.
+
+    Args:
+        pairs: Matched ``(ref_row, nmea_row)`` pairs from ``_match_epochs()``.
+        skip_epochs: Number of initial epochs to discard (convergence exclusion).
+        threshold_2d: Horizontal error threshold in metres for threshold-based
+            fix rate and convergence time (e.g. 0.30 for PPP modes where Q=4
+            is never set).  When ``nan``, only Q=4-based metrics are computed.
+
+    Returns:
+        Dict of statistics, or ``None`` if no usable pairs remain.
+    """
+    pairs = pairs[skip_epochs:]
+    if not pairs:
+        return None
+
+    # Per-epoch ENU projection: compute ECEF error vector and project to local
+    # ENU using the ground-truth lat/lon as the origin for that epoch.
+    enu_errors = []
+    q_list = []
+    sv_list = []
+    abs_tows = []
+
+    for ref_row, nrow in pairs:
+        r_lat, r_lon, r_h = ref_row[1], ref_row[2], ref_row[3]
+        n_lat, n_lon, n_h = nrow[1], nrow[2], nrow[3]
+        q = nrow[4]
+        n_sv = nrow[5] if len(nrow) > 5 else 0
+
+        true_xyz = blh2xyz(r_lat, r_lon, r_h)
+        test_xyz = blh2xyz(n_lat, n_lon, n_h)
+        dx = test_xyz - true_xyz
+        enu = xyz2enu(dx, r_lat, r_lon)
+        enu_errors.append(enu)
+        q_list.append(q)
+        sv_list.append(n_sv)
+        abs_tows.append(ref_row[0])  # utc_sod for convergence calculation
+
+    en = np.array(enu_errors)
+    sv = np.array(sv_list, dtype=float)
+    n = len(en)
+
+    horiz = np.sqrt(en[:, 0] ** 2 + en[:, 1] ** 2)
+    e3d = np.sqrt(en[:, 0] ** 2 + en[:, 1] ** 2 + en[:, 2] ** 2)
+
+    fix_mask = np.array([q == 4 for q in q_list])
+    n_fix = int(fix_mask.sum())
+
+    # Mean satellite count per tier
+    mean_sv_fix = float(np.mean(sv[fix_mask])) if n_fix > 0 else math.nan
+
+    # Fix-only subset (Q=4)
+    if n_fix > 0:
+        h_fix = horiz[fix_mask]
+        e_fix = e3d[fix_mask]
+        rms_2d_fix = float(np.sqrt(np.mean(h_fix**2)))
+        rms_3d_fix = float(np.sqrt(np.mean(e_fix**2)))
+        p68_2d_fix = float(np.percentile(h_fix, 68))
+        p95_2d_fix = float(np.percentile(h_fix, 95))
+    else:
+        rms_2d_fix = rms_3d_fix = p68_2d_fix = p95_2d_fix = math.nan
+
+    # Fix+Float subset: Q=4 (fix), Q=5 (RTK float), Q=3 (PPP float/MADOCA)
+    # Excludes Q=1 (SPP fallback) and Q=2 (DGPS).
+    ff_mask = np.array([q in (3, 4, 5) for q in q_list])
+    n_ff = int(ff_mask.sum())
+    mean_sv_ff = float(np.mean(sv[ff_mask])) if n_ff > 0 else math.nan
+    mean_sv_all = float(np.mean(sv))
+    if n_ff > 0:
+        h_ff = horiz[ff_mask]
+        e_ff = e3d[ff_mask]
+        rms_2d_ff = float(np.sqrt(np.mean(h_ff**2)))
+        rms_3d_ff = float(np.sqrt(np.mean(e_ff**2)))
+        p68_2d_ff = float(np.percentile(h_ff, 68))
+        p95_2d_ff = float(np.percentile(h_ff, 95))
+    else:
+        rms_2d_ff = rms_3d_ff = p68_2d_ff = p95_2d_ff = math.nan
+
+    # Q=4-based convergence: first run of ≥30 consecutive Q=4 epochs
+    conv_time_s = math.nan
+    run = 0
+    run_start_idx = 0
+    for i, q in enumerate(q_list):
+        if q == 4:
+            if run == 0:
+                run_start_idx = i
+            run += 1
+            if run >= 30:
+                conv_time_s = abs_tows[run_start_idx] - abs_tows[0]
+                break
+        else:
+            run = 0
+
+    # Threshold-based metrics (for PPP modes where Q=4 is not produced)
+    thr_rate = math.nan
+    conv_thr_s = math.nan
+    if not math.isnan(threshold_2d):
+        thr_mask = horiz < threshold_2d
+        n_thr = int(thr_mask.sum())
+        thr_rate = n_thr / n * 100.0
+        # TTFF: first run of ≥30 consecutive epochs below threshold
+        run = 0
+        run_start_idx = 0
+        for i, below in enumerate(thr_mask):
+            if below:
+                if run == 0:
+                    run_start_idx = i
+                run += 1
+                if run >= 30:
+                    conv_thr_s = abs_tows[run_start_idx] - abs_tows[0]
+                    break
+            else:
+                run = 0
+
+    return {
+        "n_matched": n,
+        # Q=4 fix
+        "n_fix": n_fix,
+        "fix_rate": n_fix / n * 100.0,
+        "mean_sv_fix": mean_sv_fix,
+        "rms_2d_fix": rms_2d_fix,
+        "rms_3d_fix": rms_3d_fix,
+        "p68_2d_fix": p68_2d_fix,
+        "p95_2d_fix": p95_2d_fix,
+        "conv_time_s": conv_time_s,
+        # Q=4 or Q=5 (fix + float)
+        "n_ff": n_ff,
+        "ff_rate": n_ff / n * 100.0,
+        "mean_sv_ff": mean_sv_ff,
+        "rms_2d_ff": rms_2d_ff,
+        "rms_3d_ff": rms_3d_ff,
+        "p68_2d_ff": p68_2d_ff,
+        "p95_2d_ff": p95_2d_ff,
+        # All epochs
+        "mean_sv_all": mean_sv_all,
+        "rms_2d_all": float(np.sqrt(np.mean(horiz**2))),
+        "rms_3d_all": float(np.sqrt(np.mean(e3d**2))),
+        "p68_2d_all": float(np.percentile(horiz, 68)),
+        "p95_2d_all": float(np.percentile(horiz, 95)),
+        "max_2d_all": float(np.max(horiz)),
+        "rms_e": float(np.sqrt(np.mean(en[:, 0] ** 2))),
+        "rms_n": float(np.sqrt(np.mean(en[:, 1] ** 2))),
+        "rms_u": float(np.sqrt(np.mean(en[:, 2] ** 2))),
+        # Raw arrays (for plotting)
+        "enu_errors": en,
+        "q_list": q_list,
+        "abs_tows": abs_tows,
+        # Threshold-based (for PPP modes)
+        "threshold_2d": threshold_2d,
+        "thr_rate": thr_rate,
+        "conv_thr_s": conv_thr_s,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Plot
+# ---------------------------------------------------------------------------
+def plot_results(m: dict, title: str = "", output_path: str = "ppc_compare.png") -> None:
+    """Generate ENU time-series and Q-flag plot.
+
+    Args:
+        m: Metrics dict from ``compute_metrics()``.
+        title: Plot title prefix.
+        output_path: Output PNG file path.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    en = m["enu_errors"] * 100  # m → cm
+    idx = np.arange(m["n_matched"])
+
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(14, 7), sharex=True)
+    ax1.plot(idx, en[:, 0], label="East", alpha=0.8, linewidth=0.6)
+    ax1.plot(idx, en[:, 1], label="North", alpha=0.8, linewidth=0.6)
+    ax1.plot(idx, en[:, 2], label="Up", alpha=0.5, linewidth=0.6, linestyle="--")
+    ax1.axhline(0, color="k", linewidth=0.4)
+    ax1.set_ylabel("Position error [cm]")
+    ax1.set_title(
+        f"{title}  2D RMS {m['rms_2d_all']*100:.2f} cm  |  "
+        f"Fix {m['fix_rate']:.1f}%  |  "
+        f"2D RMS(fix) {m['rms_2d_fix']*100:.2f} cm"
+        if not math.isnan(m["rms_2d_fix"])
+        else f"{title}  2D RMS {m['rms_2d_all']*100:.2f} cm  |  No fix"
+    )
+    ax1.legend(loc="upper right")
+    ax1.grid(True, alpha=0.3)
+
+    ax2.scatter(idx, m["q_list"], s=4, alpha=0.5)
+    ax2.set_ylabel("GGA quality")
+    ax2.set_xlabel("Matched epoch")
+    ax2.set_title("GGA quality  (Q=4: fix,  Q=5: float,  Q=1: SPP)")
+    ax2.set_yticks([1, 2, 4, 5])
+    ax2.set_yticklabels(["1:SPP", "2:DGPS", "4:Fix", "5:Float"])
+    ax2.grid(True, alpha=0.3)
+
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150)
+    print(f"  Plot saved: {output_path}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def _fmt(v: float, unit: str = "m", digits: int = 3) -> str:
+    """Format a metric value, showing 'nan' for math.nan."""
+    return "nan" if math.isnan(v) else f"{v:.{digits}f} {unit}"
+
+
+def main() -> int:
+    """Run standalone comparison of one NMEA file against one reference.csv."""
+    p = argparse.ArgumentParser(
+        description="Compare rnx2rtkp NMEA output against PPC-Dataset reference.csv"
+    )
+    p.add_argument("--ref", required=True, metavar="CSV",
+                   help="PPC-Dataset reference.csv")
+    p.add_argument("result", metavar="NMEA",
+                   help="rnx2rtkp NMEA output file")
+    p.add_argument("--skip-epochs", type=int, default=0,
+                   help="Initial epochs to skip (convergence exclusion, default: 0)")
+    p.add_argument("--plot", action="store_true",
+                   help="Generate ENU time-series PNG")
+    p.add_argument("--plot-out", default="",
+                   help="Output path for plot (default: <result>.png)")
+    args = p.parse_args()
+
+    if not os.path.isfile(args.ref):
+        print(f"FAIL: reference not found: {args.ref}", file=sys.stderr)
+        return 1
+    if not os.path.isfile(args.result):
+        print(f"FAIL: result not found: {args.result}", file=sys.stderr)
+        return 1
+
+    ref_rows = parse_reference(args.ref)
+    nmea_rows = parse_nmea(args.result)
+    if not ref_rows:
+        print("FAIL: no data in reference.csv", file=sys.stderr)
+        return 1
+    if not nmea_rows:
+        print("FAIL: no GGA sentences in result", file=sys.stderr)
+        return 1
+
+    pairs = _match_epochs(ref_rows, nmea_rows)
+    if not pairs:
+        print("FAIL: no matching epochs (check GPS week / time range)", file=sys.stderr)
+        return 1
+
+    m = compute_metrics(pairs, args.skip_epochs)
+    if m is None:
+        print("FAIL: no usable epochs after skip", file=sys.stderr)
+        return 1
+
+    print(f"Reference : {args.ref}")
+    print(f"Result    : {args.result}")
+    if args.skip_epochs:
+        print(f"Skip      : {args.skip_epochs} epochs")
+    print()
+    print(f"Matched epochs : {m['n_matched']}")
+    print(f"Fix epochs     : {m['n_fix']}  ({m['fix_rate']:.1f}%)")
+    print()
+    print("  ENU RMS (all epochs):")
+    print(f"    East   : {m['rms_e']*100:8.3f} cm")
+    print(f"    North  : {m['rms_n']*100:8.3f} cm")
+    print(f"    Up     : {m['rms_u']*100:8.3f} cm")
+    print()
+    print("  2D horizontal (all epochs):")
+    print(f"    RMS    : {_fmt(m['rms_2d_all'], 'm')}")
+    print(f"    1σ     : {_fmt(m['p68_2d_all'], 'm')}  (68th pctile)")
+    print(f"    95%    : {_fmt(m['p95_2d_all'], 'm')}  (95th pctile)")
+    print(f"    Max    : {_fmt(m['max_2d_all'], 'm')}")
+    print()
+    print("  2D horizontal (Q=4 fix only):")
+    print(f"    RMS    : {_fmt(m['rms_2d_fix'], 'm')}")
+    print(f"    1σ     : {_fmt(m['p68_2d_fix'], 'm')}")
+    print(f"    95%    : {_fmt(m['p95_2d_fix'], 'm')}")
+    print()
+    conv = m["conv_time_s"]
+    conv_str = _fmt(conv, "s", 0) if not math.isnan(conv) else "never (no 30-epoch fix run)"
+    print(f"  Convergence: {conv_str}")
+
+    if args.plot:
+        out = args.plot_out or (os.path.splitext(args.result)[0] + ".png")
+        plot_results(m, title=os.path.basename(args.result), output_path=out)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmark/download_l6.py
+++ b/scripts/benchmark/download_l6.py
@@ -1,0 +1,255 @@
+"""download_l6.py - Download QZSS L6D (CLAS) and L6E (MADOCA) archive files.
+
+Downloads only the L6 sessions needed for the configured PPC-Dataset runs.
+Files that already exist are skipped.  Requires only the Python standard library.
+
+Archive URLs
+------------
+L6D (CLAS):
+    https://sys.qzss.go.jp/archives/l6/{year}/{year}{doy}{session}.l6
+
+L6E (MADOCA):
+    https://l6msg.go.gnss.go.jp/archives/{year}/{doy}/{year}{doy}{session}.{prn}.l6
+    PRN candidates tried in order: 209, 193, 194, 195, 196, 199
+
+Usage
+-----
+    python download_l6.py [--l6-dir DIR] [--mode clas|madoca|both]
+                          [--case ID[,ID...]] [--dry-run]
+"""
+
+import argparse
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from cases import CASES, l6_sessions
+
+# ---------------------------------------------------------------------------
+# URL templates
+# ---------------------------------------------------------------------------
+_L6D_URL = "https://sys.qzss.go.jp/archives/l6/{year}/{year}{doy:03d}{session}.l6"
+_L6E_URL = (
+    "https://l6msg.go.gnss.go.jp/archives/{year}/{doy:03d}/"
+    "{year}{doy:03d}{session}.{prn}.l6"
+)
+MADOCA_PRNS = [209, 193, 194, 195, 196, 199]
+
+
+# ---------------------------------------------------------------------------
+# Low-level helpers
+# ---------------------------------------------------------------------------
+def _l6d_url(year: int, doy: int, session: str) -> str:
+    """Build L6D (CLAS) archive URL."""
+    return _L6D_URL.format(year=year, doy=doy, session=session)
+
+
+def _l6e_url(year: int, doy: int, session: str, prn: int) -> str:
+    """Build L6E (MADOCA) archive URL for a specific PRN."""
+    return _L6E_URL.format(year=year, doy=doy, session=session, prn=prn)
+
+
+def _probe_l6e_prn(year: int, doy: int, session: str) -> int | None:
+    """Find the first available MADOCA PRN for a given session.
+
+    Args:
+        year: Calendar year.
+        doy: Day-of-year.
+        session: Session letter (A–X).
+
+    Returns:
+        First PRN that returns HTTP 200, or ``None`` if none found.
+    """
+    for prn in MADOCA_PRNS:
+        url = _l6e_url(year, doy, session, prn)
+        try:
+            req = urllib.request.Request(url, method="HEAD")
+            with urllib.request.urlopen(req, timeout=10):
+                return prn
+        except (urllib.error.HTTPError, urllib.error.URLError, OSError):
+            continue
+    return None
+
+
+def _download(url: str, dest: Path, dry_run: bool = False) -> bool:
+    """Download a URL to dest, printing progress.
+
+    Args:
+        url: Source URL.
+        dest: Destination file path.
+        dry_run: If True, print URL without downloading.
+
+    Returns:
+        True on success (or dry-run), False on failure.
+    """
+    if dest.exists():
+        print(f"  [skip]     {dest.name} (already exists)")
+        return True
+    if dry_run:
+        print(f"  [dry-run]  {url}")
+        print(f"             → {dest}")
+        return True
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    try:
+        print(f"  [download] {url}")
+        print(f"             → {dest.name} ", end="", flush=True)
+        urllib.request.urlretrieve(url, tmp)
+        tmp.rename(dest)
+        size_kb = dest.stat().st_size // 1024
+        print(f"({size_kb} KB)")
+        return True
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError) as exc:
+        print(f"FAIL: {exc}")
+        if tmp.exists():
+            tmp.unlink()
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Public interface
+# ---------------------------------------------------------------------------
+def download_l6d_session(
+    year: int, doy: int, session: str, l6_dir: Path, dry_run: bool = False
+) -> Path | None:
+    """Download one L6D (CLAS) session file.
+
+    Args:
+        year: Calendar year.
+        doy: Day-of-year (1-based).
+        session: Session letter (A–X).
+        l6_dir: Local directory to store the file.
+        dry_run: Print URL without downloading.
+
+    Returns:
+        Path to the local file, or ``None`` on failure.
+    """
+    fname = f"{year}{doy:03d}{session}.l6"
+    dest = l6_dir / fname
+    url = _l6d_url(year, doy, session)
+    return dest if _download(url, dest, dry_run) else None
+
+
+def download_l6e_session(
+    year: int, doy: int, session: str, l6_dir: Path, dry_run: bool = False
+) -> Path | None:
+    """Download one L6E (MADOCA) session file.
+
+    Probes PRN candidates in order and downloads the first available file.
+
+    Args:
+        year: Calendar year.
+        doy: Day-of-year (1-based).
+        session: Session letter (A–X).
+        l6_dir: Local directory to store the file.
+        dry_run: Print URL without downloading.
+
+    Returns:
+        Path to the local file, or ``None`` if no PRN found.
+    """
+    if dry_run:
+        print(f"  [dry-run]  probing MADOCA PRNs for {year}/{doy:03d}/{session}:")
+        for prn in MADOCA_PRNS:
+            print(f"             {_l6e_url(year, doy, session, prn)}")
+        return l6_dir / f"{year}{doy:03d}{session}.{MADOCA_PRNS[0]}.l6"
+
+    prn = _probe_l6e_prn(year, doy, session)
+    if prn is None:
+        print(f"  [FAIL]     no MADOCA PRN found for {year}/{doy:03d}/{session}")
+        return None
+    fname = f"{year}{doy:03d}{session}.{prn}.l6"
+    dest = l6_dir / fname
+    url = _l6e_url(year, doy, session, prn)
+    return dest if _download(url, dest, dry_run) else None
+
+
+def ensure_case_l6(
+    case: dict, l6_dir: Path, mode: str = "both", dry_run: bool = False
+) -> dict[str, list[Path]]:
+    """Ensure all L6 files needed for a run are present.
+
+    Args:
+        case: Case metadata dict from ``cases.CASES``.
+        l6_dir: Directory to store L6 files.
+        mode: ``"clas"``, ``"madoca"``, or ``"both"``.
+        dry_run: Print URLs without downloading.
+
+    Returns:
+        Dict ``{"clas": [...], "madoca": [...]}`` with local file paths.
+        Missing files are omitted.
+    """
+    sessions = l6_sessions(case["gps_week"], case["tow_start"], case["tow_end"])
+    result: dict[str, list[Path]] = {"clas": [], "madoca": []}
+
+    for year, doy, session in sessions:
+        if mode in ("clas", "both"):
+            p = download_l6d_session(year, doy, session, l6_dir, dry_run)
+            if p:
+                result["clas"].append(p)
+        if mode in ("madoca", "both"):
+            p = download_l6e_session(year, doy, session, l6_dir, dry_run)
+            if p:
+                result["madoca"].append(p)
+    return result
+
+
+def ensure_all(
+    cases: list[dict], l6_dir: Path, mode: str = "both", dry_run: bool = False
+) -> dict[str, dict[str, list[Path]]]:
+    """Download all L6 files for a list of cases.
+
+    Args:
+        cases: List of case metadata dicts.
+        l6_dir: Directory to store L6 files.
+        mode: ``"clas"``, ``"madoca"``, or ``"both"``.
+        dry_run: Print URLs without downloading.
+
+    Returns:
+        Dict keyed by case id → ``{"clas": [...], "madoca": [...]}`` paths.
+    """
+    all_results = {}
+    for case in cases:
+        print(f"\n--- {case['id']} ---")
+        all_results[case["id"]] = ensure_case_l6(case, l6_dir, mode, dry_run)
+    return all_results
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def main() -> int:
+    """Download L6 files for the configured PPC-Dataset runs."""
+    p = argparse.ArgumentParser(
+        description="Download CLAS L6D and MADOCA L6E files for PPC-Dataset benchmark"
+    )
+    p.add_argument("--l6-dir", default="data/benchmark/l6",
+                   help="Directory to store L6 files (default: data/benchmark/l6)")
+    p.add_argument("--mode", choices=["clas", "madoca", "both"], default="both",
+                   help="Which L6 type to download (default: both)")
+    p.add_argument("--case", default="",
+                   help="Comma-separated case IDs (default: all)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Print URLs without downloading")
+    args = p.parse_args()
+
+    l6_dir = Path(args.l6_dir)
+    if not args.dry_run:
+        l6_dir.mkdir(parents=True, exist_ok=True)
+
+    # Filter cases
+    cases = CASES
+    if args.case:
+        ids = {c.strip() for c in args.case.split(",")}
+        cases = [c for c in CASES if c["id"] in ids]
+        if not cases:
+            print(f"FAIL: no matching cases for: {args.case}", file=sys.stderr)
+            return 1
+
+    ensure_all(cases, l6_dir, args.mode, args.dry_run)
+    print("\nDone.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmark/run_benchmark.py
+++ b/scripts/benchmark/run_benchmark.py
@@ -1,0 +1,508 @@
+"""run_benchmark.py - Run MRTKLIB kinematic positioning benchmark on PPC-Dataset.
+
+For each configured driving run, calls rnx2rtkp in PPP-RTK (CLAS), PPP
+(MADOCA), and/or kinematic RTK mode, then compares the NMEA output against the
+PPC-Dataset ground truth reference.csv.  Results are summarised in a
+fixed-width ASCII table.
+
+Requirements
+------------
+- PPC-Dataset must be present at --dataset-dir (manual download required).
+  See docs/benchmark.md for download instructions.
+- CLAS L6D and MADOCA L6E files are downloaded automatically to --l6-dir
+  unless --skip-download is given.
+- rnx2rtkp binary is located automatically under build/ or can be specified
+  with --rnx2rtkp.
+- Python packages: numpy (always); matplotlib (only with --plot).
+
+Usage
+-----
+    python run_benchmark.py [options]
+
+    --dataset-dir DIR           PPC-Dataset root (default: data/benchmark)
+    --l6-dir DIR                L6 file cache (default: data/benchmark/l6)
+    --out-dir DIR               Results directory (default: data/benchmark/results)
+    --mode clas|madoca|rtk|both|all  (both=clas+madoca, all=clas+madoca+rtk, default: all)
+    --case ID[,ID...]           Run subset (default: all 6 runs)
+    --rnx2rtkp PATH             rnx2rtkp binary path (default: auto-detect)
+    --skip-download             Skip L6 download step
+    --skip-epochs N             Epochs to skip for metrics (default: 60)
+    --plot                      Save per-case ENU PNG to --out-dir
+    -v / --verbose              Show rnx2rtkp stdout/stderr
+"""
+
+import argparse
+import math
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from cases import CASES, case_by_id
+from compare_ppc import _match_epochs, compute_metrics, parse_nmea, parse_reference, plot_results
+from download_l6 import ensure_case_l6
+
+# ---------------------------------------------------------------------------
+# Auto-detect rnx2rtkp
+# ---------------------------------------------------------------------------
+_CANDIDATE_BINS = [
+    "build/rnx2rtkp",
+    "build/Release/rnx2rtkp",
+    "build/Debug/rnx2rtkp",
+]
+
+
+def _find_rnx2rtkp(hint: str = "") -> str:
+    """Locate the rnx2rtkp binary.
+
+    Args:
+        hint: Explicit path supplied via --rnx2rtkp.  If non-empty, return
+              as-is after verifying the file exists.
+
+    Returns:
+        Path to rnx2rtkp binary.
+
+    Raises:
+        SystemExit: If no binary can be found.
+    """
+    if hint:
+        if not os.path.isfile(hint):
+            sys.exit(f"FAIL: rnx2rtkp not found at {hint!r}")
+        return hint
+    # Search relative to MRTKLIB root (parent of scripts/)
+    root = Path(__file__).resolve().parent.parent.parent
+    for rel in _CANDIDATE_BINS:
+        p = root / rel
+        if p.is_file():
+            return str(p)
+    # Fall back to PATH
+    import shutil
+
+    p = shutil.which("rnx2rtkp")
+    if p:
+        return p
+    sys.exit(
+        "FAIL: rnx2rtkp binary not found. "
+        "Build first with 'cmake --build build', or pass --rnx2rtkp PATH."
+    )
+
+
+# ---------------------------------------------------------------------------
+# rnx2rtkp invocation
+# ---------------------------------------------------------------------------
+def _run_rnx2rtkp(
+    rnx2rtkp: str,
+    conf: str,
+    city_conf: str,
+    week: int,
+    tow_start: float,
+    tow_end: float,
+    output: Path,
+    obs: Path,
+    nav: Path,
+    l6_files: list[Path],
+    cwd: str = "",
+    verbose: bool = False,
+) -> bool:
+    """Run rnx2rtkp for one case/mode combination.
+
+    Args:
+        rnx2rtkp: Path to rnx2rtkp binary.
+        conf: Path to mode configuration file.
+        city_conf: Path to city override configuration file (applied after conf).
+        week: GPS week (for -ts/-te flags).
+        tow_start: Run start TOW with margin already subtracted.
+        tow_end: Run end TOW with margin already added.
+        output: Destination NMEA file path.
+        obs: rover.obs path.
+        nav: base.nav path.
+        l6_files: List of L6 file paths.
+        cwd: Working directory for subprocess (conf relative paths resolve here).
+        verbose: Pass stdout/stderr through; otherwise suppress.
+
+    Returns:
+        True if rnx2rtkp exited with code 0.
+    """
+    # Resolve all file paths to absolute so they work regardless of cwd.
+    output = output.resolve()
+    obs = obs.resolve()
+    nav = nav.resolve()
+    l6_files = [f.resolve() for f in l6_files]
+    output.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        rnx2rtkp,
+        "-k", conf,
+        "-k", city_conf,
+        "-ts", str(week), f"{tow_start:.3f}",
+        "-te", str(week), f"{tow_end:.3f}",
+        "-o", str(output),
+        str(obs),
+        str(nav),
+    ] + [str(f) for f in l6_files]
+
+    if verbose:
+        print("  $", " ".join(cmd))
+    result = subprocess.run(
+        cmd,
+        cwd=cwd or None,
+        stdout=None if verbose else subprocess.DEVNULL,
+        stderr=None if verbose else subprocess.DEVNULL,
+    )
+    return result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Summary table
+# ---------------------------------------------------------------------------
+#  Three rows per case/mode: FIX (Q=4), FF (Q=4|Q=5), ALL (every epoch)
+#  Columns: Case  Mode  Tier  N  Rate%  RMS_2D  1σ  95%  TTFF_s
+_HDR = (
+    f"{'Case':<20} {'Mode':<7} {'Tier':<5} {'N':>6} {'nSV':>5} {'Rate%':>7} "
+    f"{'RMS_2D':>10} {'1σ':>10} {'95%':>10} {'TTFF_s':>8}"
+)
+_SEP = "-" * len(_HDR)
+_BLANK_CASE_MODE = " " * (20 + 1 + 7 + 1)  # pad for case+mode when repeated
+
+
+def _fmt_m(v: float) -> str:
+    """Format metres with 3 decimal places, or 'nan'."""
+    return "nan" if math.isnan(v) else f"{v:.3f}m"
+
+
+def _fmt_s(v: float) -> str:
+    """Format seconds as integer, or '—'."""
+    return "—" if math.isnan(v) else f"{v:.0f}"
+
+
+def _fmt_sv(v: float) -> str:
+    """Format mean satellite count with 1 decimal place, or '—'."""
+    return "—" if math.isnan(v) else f"{v:.1f}"
+
+
+def _row(case_id: str, mode: str, tier: str, n: int, n_sv: str, rate: str,
+         rms2: str, p68: str, p95: str, ttff: str,
+         first: bool = True) -> str:
+    """Format one tier row."""
+    if first:
+        prefix = f"{case_id:<20} {mode:<7}"
+    else:
+        prefix = _BLANK_CASE_MODE
+    return (
+        f"{prefix} {tier:<5} {n:>6} {n_sv:>5} {rate:>7} "
+        f"{rms2:>10} {p68:>10} {p95:>10} {ttff:>8}"
+    )
+
+
+def print_summary(rows: list[dict]) -> None:
+    """Print a fixed-width summary table.
+
+    CLAS and RTK produce three tier rows per case; MADOCA produces one PPP row.
+
+    Tiers (CLAS / RTK):
+      FIX  — Q=4 integer-fix epochs only
+      FF   — Q=4 or Q=5 (fix + float), excludes SPP blunders
+      ALL  — every matched epoch (fix + float + SPP)
+
+    Tier (MADOCA):
+      PPP  — all valid PPP-float epochs (Q=3)
+
+    Rate% column:
+      FIX row : Q=4 fix rate (clas/rtk)
+      FF  row : Q=4|Q=5 rate (clas/rtk)
+      PPP row : <30cm threshold rate (madoca)
+
+    TTFF column:
+      FIX row : first ≥30-consecutive-Q=4 run (clas/rtk)
+      PPP row : first ≥30-consecutive-<30cm run (madoca)
+
+    Args:
+        rows: List of result dicts from the benchmark loop.
+    """
+    print()
+    print(_SEP)
+    print(_HDR)
+    print(_SEP)
+    for i, r in enumerate(rows):
+        m = r["metrics"]
+        if i > 0 and rows[i - 1]["case_id"] != r["case_id"]:
+            print()  # blank line between cases
+
+        if m is None:
+            tag = " [FAILED]" if r["status"] == "fail" else " [skipped]"
+            print(f"{r['case_id']:<20} {r['mode']:<7} {'—':<5} {'—':>6}{tag}")
+            continue
+
+        use_threshold = not math.isnan(m.get("threshold_2d", float("nan")))
+
+        if use_threshold:
+            # PPP mode (MADOCA): single row; no integer fix, all output is PPP float
+            ppp_rate = f"{m['thr_rate']:.1f}%"
+            ppp_ttff = _fmt_s(m["conv_thr_s"])
+            print(_row(r["case_id"], r["mode"], "PPP",
+                       m["n_matched"], _fmt_sv(m["mean_sv_all"]), ppp_rate,
+                       _fmt_m(m["rms_2d_all"]), _fmt_m(m["p68_2d_all"]),
+                       _fmt_m(m["p95_2d_all"]), ppp_ttff,
+                       first=True))
+        else:
+            # AR modes (CLAS / RTK): three rows
+            # FIX row (Q=4)
+            print(_row(r["case_id"], r["mode"], "FIX",
+                       m["n_fix"], _fmt_sv(m["mean_sv_fix"]), f"{m['fix_rate']:.1f}%",
+                       _fmt_m(m["rms_2d_fix"]), _fmt_m(m["p68_2d_fix"]),
+                       _fmt_m(m["p95_2d_fix"]), _fmt_s(m["conv_time_s"]),
+                       first=True))
+            # FF row (Q=3,4,5 — fix + float, excludes SPP)
+            print(_row(r["case_id"], r["mode"], "FF",
+                       m["n_ff"], _fmt_sv(m["mean_sv_ff"]), f"{m['ff_rate']:.1f}%",
+                       _fmt_m(m["rms_2d_ff"]), _fmt_m(m["p68_2d_ff"]),
+                       _fmt_m(m["p95_2d_ff"]), "—",
+                       first=False))
+            # ALL row (every epoch including SPP)
+            print(_row(r["case_id"], r["mode"], "ALL",
+                       m["n_matched"], _fmt_sv(m["mean_sv_all"]), "—",
+                       _fmt_m(m["rms_2d_all"]), _fmt_m(m["p68_2d_all"]),
+                       _fmt_m(m["p95_2d_all"]), "—",
+                       first=False))
+
+    print(_SEP)
+    print("  CLAS/RTK tiers: FIX=Q=4 | FF=Q=4+5 (excl SPP) | ALL=every epoch")
+    print("  MADOCA tier:    PPP=all valid PPP-float epochs (Q=3); Rate%=<30cm fraction")
+
+
+# ---------------------------------------------------------------------------
+# Main benchmark loop
+# ---------------------------------------------------------------------------
+def run_benchmark(args: argparse.Namespace) -> int:
+    """Execute the full benchmark loop.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        Exit code.
+    """
+    # Resolve paths (relative paths are resolved against the repo root so the
+    # script works correctly regardless of the current working directory)
+    root = Path(__file__).resolve().parent.parent.parent
+    dataset_dir = Path(args.dataset_dir)
+    if not dataset_dir.is_absolute():
+        dataset_dir = root / dataset_dir
+    l6_dir = Path(args.l6_dir)
+    if not l6_dir.is_absolute():
+        l6_dir = root / l6_dir
+    out_dir = Path(args.out_dir)
+    if not out_dir.is_absolute():
+        out_dir = root / out_dir
+    conf_dir = root / "conf" / "benchmark"
+
+    rnx2rtkp = _find_rnx2rtkp(args.rnx2rtkp)
+    print(f"rnx2rtkp  : {rnx2rtkp}")
+    print(f"Dataset   : {dataset_dir}")
+    print(f"L6 cache  : {l6_dir}")
+    print(f"Results   : {out_dir}")
+    print(f"Mode      : {args.mode}")
+    print()
+
+    # Filter cases
+    cases = CASES
+    if args.case:
+        ids = {c.strip() for c in args.case.split(",")}
+        try:
+            cases = [case_by_id(cid) for cid in ids]
+        except KeyError as exc:
+            sys.exit(f"FAIL: {exc}")
+
+    # Validate dataset presence (rover.obs, base.nav, reference.csv)
+    for case in cases:
+        case_dir = dataset_dir / case["city"] / case["run"]
+        for fname in ("rover.obs", "base.nav", "reference.csv"):
+            fpath = case_dir / fname
+            if not fpath.exists():
+                sys.exit(
+                    f"FAIL: PPC-Dataset file not found: {fpath}\n"
+                    f"  Dataset root: {dataset_dir}\n"
+                    "  Download it manually — see docs/benchmark.md for instructions."
+                )
+
+    # Expand mode aliases
+    if args.mode == "all":
+        modes = ["clas", "madoca", "rtk"]
+    elif args.mode == "both":
+        modes = ["clas", "madoca"]
+    else:
+        modes = [args.mode]
+
+    # PPP modes use a 2D error threshold instead of Q=4 for fix/convergence
+    _PPP_THRESHOLD = 0.30  # metres
+
+    results = []
+
+    for case in cases:
+        city, run = case["city"], case["run"]
+        obs = dataset_dir / city / run / "rover.obs"
+        nav = dataset_dir / city / run / "base.nav"
+        base_obs = dataset_dir / city / run / "base.obs"
+        ref = dataset_dir / city / run / "reference.csv"
+
+        # Download L6 files (only needed for clas/madoca)
+        l6_modes = [m for m in modes if m in ("clas", "madoca")]
+        l6_paths: dict[str, list[Path]] = {"clas": [], "madoca": []}
+        if l6_modes:
+            l6_mode_arg = "both" if set(l6_modes) == {"clas", "madoca"} else l6_modes[0]
+            if not args.skip_download:
+                print(f"Downloading L6 for {case['id']} ...")
+                l6_paths = ensure_case_l6(case, l6_dir, l6_mode_arg)
+            else:
+                # Build expected paths without downloading
+                from cases import l6_sessions
+                from download_l6 import MADOCA_PRNS
+
+                sessions = l6_sessions(case["gps_week"], case["tow_start"], case["tow_end"])
+                for year, doy, session in sessions:
+                    l6d = l6_dir / f"{year}{doy:03d}{session}.l6"
+                    if l6d.exists():
+                        l6_paths["clas"].append(l6d)
+                    for prn in MADOCA_PRNS:
+                        l6e = l6_dir / f"{year}{doy:03d}{session}.{prn}.l6"
+                        if l6e.exists():
+                            l6_paths["madoca"].append(l6e)
+                            break
+
+        for mode in modes:
+            conf = str(conf_dir / f"{mode}.conf")
+            out = out_dir / f"{case['id']}_{mode}.nmea"
+
+            # Determine extra input files and convergence threshold
+            if mode == "rtk":
+                extra_files = [base_obs]
+                threshold = math.nan  # RTK uses Q=4
+            elif mode == "madoca":
+                extra_files = l6_paths.get("madoca", [])
+                threshold = _PPP_THRESHOLD  # PPP: use <30cm threshold
+            else:  # clas
+                extra_files = l6_paths.get("clas", [])
+                threshold = math.nan  # PPP-RTK uses Q=4
+
+            print(f"\n[{case['id']}  /  {mode.upper()}]")
+
+            if not extra_files:
+                print(f"  WARNING: no input files found for {mode}; skipping.")
+                results.append({"case_id": case["id"], "mode": mode,
+                                 "metrics": None, "status": "skip"})
+                continue
+
+            # Skip if output is newer than all inputs
+            if out.exists() and not args.force:
+                newest_in = max(
+                    obs.stat().st_mtime,
+                    nav.stat().st_mtime,
+                    max(f.stat().st_mtime for f in extra_files),
+                )
+                if out.stat().st_mtime > newest_in:
+                    print(f"  [cached]  {out.name}")
+                    skip_run = True
+                else:
+                    skip_run = False
+            else:
+                skip_run = False
+
+            if not skip_run:
+                t0 = time.monotonic()
+                city_conf = str(conf_dir / f"{case['city']}.conf")
+                ok = _run_rnx2rtkp(
+                    rnx2rtkp, conf, city_conf,
+                    case["gps_week"],
+                    case["tow_start"] - 60, case["tow_end"] + 60,
+                    out, obs, nav, extra_files,
+                    cwd=str(root),
+                    verbose=args.verbose,
+                )
+                elapsed = time.monotonic() - t0
+                if not ok:
+                    print(f"  FAIL: rnx2rtkp returned non-zero (elapsed {elapsed:.1f}s)")
+                    results.append({"case_id": case["id"], "mode": mode,
+                                     "metrics": None, "status": "fail"})
+                    continue
+                print(f"  rnx2rtkp completed in {elapsed:.1f}s → {out.name}")
+
+            if not out.exists():
+                print("  FAIL: output file not produced")
+                results.append({"case_id": case["id"], "mode": mode,
+                                 "metrics": None, "status": "fail"})
+                continue
+
+            # Compare against reference
+            ref_rows = parse_reference(str(ref))
+            nmea_rows = parse_nmea(str(out))
+            pairs = _match_epochs(ref_rows, nmea_rows)
+            m = compute_metrics(pairs, args.skip_epochs, threshold_2d=threshold)
+
+            if m is None:
+                print("  FAIL: no matching epochs")
+                results.append({"case_id": case["id"], "mode": mode,
+                                 "metrics": None, "status": "fail"})
+                continue
+
+            # Progress line
+            if not math.isnan(threshold):
+                rate_str = f"<{threshold*100:.0f}cm={m['thr_rate']:.1f}%"
+                conv_str = _fmt_s(m["conv_thr_s"])
+            else:
+                rate_str = f"Fix={m['fix_rate']:.1f}%  FF={m['ff_rate']:.1f}%"
+                conv_str = _fmt_s(m["conv_time_s"])
+            print(
+                f"  N={m['n_matched']}  {rate_str}  "
+                f"RMS(fix)={_fmt_m(m['rms_2d_fix'])}  "
+                f"RMS(ff)={_fmt_m(m['rms_2d_ff'])}  "
+                f"RMS(all)={m['rms_2d_all']:.3f}m  "
+                f"TTFF={conv_str}s"
+            )
+            results.append({"case_id": case["id"], "mode": mode,
+                             "metrics": m, "status": "ok"})
+
+            if args.plot:
+                png = out_dir / f"{case['id']}_{mode}.png"
+                plot_results(m, title=f"{case['id']} / {mode.upper()}", output_path=str(png))
+
+    print_summary(results)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def main() -> int:
+    """Entry point for the PPC-Dataset benchmark runner."""
+    p = argparse.ArgumentParser(
+        description="Run MRTKLIB kinematic benchmark on PPC-Dataset"
+    )
+    p.add_argument("--dataset-dir", default="data/benchmark",
+                   help="PPC-Dataset root directory (default: data/benchmark)")
+    p.add_argument("--l6-dir", default="data/benchmark/l6",
+                   help="L6 file cache directory (default: data/benchmark/l6)")
+    p.add_argument("--out-dir", default="data/benchmark/results",
+                   help="Output directory for NMEA results (default: data/benchmark/results)")
+    p.add_argument("--mode", choices=["clas", "madoca", "rtk", "both", "all"],
+                   default="all",
+                   help="Positioning mode (default: all = clas+madoca+rtk)")
+    p.add_argument("--case", default="",
+                   help="Comma-separated case IDs (default: all)")
+    p.add_argument("--rnx2rtkp", default="",
+                   help="Path to rnx2rtkp binary (default: auto-detect under build/)")
+    p.add_argument("--skip-download", action="store_true",
+                   help="Skip L6 download step (use existing files)")
+    p.add_argument("--force", action="store_true",
+                   help="Re-run rnx2rtkp even if cached output exists")
+    p.add_argument("--skip-epochs", type=int, default=60,
+                   help="Epochs to exclude from metrics for convergence (default: 60)")
+    p.add_argument("--plot", action="store_true",
+                   help="Generate ENU time-series PNG per case")
+    p.add_argument("-v", "--verbose", action="store_true",
+                   help="Show rnx2rtkp stdout/stderr")
+    args = p.parse_args()
+    return run_benchmark(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pos/mrtk_options.c
+++ b/src/pos/mrtk_options.c
@@ -409,6 +409,7 @@ extern int loadopts(const char *file, opt_t *opts)
             continue;
         }
         *p++='\0';
+        while (*p==' '||*p=='\t') p++; /* skip leading whitespace in value */
         chop(buff);
         if (!(opt=searchopt(buff,opts))) continue;
         


### PR DESCRIPTION
This pull request introduces a minor release (v0.3.3) focused on benchmarking kinematic positioning for urban driving evaluation using the PPC-Dataset. It adds a comprehensive benchmark infrastructure, configuration files, and documentation, but does not alter the core library functionality. Several fixes improve configuration layering and option parsing, and dataset attribution/disclaimer text is updated.

Benchmark infrastructure and configuration:

* Added end-to-end kinematic benchmark pipeline (`scripts/benchmark/`) for evaluating CLAS PPP-RTK, MADOCA PPP, and RTK modes against PPC-Dataset urban driving data, including metadata, auto-download scripts, comparison utilities, and orchestrator with result caching and summary table.
* Added benchmark configuration files for CLAS (`conf/benchmark/clas.conf`), MADOCA (`conf/benchmark/madoca.conf`), RTK (`conf/benchmark/rtk.conf`), and city-specific overrides for Nagoya (`conf/benchmark/nagoya.conf`) and Tokyo (`conf/benchmark/tokyo.conf`). [[1]](diffhunk://#diff-86d9c77eaca66ada614bfc2350b42fd8b0090d308897c9afae1d07e5dc0e3002R1-R144) [[2]](diffhunk://#diff-f578ed29bf7a94a99022d9a40b7b3c38697be0de2a2f411740b107e3309baed7R1-R115) [[3]](diffhunk://#diff-740e799ff1eb8fa290e8d6cf483ace07778ddbe936aa2f9c0fd48db6e7bbd9dfR1-R91) [[4]](diffhunk://#diff-c5d1f84aa3aba0538ca71e13a4d9fa7b9b66a90baf461dcc25520a9becbba0aaR1-R23) [[5]](diffhunk://#diff-2e55cd80eea11e44d0b8eedb4f9ff566b688960a64e7c8279b77bb13998f7485R1-R22)
* Added benchmark documentation (`docs/benchmark.md`) detailing dataset download, execution modes, metric definitions, results, and limitations.

Bug fixes and improvements:

* Fixed multi-`-k` configuration loading in `rnx2rtkp.c` by calling `resetsysopts()` once before the loop, ensuring layered city overrides are applied correctly.
* Fixed leading whitespace handling in `loadopts()` to prevent key lookup failures for configuration entries.
* Restored MADOCA `misc-timeinterp` option to `on` in benchmark configuration, matching upstream behavior.

Documentation and attribution:

* Updated `.gitignore` to exclude benchmark data files, and added per-file ignores in `ruff.toml`.
* Corrected PPC-Dataset attribution and added a benchmark disclaimer about parameter tuning and result usage.
* Linked v0.3.3 changelog to GitHub diff.