### PR TITLE
Fix #53: address second Copilot review for convbin/str2str

### DIFF
--- a/apps/convbin/convbin.c
+++ b/apps/convbin/convbin.c
@@ -495,8 +495,8 @@ static int cmdopts(int argc, char** argv, rnxopt_t* opt, char** ifile, char** of
         } else if (!strcmp(argv[i], "-halfc")) {
             opt->halfcyc = 1;
         } else if (!strcmp(argv[i], "-mask") && i + 1 < argc) {
-            for (j = 0; j < 6; j++)
-                for (k = 0; k < 64; k++) opt->mask[j][k] = '0';
+            for (j = 0; j < 7; j++)
+                for (k = 0; k < MAXCODE; k++) opt->mask[j][k] = '0';
             setmask(argv[++i], opt, 1);
         } else if (!strcmp(argv[i], "-nomask") && i + 1 < argc) {
             setmask(argv[++i], opt, 0);

--- a/src/stream/mrtk_streamsvr.c
+++ b/src/stream/mrtk_streamsvr.c
@@ -437,7 +437,7 @@ static void write_sta_cycle(stream_t* str, strconv_t* conv) {
         strwrite(str, conv->out.buff, conv->out.nbyte);
     }
 }
-/* convert stearm ------------------------------------------------------------*/
+/* convert stream ------------------------------------------------------------*/
 static void strconv(stream_t* str, strconv_t* conv, uint8_t* buff, int n) {
     int i, ret;
 
@@ -481,6 +481,9 @@ static void periodic_cmd(int cycle, const char* cmd, stream_t* stream) {
         for (q = p;; q++)
             if (*q == '\r' || *q == '\n' || *q == '\0') break;
         n = (int)(q - p);
+        if (n >= (int)sizeof(msg)) {
+            n = (int)sizeof(msg) - 1;
+        }
         strncpy(msg, p, n);
         msg[n] = '\0';
 
@@ -501,7 +504,7 @@ static void periodic_cmd(int cycle, const char* cmd, stream_t* stream) {
         if (!*q) break;
     }
 }
-/* stearm server thread ------------------------------------------------------*/
+/* stream server thread ------------------------------------------------------*/
 static void* strsvrthread(void* arg) {
     strsvr_t* svr = (strsvr_t*)arg;
     sol_t sol_nmea = {{0}};


### PR DESCRIPTION
- Fix -mask reset to cover all 7 systems and MAXCODE entries (was 6/64)
- Fix "stearm" typos in mrtk_streamsvr.c comments (x2)
- Cap periodic_cmd() strncpy length to sizeof(msg)-1 to prevent overflow

Skipped: half-cycle correction stat mapping (identical to upstream RTKLIB, Copilot misinterprets the LLI_HALFA/LLI_HALFS semantics); release notes table format (false positive, tables use correct single-pipe delimiters).