### PR TITLE
fix: remove extraneous semicolon after if block in mrtk_time.c

### DIFF
--- a/src/core/mrtk_time.c
+++ b/src/core/mrtk_time.c
@@ -539,7 +539,7 @@ extern void time2str(gtime_t t, char *s, int n)
     } else if (n > 12) {
         n = 12;
     }
-    if (1.0-t.sec<0.5/pow(10.0,n)) {t.time++; t.sec=0.0;};
+    if (1.0-t.sec<0.5/pow(10.0,n)) {t.time++; t.sec=0.0;}
     time2epoch(t,ep);
     sprintf(s,"%04.0f/%02.0f/%02.0f %02.0f:%02.0f:%0*.*f",ep[0],ep[1],ep[2],
             ep[3],ep[4],n<=0?2:n+3,n<=0?0:n,ep[5]);


### PR DESCRIPTION
The trailing semicolon in `};` after the if block is a null statement that could be misread as accidental. Flagged by Copilot review.