### PR TITLE
Fix #31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to MRTKLIB are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.5.5] - 2026-03-11
+
+**Bug fix** — CLAS real-time positioning via UBX does not work
+([#31](https://github.com/h-shiono/MRTKLIB/issues/31)).
+
+### Fixed
+
+- **`decode_rxmqzssl6()`** — L6D frames (msg=0) were unconditionally sent to
+  the MADOCA decoder which silently dropped them (vendor_id≠2).  Now branches on
+  the `msg` field: L6D returns `ret=10` directly, routing to the CLAS decoder
+  via the redirect block.
+- **UBX 2-channel L6D demux** — UBX streams interleave L6D frames from two QZS
+  satellites.  The redirect block now extracts the PRN from the L6 frame header
+  and routes frames to separate CLAS channels (ch0/ch1), preventing subframe
+  assembly corruption in `clas_input_cssr()`.
+- **`l6delivery[]` initial value** — Channel assignment checked `== 0` but the
+  field is initialized to `-1`.  Fixed to `< 0`.
+
+### Added
+
+- **`conf/claslib/rtkrcv_ubx_clas.toml`** — Template config for real-time CLAS
+  PPP-RTK via u-blox UBX TCP streams (F9P obs + D9C L6D).
+- **CSSR decode trace** — Diagnostic trace output for L6D redirect and CSSR
+  epoch decode events.
+
 ## [v0.5.4] - 2026-03-11
 
 **Signals architecture redesign** — Introduces `mrtk_band_t` enum (26 physical

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ incrementally back-ported to each engine:
 | **v0.5.2** | All | Code quality: mandatory braces on control flow, nested/complex ternary elimination (67 files) | ✅ Released |
 | **v0.5.3** | All | Code quality: full `clang-format` application (116 files, Google style) | ✅ Released |
 | **v0.5.4** | All | Signals update: frequency / physical band separation and structuring | ✅ Released |
-| **v0.5.5** | PPP-RTK | Bug fix: CLAS real-time positioning does not work properly ([#31](https://github.com/h-shiono/MRTKLIB/issues/31)) | 🔜 Next |
+| **v0.5.5** | PPP-RTK | Bug fix: CLAS real-time positioning via UBX does not work ([#31](https://github.com/h-shiono/MRTKLIB/issues/31)) | ✅ Released |
 | **v0.5.6** | All | Support RINEX 4.0 (OBS reading & basic data structures) | 🔜 Planned |
 | **v0.5.x** | — | Port remaining RTKLIB console apps: `convbin`, `str2str` | 💭 Backlog |
 | **v0.5.x** | All | Doxygen docstring coverage expansion | 💭 Backlog |

--- a/conf/claslib/rtkrcv_ubx_clas.toml
+++ b/conf/claslib/rtkrcv_ubx_clas.toml
@@ -1,0 +1,256 @@
+# MRTKLIB Configuration (TOML v1.0.0)
+#
+# Template for real-time CLAS PPP-RTK using u-blox receivers.
+# Rover observations and L6D corrections are both received as UBX format.
+#
+# Usage:
+#   1. Edit [streams.input.*] sections to match your local setup
+#   2. Edit [antenna.rover] type to match your receiver antenna
+#   3. Run: ./build/rtkrcv -k conf/claslib/rtkrcv_ubx_clas.toml
+#
+# Tested with: u-blox F9P (obs) + D9C (L6D via UBX-RXM-QZSSL6)
+
+[positioning]
+mode                = "ppp-rtk"  # (9:ppp-rtk)
+signals             = ["G1C", "G2W", "E1C", "E5Q", "E7Q", "J1C", "J5Q", "J2X"]
+solution_type       = "forward"  # (0:forward)
+elevation_mask      = 15.0  # (deg)
+dynamics            = true  # kinematic
+satellite_ephemeris = "brdc+ssrapc"  # (3:brdc+ssrapc)
+excluded_sats       = ""
+constellations      = 25  # GPS + Galileo + QZSS; (1:gps+8:gal+16:qzs)
+
+[positioning.clas]
+grid_selection_radius  = 1000  # CLAS grid selection radius (m)
+receiver_type          = "TRIMBLE NETR9"  # reference receiver type for ISB
+position_uncertainty_x = 10.0
+position_uncertainty_y = 10.0
+position_uncertainty_z = 10.0
+
+[positioning.snr_mask]
+rover_enabled = true
+base_enabled  = false
+L1            = [10, 10, 10, 10, 30, 30, 30, 30, 30]
+L2            = [10, 10, 10, 10, 30, 30, 30, 30, 30]
+L5            = [10, 10, 10, 10, 30, 30, 30, 30, 30]
+
+[positioning.corrections]
+satellite_antenna = false
+receiver_antenna  = true
+phase_windup      = "on"
+exclude_eclipse   = true
+raim_fde          = true
+iono_compensation = "meas"
+partial_ar        = true
+shapiro_delay     = true
+exclude_qzs_ref   = true
+no_phase_bias_adj = false
+
+[positioning.atmosphere]
+tidal_correction = "solid+otl-clasgrid+pole"
+ionosphere       = "est-adaptive"
+troposphere      = "off"
+
+[ambiguity_resolution]
+mode   = "fix-and-hold"
+qzs_ar = true
+
+[ambiguity_resolution.thresholds]
+alpha          = "10%"
+elevation_mask = 20.0  # (deg)
+hold_elevation = 30.0  # (deg)
+
+[ambiguity_resolution.counters]
+lock_count = 5
+out_count  = 1
+min_fix    = 0
+
+[ambiguity_resolution.partial_ar]
+min_ambiguities   = 6
+max_excluded_sats = 4
+
+[ambiguity_resolution.hold]
+variance = 0.001
+
+[rejection]
+l1_l2_residual       = 2.0
+dispersive           = 3.0
+non_dispersive       = 3.0
+hold_chi_square      = 0.5
+fix_chi_square       = 5.0
+pseudorange_diff     = 10.0
+position_error_count = 5
+
+[slip_detection]
+threshold = 0.05  # (m)
+
+[kalman_filter]
+iterations = 1
+
+[kalman_filter.measurement_error]
+code_phase_ratio_L1 = 50.0
+phase               = 0.01
+phase_elevation     = 0.005
+phase_baseline      = 0.0
+doppler             = 10.0
+
+[kalman_filter.initial_std]
+bias        = 100.0
+ionosphere  = 0.01
+troposphere = 0.005
+
+[kalman_filter.process_noise]
+accel_h         = 0.2
+accel_v         = 0.1
+position_h      = 0.0
+position_v      = 0.0
+bias            = 0.001
+ionosphere      = 0.001
+iono_max        = 0.05
+troposphere     = 0.001
+iono_time_const = 10.0
+clock_stability = 5.00e-12
+
+[adaptive_filter]
+iono_forgetting = 0.3
+iono_gain       = 3.0
+enabled         = false
+pva_forgetting  = 0.3
+pva_gain        = 1.0
+
+[receiver]
+baseline_length = 0.0
+baseline_sigma  = 0.0
+max_age         = 30.0
+isb             = true
+phase_shift     = "table"
+reference_type  = "CLAS"
+
+[antenna.rover]
+position_type = "single"  # initial position from SPP
+type          = "AOAD/M_T        NONE"  # change to your antenna type
+delta_e       = 0.0
+delta_n       = 0.0
+delta_u       = 0.0
+
+[antenna.base]
+position_type      = "llh"
+position_1         = 0.0
+position_2         = 0.0
+position_3         = 0.0
+type               = ""
+delta_e            = 0.0
+delta_n            = 0.0
+delta_u            = 0.0
+max_average_epochs = 0
+init_reset         = false
+
+[output]
+format            = "nmea"
+header            = true
+options           = true
+velocity          = false
+time_system       = "gpst"
+time_format       = "tow"
+time_decimals     = 3
+coordinate_format = "deg"
+field_separator   = ""
+single_output     = false
+max_solution_std  = 0.0
+height_type       = "ellipsoidal"
+geoid_model       = "internal"
+static_solution   = "all"
+nmea_interval_1   = 0.0
+nmea_interval_2   = 0.0
+solution_status   = "off"
+
+[files]
+cssr_grid     = "./tests/data/claslib/clas_grid.def"
+ocean_loading = "./tests/data/claslib/clas_grid.blq"
+eop           = "./tests/data/claslib/igu00p01.erp"
+receiver_atx  = "./tests/data/claslib/igs14_L5copy.atx"
+isb_table     = "./tests/data/claslib/isb.tbl"
+phase_cycle   = "./tests/data/claslib/l2csft.tbl"
+satellite_atx = ""
+station_pos   = ""
+geoid         = ""
+dcb           = ""
+temp_dir      = ""
+geexe         = ""
+solution_stat = ""
+trace         = ""
+
+[server]
+cycle_ms           = 10
+timeout_ms         = 10000
+reconnect_ms       = 10000
+nmea_cycle_ms      = 5000
+buffer_size        = 32768
+nav_msg_select     = "all"
+proxy              = ""
+swap_margin        = 30
+time_interpolation = true
+max_obs_loss       = 90.0
+float_count        = 15
+
+# ── Input streams ─────────────────────────────────────────────────────────────
+# Edit these sections to match your local setup.
+#
+# Example: u-blox F9P (obs) on TCP port 20001, D9C (L6D) on TCP port 20002
+#   [streams.input.rover]
+#   type   = "tcpcli"
+#   path   = "localhost:20001"
+#   format = "ubx"
+#
+#   [streams.input.correction]
+#   type   = "tcpcli"
+#   path   = "localhost:20002"
+#   format = "ubx"
+
+[streams.input.rover]
+type   = "tcpcli"
+path   = "localhost:20001"
+format = "ubx"
+
+[streams.input.base]
+type    = "off"
+path    = ""
+format  = ""
+nmeareq = false
+nmealat = 0.0
+nmealon = 0.0
+
+[streams.input.correction]
+type   = "tcpcli"
+path   = "localhost:20002"
+format = "ubx"  # UBX-RXM-QZSSL6 carrying L6D (CLAS)
+
+# ── Output streams ────────────────────────────────────────────────────────────
+
+[streams.output.stream1]
+type   = "off"
+path   = ""
+format = "nmea"
+
+[streams.output.stream2]
+type   = "off"
+path   = ""
+format = "nmea"
+
+[streams.log.stream1]
+type = "off"
+path = ""
+
+[streams.log.stream2]
+type = "off"
+path = ""
+
+[streams.log.stream3]
+type = "off"
+path = ""
+
+[console]
+passwd   = ""
+timetype = "gpst"
+soltype  = "deg"
+solflag  = "off"

--- a/docs/release-notes-v0.5.5.md
+++ b/docs/release-notes-v0.5.5.md
@@ -1,0 +1,136 @@
+# MRTKLIB v0.5.5 Release Notes
+
+**Release date:** 2026-03-11
+**Type:** Bug fix — CLAS real-time via UBX
+**Branch:** `31-bug-rtkrcv-clas-real-time-positioning-does-not-work-properly`
+
+---
+
+## Overview
+
+v0.5.5 fixes [#31](https://github.com/h-shiono/MRTKLIB/issues/31): CLAS PPP-RTK
+real-time positioning via UBX streams (`format = "ubx"`) did not work.  L6D
+correction frames from UBX-RXM-QZSSL6 messages were silently dropped, preventing
+the CLAS decoder from receiving any data.
+
+After this fix, `rtkrcv` achieves PPP-RTK float via live UBX streams from u-blox
+receivers (F9P obs + D9C L6D corrections).
+
+---
+
+## Root Cause
+
+Three cascading bugs prevented UBX L6D data from reaching the CLAS decoder:
+
+### Bug 1: L6D frames dropped by MADOCA decoder
+
+`decode_rxmqzssl6()` unconditionally called `decode_qzss_l6emsg()` (the MADOCA-PPP
+decoder) for all L6 frames, regardless of the `msg` field (0=L6D, 1=L6E).  The
+MADOCA decoder checks `vendor_id == 2` and silently returns 0 for L6D frames
+(vendor_id=1), so `ret=0` was returned instead of `ret=10`.  The redirect block
+in `decoderaw()` only fires when `ret == 10`, so L6D data never reached
+`clas_input_cssr()`.
+
+**Fix:** Branch on the `msg` field — L6D (`msg=0`) returns `ret=10` directly,
+skipping the MADOCA decoder.  L6E (`msg=1`) continues through
+`decode_qzss_l6emsg()` as before.
+
+### Bug 2: 2-channel L6D frame interleaving
+
+UBX streams contain L6D frames from **two** QZS satellites (e.g., PRN 194 and
+PRN 199) interleaved in a single stream.  The redirect block sent all frames to
+CLAS channel 0 using the fixed mapping `ch = (index == 1) ? 1 : 0`.  This
+corrupted the byte-by-byte subframe assembly in `clas_input_cssr()` — each PRN's
+subframe-start indicator reset the other PRN's partially accumulated data.
+
+**Fix:** For UBX format, extract the PRN from the L6 frame header
+(`rtcm->buff[4]`) and route to separate CLAS channels.  The first PRN
+encountered is assigned to ch=0, the second to ch=1.
+
+### Bug 3: Incorrect initial value check for channel assignment
+
+`clas_ctx_init()` initializes `l6delivery[ch]` to `-1` (not `0`).  The
+PRN-based demux condition checked `l6delivery[0] == 0`, which was never true,
+causing **all** frames to be routed to ch=1 regardless of PRN.
+
+**Fix:** Changed the condition to `l6delivery[0] < 0`.
+
+### Why simulated RT tests were not affected
+
+The existing `rtkrcv_rt_clas` and `rtkrcv_rt_clas_2ch` tests use
+`format = "clas"` (STRFMT_CLAS) for the correction stream.  In this path, raw
+L6 bytes are fed **directly** to `clas_input_cssr()`, bypassing the UBX decoder
+entirely.  The UBX path (`format = "ubx"`) was never exercised by the simulated
+RT tests, so the bug was undetected.
+
+In practice, users receive L6D corrections via UBX-RXM-QZSSL6 messages from
+u-blox receivers — the `format = "clas"` path is only used with pre-recorded
+raw L6 data.
+
+---
+
+## Changes
+
+### Fixed
+
+| File | Change |
+|------|--------|
+| `src/data/rcv/mrtk_rcv_ublox.c` | `decode_rxmqzssl6()`: branch on `msg` field, return `ret=10` for L6D |
+| `src/stream/mrtk_rtksvr.c` | Redirect block: PRN-based channel demux for UBX format |
+| `src/stream/mrtk_rtksvr.c` | `l6delivery[]` initial value check: `< 0` instead of `== 0` |
+
+### Added
+
+| File | Change |
+|------|--------|
+| `conf/claslib/rtkrcv_ubx_clas.toml` | Template config for real-time CLAS PPP-RTK via UBX TCP streams |
+| `src/stream/mrtk_rtksvr.c` | Diagnostic trace for CSSR epoch decode events (level 2) |
+
+---
+
+## Data Flow: Before and After
+
+### Before (broken)
+
+```
+UBX stream → decode_rxmqzssl6()
+  → decode_qzss_l6emsg()     ← called for ALL L6 frames
+  → vid != 2 → return 0      ← L6D silently dropped
+  → ret=0 → redirect block skipped
+  → CLAS decoder never receives data
+```
+
+### After (fixed)
+
+```
+UBX stream → decode_rxmqzssl6()
+  → msg=0 (L6D): ret=10      ← routed to CLAS
+  → msg=1 (L6E): decode_qzss_l6emsg()  ← MADOCA path unchanged
+  → redirect block fires
+  → PRN-based demux: PRN-A→ch0, PRN-B→ch1
+  → clas_input_cssr() per channel
+  → clas_decode_msg() → clas_update_global()
+```
+
+---
+
+## Test Results
+
+56/56 non-realtime tests pass — unchanged from v0.5.4.
+
+| Test Suite | Count | Status |
+|------------|-------|--------|
+| Unit tests | 12 | PASS |
+| SPP / receiver bias | 4 | PASS |
+| MADOCA PPP / PPP-AR / PPP-AR+iono | 10 | PASS |
+| CLAS PPP-RTK + VRS-RTK | 19 | PASS |
+| ssr2obs / ssr2osr / BINEX | 4 | PASS |
+| Tier 2 absolute accuracy | 2 | PASS |
+| Tier 3 position scatter | 2 | PASS |
+| Fixtures | 3 | PASS |
+
+### Live UBX verification
+
+PPP-RTK float achieved via live UBX streams (u-blox F9P obs + D9C L6D) with
+`conf/claslib/rtkrcv_ubx_clas.toml`.  Fix convergence is dependent on CLAS
+correction availability and grid coverage.

--- a/src/data/rcv/mrtk_rcv_ublox.c
+++ b/src/data/rcv/mrtk_rcv_ublox.c
@@ -1361,7 +1361,13 @@ static int decode_rxmqzssl6(raw_t* raw, rtcm_t* rtcm) {
     ret = 0;
     if (stat == 1) {
         memcpy(rtcm->buff, p + 14, 250);
-        ret = decode_qzss_l6emsg(rtcm);
+        if (msg == 0) {
+            /* L6D (CLAS): skip MADOCA decoder, route to CLAS via redirect block */
+            ret = 10;
+        } else {
+            /* L6E (MADOCA-PPP): decode SSR corrections */
+            ret = decode_qzss_l6emsg(rtcm);
+        }
     }
     return ret;
 }

--- a/src/stream/mrtk_rtksvr.c
+++ b/src/stream/mrtk_rtksvr.c
@@ -469,13 +469,30 @@ static int decoderaw(rtksvr_t* svr, int index) {
                   time_str(obs->data[0].time,0),obs->n);
         }
 #endif
-        /* update rtk server */
-        if (ret > 0) {
+        /* update rtk server (skip update_ssr for UBX L6D: ret=10 means
+         * "L6 payload ready for CLAS redirect", not "SSR message decoded") */
+        if (ret > 0 && !(ret == 10 && svr->format[index] == STRFMT_UBX)) {
             update_svr(svr, ret, obs, nav, ephsat, ephset, sbsmsg, index, fobs);
         }
         /* redirect L6 payload to CLAS decoder (UBX/L6E → CLAS path) */
         if (svr->clas && ret == 10 && (svr->format[index] == STRFMT_UBX || svr->format[index] == STRFMT_L6E)) {
-            int k, ch = (index == 1) ? 1 : 0, cret;
+            int k, ch, cret, max_cret = 0;
+
+            if (svr->format[index] == STRFMT_UBX) {
+                /* UBX: demux L6D frames by PRN (both channels in same stream) */
+                int l6prn = svr->rtcm[index].buff[4]; /* PRN from L6 frame header */
+                if (svr->clas->l6delivery[0] < 0 || svr->clas->l6delivery[0] == l6prn) {
+                    ch = 0;
+                } else {
+                    ch = 1;
+                }
+            } else {
+                /* L6E: use stream index mapping (separate streams per channel) */
+                ch = (index == 1) ? 1 : 0;
+            }
+
+            trace(NULL, 3, "L6 redirect: fmt=%d ch=%d prn=%d index=%d\n", svr->format[index], ch,
+                  svr->rtcm[index].buff[4], index);
             /* initialize week_ref from obs time (once) */
             if (svr->clas->week_ref[0] == 0) {
                 gtime_t t = svr->raw[0].time;
@@ -486,13 +503,18 @@ static int decoderaw(rtksvr_t* svr, int index) {
                         svr->clas->week_ref[j] = week;
                         svr->clas->tow_ref[j] = -1;
                     }
+                    trace(NULL, 2, "L6 redirect: week_ref initialized to %d\n", week);
                 }
             }
             /* feed 250-byte L6 frame from rtcm->buff to CLAS decoder */
             for (k = 0; k < 250; k++) {
                 clas_input_cssr(svr->clas, svr->rtcm[index].buff[k], ch);
                 cret = clas_decode_msg(svr->clas, ch);
+                if (cret > max_cret) {
+                    max_cret = cret;
+                }
                 if (cret == 10) {
+                    trace(NULL, 2, "L6 CSSR epoch: ch=%d k=%d\n", ch, k);
                     int net = svr->clas->grid[ch].network;
                     if (net > 0) {
                         if (clas_bank_get_close(svr->clas, svr->clas->l6buf[ch].time, net, ch,
@@ -514,6 +536,10 @@ static int decoderaw(rtksvr_t* svr, int index) {
                         }
                     }
                 }
+            }
+            if (max_cret > 0) {
+                trace(NULL, 2, "L6 redirect: max_cret=%d ch=%d nframe=%d havebit=%d nbit=%d\n", max_cret, ch,
+                      svr->clas->l6buf[ch].nframe, svr->clas->l6buf[ch].havebit, svr->clas->l6buf[ch].nbit);
             }
         }
         /* observation data received */


### PR DESCRIPTION
This pull request addresses a critical bug in real-time CLAS PPP-RTK positioning via UBX streams, ensuring that L6D correction frames from u-blox receivers are correctly routed to the CLAS decoder. It also adds a template configuration for live UBX-based CLAS PPP-RTK operation and introduces diagnostic trace outputs for debugging. The fixes resolve three cascading issues that previously prevented CLAS corrections from being processed, and the release is now marked as completed in documentation.

**Bug fixes for CLAS real-time positioning via UBX:**

* [`src/data/rcv/mrtk_rcv_ublox.c`](diffhunk://#diff-dd76084d7b1aef78eb43824e9fbdad2c0c359a37d05bf06fe5d5db41e2a5ea41R1364-R1371): Modified `decode_rxmqzssl6()` to branch on the `msg` field, returning `ret=10` directly for L6D frames, so they are routed to the CLAS decoder instead of being silently dropped by the MADOCA decoder.
* [`src/stream/mrtk_rtksvr.c`](diffhunk://#diff-2023b7dec0866ab12a3f5f0d453f48a76f4ae74361600bc19f9e51cbc3b31558L472-R495): Updated the redirect block to demux UBX L6D frames by PRN, assigning each PRN to a separate CLAS channel, preventing subframe assembly corruption. Also fixed the initial value check for channel assignment from `== 0` to `< 0`.
* [`src/stream/mrtk_rtksvr.c`](diffhunk://#diff-2023b7dec0866ab12a3f5f0d453f48a76f4ae74361600bc19f9e51cbc3b31558R506-R517): Added diagnostic trace outputs for CSSR epoch decode events and maximum decode return values to aid debugging and verification. [[1]](diffhunk://#diff-2023b7dec0866ab12a3f5f0d453f48a76f4ae74361600bc19f9e51cbc3b31558R506-R517) [[2]](diffhunk://#diff-2023b7dec0866ab12a3f5f0d453f48a76f4ae74361600bc19f9e51cbc3b31558R540-R543)

**Documentation and configuration updates:**

* `CHANGELOG.md`, `README.md`, `docs/release-notes-v0.5.5.md`: Updated release notes and changelog to reflect the bug fix, root cause, and test results. Marked v0.5.5 as released and provided detailed explanation of the issue and resolution. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R32) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R52) [[3]](diffhunk://#diff-5c5552bd4d7792adcf1d3d1c2c94c12b8d654ee22b0a19ccde08e2e59dfa21eeR1-R136)
* [`conf/claslib/rtkrcv_ubx_clas.toml`](diffhunk://#diff-e7793e2f7b0041b5965e59b2137d506a8da535ef11a60c0e944b415cb0842982R1-R256): Added a template configuration for real-time CLAS PPP-RTK using UBX TCP streams, facilitating live operation with u-blox F9P and D9C receivers.