### PR TITLE
Fix #61: address Copilot review for v0.6.1 TOML config

### DIFF
--- a/conf/benchmark/rtk.toml
+++ b/conf/benchmark/rtk.toml
@@ -11,7 +11,7 @@ dynamics = true                                                                 
 satellite_ephemeris = "brdc"
 excluded_sats = ""
 # constellations    = 57  # deprecated: use systems instead
-systems = ["GPS", "SBAS", "GLONASS", "Galileo", "QZSS", "BeiDou"]
+systems = ["GPS", "Galileo", "QZSS", "BeiDou"]
 
 [positioning.snr_mask]
 rover_enabled = true

--- a/conf/claslib/ssr2obs.toml
+++ b/conf/claslib/ssr2obs.toml
@@ -17,8 +17,6 @@ shapiro_delay = true                         # shapiro time delay correction (0:
 no_phase_bias_adj = false                    # don't adjust phase bias (0:off,1:on)
 tidal_correction = "solid+otl-clasgrid+pole" # (0:off,3:solid+otl-clasgrid+pole)
 
-[positioning.atmosphere]
-
 [antenna.rover]
 position_type = "llh"         # (0:llh,1:xyz)
 position_1 = 36.1036338527778

--- a/conf/claslib/ssr2osr.toml
+++ b/conf/claslib/ssr2osr.toml
@@ -28,8 +28,6 @@ shapiro_delay = true                         # shapiro time delay correction (0:
 no_phase_bias_adj = false                    # don't adjust phase bias (0:off,1:on)
 tidal_correction = "solid+otl-clasgrid+pole" # (0:off,3:solid+otl-clasgrid+pole)
 
-[positioning.atmosphere]
-
 [kalman_filter.measurement_error]
 code_phase_ratio_L1 = 50.0 # code/phase error ratio
 phase = 0.01               # (m) measurement error


### PR DESCRIPTION
- benchmark/rtk.toml: remove SBAS and GLONASS from systems list to match original constellations=57 (GPS+Galileo+QZSS+BeiDou)
- claslib/ssr2obs.toml: remove empty [positioning.atmosphere] section
- claslib/ssr2osr.toml: remove empty [positioning.atmosphere] section