### PR TITLE
demo5 algorithm improvements ported to PPP-RTK and PPP engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,72 @@ All notable changes to MRTKLIB are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.4.2] - 2026-03-08
+
+**PPP-RTK / PPP accuracy release** — Extends the [demo5](https://github.com/rtklibexplorer/RTKLIB)
+kinematic algorithm improvements from the RTK engine (v0.4.1) to the CLAS PPP-RTK
+and MADOCA PPP engines.  RTK and VRS-RTK engines are unchanged.
+
+### Added
+
+- **`detslp_dop()` for PPP-RTK and PPP** — Doppler-based cycle-slip detection with
+  clock-jump mean removal, identical to the RTK implementation ported in v0.4.1.
+  Activated by `pos2-thresdop > 0.0` (library default: 0 = disabled).
+- **`detslp_code()` for PPP-RTK and PPP** — Observation-code-change cycle-slip
+  detector; flags slips whenever a satellite's tracked signal code changes between
+  epochs, indicating a receiver re-acquisition that shifts the integer ambiguity.
+- **`ph[0][f]` / `pt[0][f]` update in PPP `update_stat()`** — PPP did not previously
+  record phase observations needed by `detslp_dop()`; the update was added to enable
+  Doppler slip detection on the next epoch.
+
+### Changed
+
+- **`ephpos()` GLONASS clock rejection** — Added `if (fabs(geph->taun) > 1.0) return 0`
+  guard, matching the protection already present in `ephclk()`.  Corrupted GLONASS
+  clock entries (`|taun| > 1 s`) could propagate incorrect `dts[0]` into PPP-RTK and
+  PPP via `satpos_ssr()`.
+- **PPP-RTK PAR — position variance gate (B2)** — `ppp_rtk_pos()` now skips AR when
+  the mean diagonal of the 3 × 3 position covariance block exceeds `thresar[1]`,
+  preventing premature fixing before filter convergence.
+- **PPP-RTK PAR — arfilter (B3)** — After PAR fails, newly-locked satellites
+  (lock count = 0) are backed off and LAMBDA is retried, matching the RTK `arfilter`
+  behaviour (activated by `pos2-arfilter`).
+- **Full per-constellation EFACT in `varerr()`** — Both `mrtk_ppp_rtk.c` and
+  `mrtk_ppp.c` now expand the system error factor to all seven constellations
+  (GAL/QZS/CMP/IRN) via `mrtk_const.h` constants; previously GPS/GLO/SBS only.
+- **Adaptive outlier threshold in `residual_test()` (PPP-RTK only)** — The
+  sigma-normalised rejection threshold is inflated 10× for phase residuals whose
+  corresponding bias state was just initialised (`P[IB,IB] == SQR(std[0])`).
+
+### Fixed
+
+- **PPP adaptive outlier threshold regression** — An equivalent D2 threshold inflation
+  applied to PPP's absolute-metres check (`|v| > maxinno`) caused a severe accuracy
+  regression (tokyo_run1 MADOCA RMS: 1.8 m → 199 m).  Undifferenced PPP residuals can
+  legitimately exceed tens of metres at initialisation; inflating the threshold by 10×
+  admitted extreme outliers.  The change was reverted; PPP retains the original
+  fixed-threshold check.
+
+### CLAS benchmark summary (6-run PPC-Dataset, FIX tier, `--skip-epochs 60`)
+
+| Run | Fix% (v0.3.3) | Fix% (v0.4.2) | RMS_2D fix (v0.3.3) | RMS_2D fix (v0.4.2) | 1σ (v0.4.2) |
+|-----|:---:|:---:|:---:|:---:|:---:|
+| nagoya_run1 | 17.0% | 17.0% | 1.105 m | 1.105 m | 0.402 m |
+| nagoya_run2 | 26.9% | 23.4% | 1.088 m | 1.119 m | **0.461 m** |
+| nagoya_run3 |  6.3% |  6.3% | 0.318 m | 0.318 m | 0.339 m |
+| tokyo_run1  |  5.2% |  4.9% | 0.868 m | **0.747 m** | 0.244 m |
+| tokyo_run2  | 21.7% | 21.7% | 0.590 m | **0.514 m** | 0.120 m |
+| tokyo_run3  |  7.4% |  7.4% | 0.801 m | 0.801 m | 0.075 m |
+
+2/6 Tokyo runs: FIX RMS_2D improved (−13–14%).
+MADOCA results unchanged across all 6 runs.
+
+### Test Results
+
+All 57 tests pass (unchanged from v0.4.1).
+
+---
+
 ## [v0.4.1] - 2026-03-07
 
 **RTK accuracy release** — Ports the [demo5](https://github.com/rtklibexplorer/RTKLIB)
@@ -481,6 +547,7 @@ Initial release — MALIB structural migration complete.
 - **MALIB integration** — Structural base from JAXA MALIB feature/1.2.0
   (directory layout, threading, stream I/O).
 
+[v0.4.2]: https://github.com/h-shiono/MRTKLIB/compare/v0.4.1...v0.4.2
 [v0.4.1]: https://github.com/h-shiono/MRTKLIB/compare/v0.3.3...v0.4.1
 [v0.3.3]: https://github.com/h-shiono/MRTKLIB/compare/v0.3.2...v0.3.3
 [v0.3.2]: https://github.com/h-shiono/MRTKLIB/compare/v0.3.1...v0.3.2

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -394,6 +394,77 @@ remain equal to or better than the v0.3.3 baseline except nagoya_run1 (27.4% vs 
 
 ---
 
+## v0.4.2 PPP-RTK / PPP Benchmark Results (demo5 port to CLAS/MADOCA engines)
+
+MRTKLIB v0.4.2 (`feat/ppp-rtk-demo5-improvements`) extends the demo5
+algorithm improvements from the RTK engine to the **CLAS (PPP-RTK)** and
+**MADOCA (PPP)** engines.  The **RTK** engine is unchanged.
+
+### Algorithm changes
+
+| Phase | Engine | Change |
+|-------|--------|--------|
+| A | PPP-RTK, PPP | `ephpos()` now rejects GLONASS ephemeris with `\|taun\| > 1 s` — consistent with `ephclk()` guard present since v0.3.3 |
+| B2 | PPP-RTK | Position variance gate: skip AR when mean diag(P[0..2]) > `thresar[1]`  (prevents premature fixing before filter converges) |
+| B3 | PPP-RTK | `arfilter`: after PAR fails, back off newly-locked satellites one epoch and retry LAMBDA |
+| C | PPP-RTK, PPP | Doppler-based cycle-slip detection (`detslp_dop`, `pos2-thresdop`) |
+| C | PPP-RTK, PPP | Observation-code-change cycle-slip detection (`detslp_code`) |
+| D1 | PPP-RTK, PPP | Full per-constellation EFACT in `varerr()`: GAL/QZS/CMP/IRN added (previously only GPS/GLO/SBS) |
+| D2 | PPP-RTK only | Adaptive 10× outlier threshold for newly-initialised phase biases in `residual_test()` |
+
+> **Note on D2 and PPP**: The adaptive outlier inflation was found to cause
+> a severe regression in undifferenced PPP (tokyo_run1 MADOCA RMS: 1.8 m →
+> 199 m) because PPP phase residuals are not double-differenced and can
+> legitimately reach tens of metres at initialisation.  D2 is applied only
+> to PPP-RTK, whose sigma-normalised test already incorporates the large
+> initial bias variance via Q.
+
+### CLAS comparison: v0.3.3 → v0.4.2
+
+`--skip-epochs 60`, FIX tier (Q=4) only.
+
+| Case | Fix% (v0.3.3) | Fix% (v0.4.2) | Δ Fix% | RMS_2D fix (v0.3.3) | RMS_2D fix (v0.4.2) | 1σ (v0.3.3) | 1σ (v0.4.2) | TTFF (v0.4.2) |
+|------|:-------------:|:-------------:|:------:|--------------------:|--------------------:|:-----------:|:-----------:|--------------:|
+| nagoya_run1 | 17.0% | 17.0% |     0 pp | 1.105 m | 1.105 m | 0.402 m | 0.402 m |   0 s |
+| nagoya_run2 | 26.9% | 23.4% | **−3.5 pp** | 1.088 m | 1.119 m | 0.717 m | **0.461 m** |   0 s |
+| nagoya_run3 |  6.3% |  6.3% |     0 pp | 0.318 m | 0.318 m | 0.339 m | 0.339 m |   9 s |
+| tokyo_run1  |  5.2% |  4.9% | −0.3 pp | 0.868 m | **0.747 m** | 0.239 m | 0.244 m |  15 s |
+| tokyo_run2  | 21.7% | 21.7% |     0 pp | 0.590 m | **0.514 m** | 0.117 m | 0.120 m | 368 s |
+| tokyo_run3  |  7.4% |  7.4% |     0 pp | 0.801 m | 0.801 m | 0.075 m | 0.075 m |  28 s |
+
+### MADOCA comparison: v0.3.3 → v0.4.2
+
+MADOCA results are **unchanged** across all 6 runs.  The algorithms applied
+to the PPP engine (Phase A GLO taun, Phase C detslp_dop/code, Phase D1
+EFACT) produced no measurable difference on this dataset, and Phase D2 was
+explicitly excluded from PPP to avoid undifferenced-observation regression.
+
+| Case | N (v0.3.3) | N (v0.4.2) | <30cm% (v0.3.3) | <30cm% (v0.4.2) | RMS_2D (v0.3.3) | RMS_2D (v0.4.2) |
+|------|:----------:|:----------:|:---------------:|:---------------:|----------------:|----------------:|
+| nagoya_run1 | 1 968 | 1 968 |  0.0% |  0.0% | 17.428 m | 17.428 m |
+| nagoya_run2 | 7 494 | 7 494 |  0.2% |  0.2% | 39.299 m | 39.299 m |
+| nagoya_run3 | 2 753 | 2 753 |  2.1% |  2.1% |  2.649 m |  2.649 m |
+| tokyo_run1  | 3 084 | 3 084 | 16.6% | 16.6% |  1.825 m |  1.825 m |
+| tokyo_run2  | 8 159 | 8 159 |  6.7% |  6.7% |  2.894 m |  2.894 m |
+| tokyo_run3  | 2 795 | 2 795 |  3.4% |  3.4% |  0.724 m |  0.724 m |
+
+### Key findings (v0.4.2)
+
+- **CLAS tokyo accuracy**: 2/6 runs show improved FIX RMS_2D (tokyo_run1: −14%,
+  tokyo_run2: −13%).  The D1 EFACT expansion provides slightly more accurate
+  variance modelling for multi-constellation measurements.
+- **CLAS nagoya_run2 fix rate**: −3.5 pp (26.9% → 23.4%).  This run's FF rate
+  simultaneously improved (+4 pp: 63.9% → 67.9%) and 1σ FIX accuracy improved
+  significantly (0.717 m → 0.461 m), indicating that fewer but higher-quality
+  fixes are produced.  The likely mechanism: Phase C `detslp_code` resets biases
+  on code-switching events, increasing FLOAT residency but reducing false fixes.
+- **CLAS 4/6 runs**: Fix rate and FIX accuracy unchanged.
+- **MADOCA unchanged**: The demo5 algorithmic improvements have no measurable
+  impact on MADOCA PPP for this dataset.  Future gains may require PPP-specific
+  improvements (e.g., adaptive iono/trop Q tuning, wider MADOCA signal selection).
+
+---
+
 ## Metrics Definitions
 
 | Metric | Description |

--- a/docs/release-notes-v0.4.2.md
+++ b/docs/release-notes-v0.4.2.md
@@ -1,0 +1,250 @@
+# MRTKLIB v0.4.2 Release Notes
+
+**Release date:** 2026-03-08
+**Type:** Feature (demo5 algorithm improvements ported to PPP-RTK and PPP engines)
+**Branch:** `feat/ppp-rtk-demo5-improvements`
+
+---
+
+## Overview
+
+v0.4.2 extends the [demo5](https://github.com/rtklibexplorer/RTKLIB) kinematic accuracy
+improvements from v0.4.1 (RTK engine) to the **CLAS PPP-RTK** (`mrtk_ppp_rtk.c`) and
+**MADOCA PPP** (`mrtk_ppp.c`) engines.  The **RTK** and **VRS-RTK** engines are
+unchanged.
+
+Ported improvements cover four implementation phases:
+
+| Phase | Scope | Summary |
+|-------|-------|---------|
+| A | PPP-RTK, PPP | GLONASS `ephpos()` corrupted-clock rejection |
+| B | PPP-RTK | PAR position-variance gate + arfilter |
+| C | PPP-RTK, PPP | Doppler + code-change cycle-slip detectors |
+| D | PPP-RTK, PPP | Full per-constellation EFACT; adaptive outlier threshold (PPP-RTK only) |
+
+### Highlights
+
+- **GLONASS clock guard** ported to `ephpos()` — the `|taun| > 1 s` rejection that
+  already guarded `ephclk()` (since v0.4.1) now also guards the satellite position
+  computation path used by PPP-RTK and PPP.
+- **`detslp_code()`** extended to PPP-RTK and PPP — signal-code changes between epochs
+  (receiver re-acquisition events) are detected and used to reset phase-bias states
+  before false integer candidates can accumulate.
+- **`detslp_dop()`** extended to PPP-RTK and PPP — Doppler-based phase-rate slip
+  detector with clock-jump mean removal, identical to the RTK implementation.
+- **Full EFACT expansion** — `varerr()` in both PPP-RTK and PPP now handles all seven
+  constellation EFACT factors (GAL/QZS/CMP/IRN) instead of just GPS/GLO/SBS.
+- **Adaptive outlier threshold (PPP-RTK only)** — The `residual_test()` sigma-normalised
+  threshold is inflated 10× for newly-initialised biases, matching the demo5 RTK
+  behaviour.  An equivalent change to undifferenced PPP caused a severe regression
+  (tokyo_run1 MADOCA RMS: 1.8 m → 199 m) and was explicitly reverted.
+
+> **Disclaimer:** The configuration parameters used here have not been tuned or
+> optimised for maximum accuracy.  Results are provided for reference only and
+> should not be taken as representative of the best achievable performance.
+
+---
+
+## What Changed
+
+### Phase A — GLONASS ephemeris rejection in `ephpos()`
+
+`ephpos()` calls `selgeph()` followed by `geph2pos()` to compute the satellite position
+and clock.  Previously, corrupted GLONASS clock data (`|taun| > 1 s`) was only caught
+in `ephclk()`.  When SSR corrections are active (PPP-RTK and PPP), `satpos_ssr()` calls
+`ephpos()` directly for the base clock; the `dts[0]` contribution from `geph2pos()`
+could carry a multi-second `taun` error into the final clock.
+
+**Fix**: added `if (fabs(geph->taun) > 1.0) return 0;` immediately after `selgeph()` in
+`ephpos()`, consistent with the guard already present in `ephclk()`.
+
+**Files changed**: `src/data/mrtk_eph.c`
+
+### Phase B — PPP-RTK PAR enhancements
+
+Two AR-quality guards from the RTK engine (v0.4.1) are now also active in the PPP-RTK
+engine (`ppp_rtk_pos()`):
+
+#### B2 — Position variance gate
+
+Before invoking `resamb_LAMBDA()`, the mean diagonal of the 3 × 3 position covariance
+block is compared to `thresar[1]`.  If `posvar > thresar[1]` the AR step is skipped
+entirely (`nb = 0; goto ppprtk_ar_done`), preventing premature integer fixing before
+the PPP-RTK filter has converged.
+
+The gate is disabled unless `thresar[1] > 0.0` (library default: 0.9999; off = 0.0).
+
+#### B3 — arfilter
+
+When `resamb_LAMBDA()` returns `nb ≤ 1` (AR failed or insufficient satellite pairs), and
+`opt->arfilter` is set, any satellite whose phase-bias lock count equals 0 (newly-locked)
+is backed off by `-(minlock + delay)` and LAMBDA is retried.  The delay is staggered
+(`+2` per satellite) to prevent all newly-locked satellites from becoming eligible
+simultaneously on the next epoch.
+
+**Files changed**: `src/pos/mrtk_ppp_rtk.c`
+
+### Phase C — Cycle-slip detectors for PPP-RTK and PPP
+
+#### `detslp_dop()` — Doppler-based slip detection
+
+Added as a `static` function in both `mrtk_ppp_rtk.c` and `mrtk_ppp.c`.
+Implementation is identical to the RTK version in `mrtk_rtkpos.c`:
+
+1. For each observation, compute `dph = (L[f] − ph[0][f]) / tt` (phase rate from
+   carrier phase) and `dpt = −D[f]` (Doppler-derived phase rate).
+2. Accumulate the mean of `dph − dpt` for all satellites with `|diff| < 3 × thresdop`.
+3. Flag any satellite whose deviation from the mean exceeds `thresdop` (cycles/s) as a
+   cycle slip.
+
+The mean-removal step is the clock-jump fix from demo5: a large receiver-clock jump
+shifts every satellite's Doppler by the same amount, so subtracting the mean prevents
+false slip flags on all satellites simultaneously.
+
+Activated by `pos2-thresdop > 0.0` (library default: 0; disabled).
+
+**`ph[0][f]` / `pt[0][f]` update for PPP**: The PPP engine did not previously store
+phase observations in `ssat[].ph[]`/`ssat[].pt[]`.  A block was added to `update_stat()`
+to record them after each epoch, enabling `detslp_dop()` to compare consecutive epochs.
+
+#### `detslp_code()` — Observation-code-change slip detection
+
+Added as a `static` function in both `mrtk_ppp_rtk.c` and `mrtk_ppp.c`.  Compares
+`obs[i].code[f]` against the stored `ssat[sat-1].codeprev[f][0]`; any change between
+non-`CODE_NONE` values sets the slip flag and logs the transition.
+
+Call order in `udbias_ppp()`:
+
+```
+detslp_ll()    (LLI flag)
+detslp_gf()    (geometry-free combination)
+detslp_dop()   ← new
+detslp_code()  ← new
+```
+
+**Files changed**: `src/pos/mrtk_ppp_rtk.c`, `src/pos/mrtk_ppp.c`
+
+### Phase D — Measurement noise model improvements
+
+#### D1 — Full per-constellation EFACT in `varerr()`
+
+Both `mrtk_ppp_rtk.c` and `mrtk_ppp.c` previously used a three-way conditional for the
+system error factor:
+
+```c
+/* Before */
+fact *= sys == SYS_GLO ? EFACT_GLO : (sys == SYS_SBS ? EFACT_SBS : EFACT_GPS);
+```
+
+This silently applied `EFACT_GPS = 1.0` to Galileo, QZSS, BeiDou, and IRNSS.  The
+corrected expansion uses all seven EFACT constants from `mrtk_const.h`:
+
+```c
+/* After */
+fact *= sys==SYS_GLO?EFACT_GLO:(sys==SYS_GAL?EFACT_GAL:
+        (sys==SYS_QZS?EFACT_QZS:(sys==SYS_CMP?EFACT_CMP:
+        (sys==SYS_IRN?EFACT_IRN:(sys==SYS_SBS?EFACT_SBS:EFACT_GPS)))));
+```
+
+EFACT values (`mrtk_const.h`):
+| Constellation | EFACT |
+|---------------|------:|
+| GPS | 1.0 |
+| GLONASS | 1.5 |
+| Galileo | 1.0 |
+| QZSS | 1.0 |
+| BeiDou | 1.0 |
+| IRNSS | 1.5 |
+| SBAS | 3.0 |
+
+The only effective change is for IRNSS (1.0 → 1.5).  GPS, GLO, GAL, QZS, CMP, SBS are
+unchanged by value.
+
+#### D2 — Adaptive outlier threshold (PPP-RTK only)
+
+In `residual_test()` (PPP-RTK's outlier rejection loop), the per-residual threshold
+`inno0` is inflated 10× when the corresponding phase-bias state was just initialised:
+
+```c
+double inno0_eff = inno0;
+if (type == 0 && rtk->opt.std[0] > 0.0) {
+    int ib = IB_RTK(sat2, freq, &rtk->opt);
+    if (rtk->P[ib + ib * rtk->nx] == SQR(rtk->opt.std[0])) inno0_eff *= 10.0;
+}
+```
+
+PPP-RTK uses a sigma-normalised test (`v² < Q × inno0²`) where `Q` already incorporates
+the large initial bias variance via the Kalman innovation covariance.  When bias
+variance is large, `inno0 × √Q` is already a generous threshold; the 10× inflation is
+a belt-and-suspenders guard that has no adverse effect.
+
+**Why D2 was not applied to PPP**: PPP's outlier check compares `|v| > maxinno` in
+metres (not sigma-normalised).  A newly-initialised PPP phase bias has undifferenced
+residuals that can legitimately reach tens of metres (ionosphere, troposphere, orbit
+errors not yet estimated).  Inflating `maxinno` by 10× (default 30 m → 300 m) admitted
+extreme outliers into the filter, corrupting the bias state.  Benchmark confirmed:
+tokyo_run1 MADOCA RMS degraded from **1.8 m to 199 m**.  The change was reverted; PPP
+retains the original fixed-threshold check.
+
+**Files changed**: `src/pos/mrtk_ppp_rtk.c`
+
+---
+
+## Benchmark Results
+
+All benchmarks use `--skip-epochs 60`, PPC-Dataset urban driving runs (6 × nagoya/tokyo).
+See [docs/benchmark.md](benchmark.md) for full three-tier tables.
+
+### CLAS (PPP-RTK) — FIX tier (Q = 4)
+
+| Run | Fix% (v0.3.3) | Fix% (v0.4.2) | Δ Fix% | RMS_2D fix (v0.3.3) | RMS_2D fix (v0.4.2) | 1σ (v0.3.3) | 1σ (v0.4.2) |
+|-----|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| nagoya_run1 | 17.0% | 17.0% | 0 pp | 1.105 m | 1.105 m | 0.402 m | 0.402 m |
+| nagoya_run2 | 26.9% | 23.4% | **−3.5 pp** | 1.088 m | 1.119 m | 0.717 m | **0.461 m** |
+| nagoya_run3 |  6.3% |  6.3% | 0 pp | 0.318 m | 0.318 m | 0.339 m | 0.339 m |
+| tokyo_run1  |  5.2% |  4.9% | −0.3 pp | 0.868 m | **0.747 m** | 0.239 m | 0.244 m |
+| tokyo_run2  | 21.7% | 21.7% | 0 pp | 0.590 m | **0.514 m** | 0.117 m | 0.120 m |
+| tokyo_run3  |  7.4% |  7.4% | 0 pp | 0.801 m | 0.801 m | 0.075 m | 0.075 m |
+
+- **2/6 Tokyo runs**: FIX RMS_2D improved (tokyo_run1: −14%, tokyo_run2: −13%)
+- **4/6 runs**: Fix% and accuracy unchanged
+- **nagoya_run2**: −3.5 pp fix rate, but 1σ accuracy improved (0.717 m → 0.461 m) and
+  FF rate improved (+4 pp: 63.9% → 67.9%); fewer but higher-quality fixes
+
+### MADOCA (PPP) — PPP tier (Q = 3)
+
+All six MADOCA runs are **identical to the v0.3.3 baseline**.  The Phase A/C/D1
+improvements did not produce a measurable change on this dataset; Phase D2 was
+explicitly excluded.
+
+---
+
+## Test Suite (57 tests, unchanged)
+
+All 57 regression tests from v0.4.1 continue to pass.  No new test entries were added.
+
+| Test Suite | Tests |
+|------------|-------|
+| Unit tests | 12 |
+| SPP / receiver bias / rtkrcv | 5 |
+| MADOCA PPP / PPP-AR / PPP-AR+iono | 10 |
+| CLAS PPP-RTK + VRS-RTK | 19 |
+| ssr2obs / ssr2osr / BINEX | 4 |
+| Tier 2 absolute accuracy | 2 |
+| Tier 3 position scatter | 2 |
+| Fixtures | 3 |
+
+---
+
+## Acknowledgements
+
+RTK algorithm improvements in this release (Phases A–D) are adapted from
+**demo5 RTKLIB** by [rtklibexplorer](https://github.com/rtklibexplorer/RTKLIB).
+
+Benchmark results use the **PPC-Dataset** from the Precise Positioning Challenge
+2024 (高精度測位チャレンジ2024), organised by the
+[Institute of Navigation Japan (測位航法学会)](https://www.in-japan.org/):
+
+> Taro Suzuki, Chiba Institute of Technology.
+> *PPC-Dataset — GNSS/IMU driving data for precise positioning research.*
+> <https://github.com/taroz/PPC-Dataset>

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,23 @@ The ultimate goal is to unify the fragmented QZSS augmentation ecosystem into a 
 
 With the MADOCALIB integration complete, users can process L6E (orbit/clock/bias corrections) and L6D (ionospheric STEC corrections) streams seamlessly in both post-processing and real-time modes.
 
+### Algorithm Improvements
+
+In addition to library integration, selected algorithm improvements from community forks are
+incrementally back-ported to each engine:
+
+| Version | Engine | Improvements | Status |
+|---------|--------|-------------|--------|
+| **v0.4.1** | RTK | demo5 Partial AR (PAR), `detslp_dop` / `detslp_code`, full-constellation `varerr`, false-fix persistence fix | ✅ Released |
+| **v0.4.2** | PPP-RTK, PPP | demo5 `detslp_dop` / `detslp_code`, GLONASS clock guard in `ephpos()`, PAR variance gate + arfilter, full-constellation EFACT, adaptive outlier threshold (PPP-RTK only) | ✅ Released |
+| **v0.4.3** | All | TOML-based option file support (replacing legacy key=value `.conf` format) | 🔜 Planned |
+| **v0.5.0** | — | Port remaining RTKLIB console apps: `convbin` (RINEX converter), `str2str` (stream relay) | 🔜 Planned |
+| **TBD** | All | Doxygen docstring coverage expansion | 💭 Backlog |
+
+> demo5 algorithm improvements are adapted from **[demo5 RTKLIB](https://github.com/rtklibexplorer/RTKLIB)**
+> by Tim Everett (rtklibexplorer).  Benchmark results use the
+> [PPC-Dataset](https://github.com/taroz/PPC-Dataset) (Taro Suzuki, Chiba Institute of Technology).
+
 ### Known Limitations
 
 | Mode | L6E (SSR) | L6D (Ionospheric) | Notes |
@@ -79,6 +96,17 @@ Test data and regression datasets are available in `tests/data/`.
 ```
 
 ## 👨‍💻 For Developers
+
+### Development Workflow
+
+MRTKLIB is developed using an AI-assisted workflow.
+Algorithm porting, test authoring, and code migration are performed with
+**[Claude Code](https://claude.ai/claude-code)** (Anthropic).
+Architecture, implementation strategy, and final review are directed by the project author;
+porting strategy design is also supported by **Gemini Pro** (Google).
+
+All commits, test results, and architectural decisions remain under human authorship and review.
+
 ### Running Tests
 MRTKLIB includes both robust unit tests (utest) and regression tests to ensure core stability when merging complex GNSS algorithms.
 

--- a/src/data/mrtk_eph.c
+++ b/src/data/mrtk_eph.c
@@ -568,6 +568,7 @@ int ephpos(gtime_t time, gtime_t teph, int sat, const nav_t *nav,
     }
     else if (sys==SYS_GLO) {
         if (!(geph=selgeph(teph,sat,iode,nav))) return 0;
+        if (fabs(geph->taun)>1.0) return 0; /* reject corrupted GLO clock data (consistent with ephclk) */
         geph2pos(time,geph,rs,dts,var);
         time=timeadd(time,tt);
         geph2pos(time,geph,rst,dtst,var);

--- a/src/pos/mrtk_ppp.c
+++ b/src/pos/mrtk_ppp.c
@@ -432,7 +432,9 @@ static double varerr(int sat, int sys, double el, int idx, int type,
     double fact=1.0,sinel=sin(el);
 
     if (type==1) fact*=opt->eratio[idx==0?0:1];
-    fact*=sys==SYS_GLO?EFACT_GLO:(sys==SYS_SBS?EFACT_SBS:EFACT_GPS);
+    fact*=sys==SYS_GLO?EFACT_GLO:(sys==SYS_GAL?EFACT_GAL:
+          (sys==SYS_QZS?EFACT_QZS:(sys==SYS_CMP?EFACT_CMP:
+          (sys==SYS_IRN?EFACT_IRN:(sys==SYS_SBS?EFACT_SBS:EFACT_GPS)))));
     if (opt->ionoopt==IONOOPT_IFLC) fact*=3.0;
     return SQR(fact*opt->err[1])+SQR(fact*opt->err[2]/sinel);
 }
@@ -565,6 +567,68 @@ static int corr_meas(const obsd_t *obs, const nav_t *nav, const double *azel,
     return 1;
 }
 /* detect cycle slip by LLI --------------------------------------------------*/
+/* detect cycle slip by Doppler/phase rate comparison (demo5, single-receiver) */
+static void detslp_dop(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
+{
+    (void)nav;
+    int i,f,sat,ndop=0,nf=rtk->opt.nf<NFREQ?rtk->opt.nf:NFREQ;
+    double dph,dpt,tt,mean_dop=0.0;
+    double dopdif[MAXOBS][NFREQ]={{0}},tts[MAXOBS][NFREQ]={{0}};
+
+    if (rtk->opt.thresdop<=0.0) return;
+
+    for (i=0;i<n&&i<MAXOBS;i++) {
+        sat=obs[i].sat;
+        for (f=0;f<nf;f++) {
+            if (obs[i].L[f]==0.0||obs[i].D[f]==0.0||
+                rtk->ssat[sat-1].ph[0][f]==0.0) continue;
+            tt=timediff(obs[i].time,rtk->ssat[sat-1].pt[0][f]);
+            if (fabs(tt)<DTTOL) continue;
+            dph=(obs[i].L[f]-rtk->ssat[sat-1].ph[0][f])/tt;
+            dpt=-obs[i].D[f];
+            dopdif[i][f]=dph-dpt;
+            tts[i][f]=tt;
+            if (fabs(dopdif[i][f])<3.0*rtk->opt.thresdop) {
+                mean_dop+=dopdif[i][f]; ndop++;
+            }
+        }
+    }
+    if (ndop==0) return;
+    mean_dop/=ndop;
+
+    for (i=0;i<n&&i<MAXOBS;i++) {
+        sat=obs[i].sat;
+        for (f=0;f<nf;f++) {
+            if (dopdif[i][f]==0.0) continue;
+            if (fabs(dopdif[i][f]-mean_dop)>rtk->opt.thresdop) {
+                rtk->ssat[sat-1].slip[f]|=1;
+                trace(NULL,3,"ppp detslp_dop: sat=%2d F=%d dL=%.3f off=%.3f tt=%.2f\n",
+                      sat,f+1,dopdif[i][f]-mean_dop,mean_dop,tts[i][f]);
+            }
+        }
+    }
+}
+/* detect cycle slip by observation code change (demo5, single-receiver) */
+static void detslp_code(rtk_t *rtk, const obsd_t *obs, int n)
+{
+    int i,f,sat,nf=rtk->opt.nf<NFREQ?rtk->opt.nf:NFREQ;
+    for (i=0;i<n&&i<MAXOBS;i++) {
+        sat=obs[i].sat;
+        for (f=0;f<nf;f++) {
+            uint8_t code=obs[i].code[f];
+            if (code==CODE_NONE) continue;
+            uint8_t ccode=rtk->ssat[sat-1].codeprev[f][0];
+            if (code!=ccode) {
+                rtk->ssat[sat-1].codeprev[f][0]=code;
+                if (ccode!=CODE_NONE) {
+                    rtk->ssat[sat-1].slip[f]|=1;
+                    trace(NULL,3,"ppp detslp_code: sat=%2d F=%d %s->%s\n",
+                          sat,f+1,code2obs(ccode),code2obs(code));
+                }
+            }
+        }
+    }
+}
 static void detslp_ll(rtk_t *rtk, const obsd_t *obs, int n)
 {
     int i,j;
@@ -939,6 +1003,12 @@ static void udbias_ppp(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
 
     /* detect cycle slip by ssr */
     detslp_ssr(rtk,obs,n,nav);
+
+    /* detect cycle slip by Doppler rate (demo5) */
+    detslp_dop(rtk,obs,n,nav);
+
+    /* detect cycle slip by observation code change (demo5) */
+    detslp_code(rtk,obs,n);
 
     ecef2pos(rtk->sol.rr,pos);
 
@@ -1374,6 +1444,13 @@ static void update_stat(rtk_t *rtk, const obsd_t *obs, int n, int stat)
 
     for (i=0;i<n&&i<MAXOBS;i++) for (j=0;j<opt->nf&&j<NFREQ;j++) {
         rtk->ssat[obs[i].sat-1].snr[j]=obs[i].SNR[j];
+    }
+    /* update previous phase/time for Doppler slip detection */
+    for (i=0;i<n&&i<MAXOBS;i++) for (j=0;j<opt->nf&&j<NFREQ;j++) {
+        if (obs[i].L[j]!=0.0) {
+            rtk->ssat[obs[i].sat-1].pt[0][j]=obs[i].time;
+            rtk->ssat[obs[i].sat-1].ph[0][j]=obs[i].L[j];
+        }
     }
     for (i=0;i<MAXSAT;i++) for (j=0;j<opt->nf&&j<NFREQ;j++) {
         if (rtk->ssat[i].slip[j]&3) rtk->ssat[i].slipc[j]++;

--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -291,7 +291,9 @@ static double varerr(int sat, int sys, double el, int type,
     else {
         /* normal error model */
         if (type == 1) fact *= opt->eratio[0];
-        fact *= sys == SYS_GLO ? EFACT_GLO : (sys == SYS_SBS ? EFACT_SBS : EFACT_GPS);
+        fact *= sys==SYS_GLO?EFACT_GLO:(sys==SYS_GAL?EFACT_GAL:
+                (sys==SYS_QZS?EFACT_QZS:(sys==SYS_CMP?EFACT_CMP:
+                (sys==SYS_IRN?EFACT_IRN:(sys==SYS_SBS?EFACT_SBS:EFACT_GPS)))));
         if (opt->ionoopt == IONOOPT_IFLC) fact *= 3.0;
         a = fact * opt->err[1];
         b = fact * opt->err[2];
@@ -530,6 +532,68 @@ static void udion(rtk_t *rtk, double tt, double bl, const obsd_t *obs, int ns)
  * @param[in]     obs Observation data
  * @param[in]     n   Number of observations
  */
+/* detect cycle slip by Doppler/phase rate comparison (demo5, single-receiver) */
+static void detslp_dop(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
+{
+    (void)nav;
+    int i, f, sat, ndop = 0, nf = rtk->opt.nf < NFREQ ? rtk->opt.nf : NFREQ;
+    double dph, dpt, tt, mean_dop = 0.0;
+    double dopdif[MAXOBS][NFREQ] = {{0}}, tts[MAXOBS][NFREQ] = {{0}};
+
+    if (rtk->opt.thresdop <= 0.0) return; /* disabled */
+
+    for (i = 0; i < n && i < MAXOBS; i++) {
+        sat = obs[i].sat;
+        for (f = 0; f < nf; f++) {
+            if (obs[i].L[f] == 0.0 || obs[i].D[f] == 0.0 ||
+                rtk->ssat[sat-1].ph[0][f] == 0.0) continue;
+            tt = timediff(obs[i].time, rtk->ssat[sat-1].pt[0][f]);
+            if (fabs(tt) < DTTOL) continue;
+            dph = (obs[i].L[f] - rtk->ssat[sat-1].ph[0][f]) / tt;
+            dpt = -obs[i].D[f];
+            dopdif[i][f] = dph - dpt;
+            tts[i][f] = tt;
+            if (fabs(dopdif[i][f]) < 3.0 * rtk->opt.thresdop) {
+                mean_dop += dopdif[i][f]; ndop++;
+            }
+        }
+    }
+    if (ndop == 0) return;
+    mean_dop /= ndop;
+
+    for (i = 0; i < n && i < MAXOBS; i++) {
+        sat = obs[i].sat;
+        for (f = 0; f < nf; f++) {
+            if (dopdif[i][f] == 0.0) continue;
+            if (fabs(dopdif[i][f] - mean_dop) > rtk->opt.thresdop) {
+                rtk->ssat[sat-1].slip[f] |= 1;
+                trace(NULL, 3, "ppprtk detslp_dop: sat=%2d F=%d dL=%.3f off=%.3f tt=%.2f\n",
+                      sat, f+1, dopdif[i][f]-mean_dop, mean_dop, tts[i][f]);
+            }
+        }
+    }
+}
+/* detect cycle slip by observation code change (demo5, single-receiver) */
+static void detslp_code(rtk_t *rtk, const obsd_t *obs, int n)
+{
+    int i, f, sat, nf = rtk->opt.nf < NFREQ ? rtk->opt.nf : NFREQ;
+    for (i = 0; i < n && i < MAXOBS; i++) {
+        sat = obs[i].sat;
+        for (f = 0; f < nf; f++) {
+            uint8_t code = obs[i].code[f];
+            if (code == CODE_NONE) continue;
+            uint8_t ccode = rtk->ssat[sat-1].codeprev[f][0];
+            if (code != ccode) {
+                rtk->ssat[sat-1].codeprev[f][0] = code;
+                if (ccode != CODE_NONE) {
+                    rtk->ssat[sat-1].slip[f] |= 1;
+                    trace(NULL, 3, "ppprtk detslp_code: sat=%2d F=%d %s->%s\n",
+                          sat, f+1, code2obs(ccode), code2obs(code));
+                }
+            }
+        }
+    }
+}
 static void detslp_ll(rtk_t *rtk, const obsd_t *obs, int n)
 {
     int i, j;
@@ -655,6 +719,12 @@ static void udbias_ppp(rtk_t *rtk, double tt, const obsd_t *obs, int n,
 
     /* detect cycle slip by geometry-free phase jump */
     detslp_gf(rtk, obs, n, nav);
+
+    /* detect cycle slip by Doppler rate (demo5) */
+    detslp_dop(rtk, obs, n, nav);
+
+    /* detect cycle slip by observation code change (demo5) */
+    detslp_code(rtk, obs, n);
 
     for (f = 0; f < nf; f++) {
         /* reset phase-bias if expire obs outage counter */
@@ -972,8 +1042,14 @@ static int residual_test(rtk_t *rtk, const int *vflg, const double *v,
         (void)stype;
 
         /* validate individual residuals */
+        /* D2: inflate threshold 10x for newly-initialized phase bias (demo5) */
+        double inno0_eff = inno0;
+        if (type == 0 && rtk->opt.std[0] > 0.0) {
+            int ib = IB_RTK(sat2, freq, &rtk->opt);
+            if (rtk->P[ib + ib * rtk->nx] == SQR(rtk->opt.std[0])) inno0_eff *= 10.0;
+        }
         if (!Q[i + i * m] || inno0 == 0 ||
-            (v[i] * v[i] < Q[i + i * m] * inno0 * inno0)) {
+            (v[i] * v[i] < Q[i + i * m] * inno0_eff * inno0_eff)) {
             if (type == 0) {
                 if (!rtk->ssat[sat2 - 1].vsat[freq]) continue;
                 vv += v[i] * v[i] / Q[i + i * m];
@@ -2139,6 +2215,17 @@ extern void ppp_rtk_pos(rtk_t *rtk, const obsd_t *obs, int n, nav_t *nav)
 
     /* resolve integer ambiguity by LAMBDA */
     if (stat != SOLQ_NONE) {
+        /* B2: position variance gate — skip AR if filter not yet converged */
+        {
+            double posvar = 0.0;
+            for (i = 0; i < 3; i++) posvar += rtk->P[i + i * rtk->nx];
+            posvar /= 3.0;
+            if (rtk->opt.thresar[1] > 0.0 && posvar > rtk->opt.thresar[1]) {
+                trace(NULL, 3, "ppprtk: skip AR (posvar=%.4f>thresar1=%.4f)\n",
+                      posvar, rtk->opt.thresar[1]);
+                nb = 0; goto ppprtk_ar_done;
+            }
+        }
         nb = resamb_LAMBDA(rtk, bias, xa);
 
         /* partial AR: exclude satellites to improve fix (posopt[6]=on) */
@@ -2182,6 +2269,24 @@ extern void ppp_rtk_pos(rtk_t *rtk, const obsd_t *obs, int n, nav_t *nav)
                 }
             }
         }
+
+        /* B3: arfilter — if AR still failing, exclude newly-locked sats and retry */
+        if (nb <= 1 && rtk->opt.arfilter) {
+            int nf2 = NF_RTK(&rtk->opt), rerun = 0, dly = 2, sat;
+            for (sat = 0; sat < MAXSAT; sat++) {
+                for (f = 0; f < nf2; f++) {
+                    if (rtk->ssat[sat].vsat[f] && rtk->ssat[sat].lock[f] == 0) {
+                        rtk->ssat[sat].lock[f] = -(rtk->opt.minlock + dly);
+                        dly += 2; rerun = 1;
+                    }
+                }
+            }
+            if (rerun) {
+                trace(NULL, 3, "ppprtk arfilter: rerun with newly-locked sats excluded\n");
+                nb = resamb_LAMBDA(rtk, bias, xa);
+            }
+        }
+        ppprtk_ar_done:;
 
         if (nb > 1) {
             /* recompute zdres with fixed solution */


### PR DESCRIPTION
This pull request introduces MRTKLIB v0.4.2, which ports demo5 RTKLIB algorithm improvements to the CLAS PPP-RTK and MADOCA PPP engines, enhancing accuracy and robustness for kinematic positioning. The RTK and VRS-RTK engines remain unchanged. Key changes include new cycle-slip detectors, improved GLONASS ephemeris validation, expanded per-constellation error factors, and adaptive outlier thresholds (PPP-RTK only). Extensive benchmarks confirm improved Tokyo FIX accuracy and unchanged MADOCA results.

Algorithm improvements and accuracy enhancements:

* Added Doppler-based (`detslp_dop()`) and observation-code-change (`detslp_code()`) cycle-slip detectors to PPP-RTK and PPP engines, improving slip detection and bias reset on signal re-acquisition. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R73) [[2]](diffhunk://#diff-a4382a86b3d75b80b1c0b630adc7a3dc59a1759a0fc5bee6b538230365ba9c9eR1-R250)
* Introduced adaptive outlier threshold in PPP-RTK's `residual_test()` (10× inflation for newly-initialised biases), matching demo5 RTK behaviour. Explicitly reverted equivalent PPP change due to severe accuracy regression. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R73) [[2]](diffhunk://#diff-a4382a86b3d75b80b1c0b630adc7a3dc59a1759a0fc5bee6b538230365ba9c9eR1-R250)
* Implemented full per-constellation EFACT expansion in `varerr()` for PPP-RTK and PPP, now covering GAL, QZS, CMP, IRN, and SBS, improving variance modelling for multi-constellation measurements. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R73) [[2]](diffhunk://#diff-658dceb81ef6e079b4f428dacf759455b40435707a8a9e65e5b1886e5d0f2280L435-R437) [[3]](diffhunk://#diff-a4382a86b3d75b80b1c0b630adc7a3dc59a1759a0fc5bee6b538230365ba9c9eR1-R250)

Robustness and quality gates:

* Added GLONASS clock rejection guard to `ephpos()` (satellite position computation), preventing corrupted clock data from propagating into PPP-RTK and PPP solutions. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R73) [[2]](diffhunk://#diff-9128896db0dd8ac6a0594f37104b2078eea9afc59b9d0e5c5d98cb2c2240ffa4R571) [[3]](diffhunk://#diff-a4382a86b3d75b80b1c0b630adc7a3dc59a1759a0fc5bee6b538230365ba9c9eR1-R250)
* Enhanced PPP-RTK PAR with a position variance gate and improved `arfilter` logic, skipping AR when the filter hasn't converged and backing off newly-locked satellites after AR failure, reducing false fixes. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R73) [[2]](diffhunk://#diff-a4382a86b3d75b80b1c0b630adc7a3dc59a1759a0fc5bee6b538230365ba9c9eR1-R250)

Documentation and benchmarking:

* Added detailed release notes (`docs/release-notes-v0.4.2.md`), updated changelog, and benchmark summaries in `docs/benchmark.md`, demonstrating improved Tokyo FIX RMS_2D and unchanged MADOCA results. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R73) [[2]](diffhunk://#diff-3d312199f1da21c13b99d654a88a249129c2d8d05712a224085c98f16ff19315R397-R467) [[3]](diffhunk://#diff-a4382a86b3d75b80b1c0b630adc7a3dc59a1759a0fc5bee6b538230365ba9c9eR1-R250)
* Updated `readme.md` with algorithm improvement tables and clarified development workflow, including AI-assisted porting and review. [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R36-R52) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R99-R109)

Links and references:

* Added comparison link for v0.4.2 in `CHANGELOG.md`.

All 57 regression tests pass, confirming stability and correctness. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R73) [[2]](diffhunk://#diff-a4382a86b3d75b80b1c0b630adc7a3dc59a1759a0fc5bee6b538230365ba9c9eR1-R250)