### PR TITLE
Enhance configuration reference and add Quick Start guides

### DIFF
--- a/docs/guide/quickstart-clas.md
+++ b/docs/guide/quickstart-clas.md
@@ -1,0 +1,223 @@
+# Quick Start: CLAS PPP-RTK
+
+This guide walks you through running CLAS PPP-RTK positioning with MRTKLIB,
+from required files to your first solution.
+
+CLAS (Centimeter Level Augmentation Service) is a satellite-based augmentation
+service broadcast via QZSS L6D. It provides ionospheric, tropospheric, and
+satellite bias corrections that enable centimeter-level PPP-RTK positioning
+within Japan.
+
+---
+
+## Prerequisites
+
+- MRTKLIB built successfully (`cmake --build build`)
+- Test data extracted:
+
+```bash
+tar xzf tests/data/claslib/claslib_testdata.tar.gz -C tests/data/claslib/
+```
+
+## Required Files
+
+CLAS PPP-RTK requires several support files beyond the usual observation
+and navigation data. All files below are **bundled** with MRTKLIB.
+
+| File | TOML Key | Purpose |
+|:-----|:---------|:--------|
+| `clas_grid.def` | `files.cssr_grid` | CLAS grid point definitions covering Japan. **Required** — without this, no corrections are applied. |
+| `clas_grid.blq` | `files.ocean_loading` | Ocean tide loading coefficients at each grid point. |
+| `igu00p01.erp` | `files.eop` | Earth rotation parameters for coordinate frame transformation. |
+| `igs14_L5copy.atx` | `files.receiver_atx` | Antenna phase center model (receiver and satellite). |
+| `isb.tbl` | `files.isb_table` | Inter-system bias table mapping receiver types to CLAS reference. |
+| `l2csft.tbl` | `files.phase_cycle` | L2C quarter-cycle phase shift correction per receiver type. |
+
+All bundled files are located in `tests/data/claslib/`.
+
+!!! warning "ANTEX File: Use IGS14, Not IGS20"
+    CLAS corrections are based on the **ITRF2014** reference frame. You must
+    use an IGS14-based ANTEX file (e.g., `igs14.atx` or `igs14_L5copy.atx`).
+
+    The latest IGS20-based ANTEX (`igs20.atx`) uses ITRF2020, which introduces
+    millimeter-to-centimeter frame differences that degrade positioning accuracy.
+
+---
+
+## Post-Processing
+
+### Run with Bundled Test Data
+
+```bash
+mrtk post -k conf/claslib/rnx2rtkp.toml \
+  -ts 2019/08/27 16:00:00 -te 2019/08/27 17:00:00 -ti 1 \
+  -o output_clas.pos \
+  tests/data/claslib/0627239Q.obs \
+  tests/data/claslib/0627239Q.nav \
+  tests/data/claslib/2019239Q.l6
+```
+
+- **Observation file** (`.obs` / `.bnx`) — RINEX or BINEX from a GNSS receiver in Japan
+- **Navigation file** (`.nav`) — Broadcast ephemeris
+- **L6 correction file** (`.l6`) — CLAS L6D data (extracted from QZSS L6 signal)
+
+### Expected Output
+
+After ~1 minute of convergence, the solution should reach **Fix (Q=4)**:
+
+```
+$GNGGA,160131.00,3908.109031,N,14107.972285,E,4,08,...
+```
+
+- **Q=4 (Fix)** — Ambiguities resolved, centimeter-level accuracy
+- **Q=5 (Float)** — Convergence in progress
+- **Q=1 (SPP)** — Initial convergence or missing corrections
+
+Typical fix rate for this dataset: **>99%** (after initial convergence).
+
+---
+
+## Real-Time Processing
+
+For real-time CLAS PPP-RTK, use `mrtk run` with live receiver streams.
+See [Real-Time CLAS Reference](../reference/rtkrcv-clas-realtime.md) for
+architecture details, stream configuration, and performance data.
+
+### File Replay (Testing)
+
+To test real-time processing with recorded data:
+
+```bash
+mrtk run -s -o conf/claslib/rtkrcv.toml
+```
+
+The bundled `rtkrcv.toml` is pre-configured for file replay using the
+test dataset with time-tag synchronization.
+
+### Live Receiver
+
+For a live u-blox F9P + D9C setup, use the template config:
+
+```bash
+mrtk run -s -o conf/claslib/rtkrcv_ubx_clas.toml
+```
+
+Edit the `[streams.input.*]` sections to match your receiver connections.
+
+---
+
+## Key Configuration Points
+
+These settings are critical for correct CLAS PPP-RTK operation. Getting
+any of them wrong will silently degrade or prevent Fix solutions.
+
+### Frequency: Must Be `l1+2`
+
+```toml
+[positioning]
+frequency = "l1+2"   # REQUIRED for CLAS
+```
+
+CLAS provides E1 and E5a corrections but does not provide Galileo E5b
+phase bias. Using `l1+2+3` (nf=3) adds the E5b slot, which has no valid
+bias correction, causing false geometry-free cycle slips on Galileo and
+dropping fix rate from >99% to ~67%.
+
+### Ionosphere: `est-adaptive` (Not `dual-freq`)
+
+```toml
+[positioning.atmosphere]
+ionosphere = "est-adaptive"   # CLAS provides iono corrections
+troposphere = "off"           # CLAS provides tropo corrections
+```
+
+CLAS supplies ionospheric and tropospheric corrections via the grid. The
+Kalman filter estimates residual ionospheric delays adaptively.
+Do not use `dual-freq` — that discards the CLAS ionospheric information.
+
+### Tidal Correction: CLAS Grid-Based
+
+```toml
+[positioning.corrections]
+tidal_correction = "solid+otl-clasgrid+pole"
+```
+
+This uses the CLAS grid points for ocean tide loading interpolation,
+rather than the station-specific BLQ method.
+
+### ISB and Phase Shift: Enabled with Tables
+
+```toml
+[receiver]
+isb = true
+phase_shift = "table"
+reference_type = "CLAS"
+```
+
+CLAS corrections are referenced to a specific receiver type. The ISB
+table and phase cycle table correct for inter-system biases and L2C
+quarter-cycle shifts between your receiver and the CLAS reference.
+
+!!! note "Receiver Type"
+    Set `[positioning.clas].receiver_type` to match your GNSS receiver
+    (e.g., `"Trimble NetR9"`). This value is used for ISB table lookup.
+    Check `isb.tbl` for supported receiver types.
+
+### Grid Selection Radius
+
+```toml
+[positioning.clas]
+grid_selection_radius = 1000   # meters
+```
+
+Controls how far from the rover position to search for CLAS grid points.
+1000 m is appropriate for most locations within Japan.
+
+!!! warning "Japan Coverage Only"
+    CLAS grid corrections are only available within Japan. Processing
+    observations from outside the coverage area will fail silently
+    (grid lookup returns no results).
+
+---
+
+## Bundled Configuration Files
+
+| File | Description |
+|:-----|:------------|
+| `conf/claslib/rnx2rtkp.toml` | Post-processing, single-channel L6 |
+| `conf/claslib/rnx2rtkp_vrs.toml` | Post-processing, VRS-RTK mode |
+| `conf/claslib/rtkrcv.toml` | Real-time, single-channel L6 (file replay) |
+| `conf/claslib/rtkrcv_2ch.toml` | Real-time, dual-channel L6 (file replay) |
+| `conf/claslib/rtkrcv_ubx_clas.toml` | Real-time, u-blox F9P + D9C (live) |
+| `conf/claslib/rtkrcv_sbf_l6d.toml` | Real-time, Septentrio SBF + L6D |
+| `conf/claslib/rtkrcv_rtcm3_ubx.toml` | Real-time, RTCM3 + UBX L6 |
+
+---
+
+## Troubleshooting
+
+### All Solutions Are SPP (Q=1)
+
+1. **Missing grid file** — Check that `files.cssr_grid` points to a valid `clas_grid.def`
+2. **Wrong frequency** — Ensure `frequency = "l1+2"`, not `l1+2+3`
+3. **No L6 data** — Verify the L6 correction file path and format
+
+### Fix Rate Lower Than Expected
+
+1. **nf=3 instead of nf=2** — Most common cause. See [Frequency](#frequency-must-be-l1-2) above.
+2. **Wrong ANTEX** — Using `igs20.atx` instead of `igs14.atx` introduces frame errors.
+3. **Receiver type mismatch** — Check `[positioning.clas].receiver_type` matches `isb.tbl`.
+
+### `clas grid file error`
+
+The grid file path is invalid or the file doesn't exist. Check the
+`files.cssr_grid` setting. Relative paths are resolved from the
+working directory, not from the config file location.
+
+---
+
+## Next Steps
+
+- [Configuration Options Reference](../reference/config-options.md) — Full options list with mode applicability
+- [Real-Time CLAS Reference](../reference/rtkrcv-clas-realtime.md) — Architecture, performance data, tag generation
+- [Configuration Guide](configuration.md) — TOML format overview

--- a/docs/guide/quickstart-madoca-ppp.md
+++ b/docs/guide/quickstart-madoca-ppp.md
@@ -1,0 +1,213 @@
+# Quick Start: MADOCA-PPP
+
+This guide walks you through running MADOCA-PPP (Precise Point Positioning)
+with MRTKLIB, covering both basic PPP and PPP with ambiguity resolution (PPP-AR).
+
+MADOCA (Multi-GNSS Advanced Demonstration tool for Orbit and Clock Analysis)
+provides real-time satellite orbit, clock, and bias corrections via QZSS L6E.
+Combined with broadcast ephemeris, it enables decimeter-to-centimeter-level
+global PPP positioning.
+
+---
+
+## Prerequisites
+
+- MRTKLIB built successfully (`cmake --build build`)
+- Test data extracted:
+
+```bash
+tar xzf tests/data/madocalib/madocalib_testdata.tar.gz -C tests/data/madocalib/
+```
+
+## Required Files
+
+| File | TOML Key | Purpose |
+|:-----|:---------|:--------|
+| RINEX observation (`.obs`) | positional arg | GNSS observations from a receiver |
+| RINEX navigation (`.rnx` / `.nav`) | positional arg | Broadcast ephemeris (mixed GNSS) |
+| L6E correction (`.l6`) | positional arg | MADOCA SSR corrections (orbit, clock, bias) |
+| Antenna model (`.atx`) | `files.receiver_atx` | Receiver/satellite antenna phase center model |
+
+!!! note "ANTEX File: IGS20 for MADOCA"
+    Unlike CLAS (which requires IGS14), MADOCA-PPP uses the **IGS20/ITRF2020**
+    reference frame. Use `igs20.atx` for antenna corrections.
+
+### Optional Files (for PPP-AR)
+
+For ambiguity-resolved PPP, no additional files are required beyond the L6E
+corrections — MADOCA provides the necessary phase bias information via SSR.
+
+---
+
+## Bundled Configuration Files
+
+MRTKLIB provides three MADOCA-PPP configurations with increasing capability:
+
+| File | Mode | AR | Iono | Frequencies |
+|:-----|:-----|:---|:-----|:------------|
+| `conf/madocalib/rnx2rtkp.toml` | PPP | Off | dual-freq | L1+L2 |
+| `conf/madocalib/rnx2rtkp_pppar.toml` | PPP-AR | Continuous | est-stec | L1+L2+L3+L4 |
+| `conf/madocalib/rnx2rtkp_pppar_iono.toml` | PPP-AR + Iono | Continuous | est-stec | L1+L2+L3+L4 |
+
+---
+
+## Post-Processing
+
+### Basic PPP (Float Solution)
+
+The simplest mode — no ambiguity resolution, dual-frequency ionospheric
+correction:
+
+```bash
+mrtk post -k conf/madocalib/rnx2rtkp.toml \
+  -ts 2025/04/01 0:00:00 -te 2025/04/01 0:59:30 -ti 30 \
+  -o output_madoca_ppp.pos \
+  tests/data/madocalib/MIZU00JPN_R_20250910000_01D_30S_MO.obs \
+  tests/data/madocalib/BRDM00DLR_S_20250910000_01D_MN.rnx \
+  tests/data/madocalib/2025091A.204.l6 \
+  tests/data/madocalib/2025091A.206.l6
+```
+
+!!! tip "Multiple L6E Files"
+    MADOCA uses two L6E streams (mdc-003 and mdc-004) on different PRNs.
+    Pass both `.l6` files as positional arguments. The decoder selects the
+    appropriate stream automatically.
+
+**Expected accuracy:** Decimeter-level (Q=5 Float).
+
+### PPP-AR (Ambiguity Resolution)
+
+For centimeter-level accuracy with integer ambiguity resolution:
+
+```bash
+mrtk post -k conf/madocalib/rnx2rtkp_pppar.toml \
+  -ts 2025/04/01 0:00:00 -te 2025/04/01 0:59:30 -ti 30 \
+  -o output_madoca_pppar.pos \
+  tests/data/madocalib/MIZU00JPN_R_20250910000_01D_30S_MO.obs \
+  tests/data/madocalib/BRDM00DLR_S_20250910000_01D_MN.rnx \
+  tests/data/madocalib/2025091A.204.l6 \
+  tests/data/madocalib/2025091A.206.l6
+```
+
+Key differences from basic PPP:
+
+- `frequency = "l1+2+3+4"` — Multi-frequency processing
+- `ambiguity_resolution.mode = "continuous"` — AR enabled
+- `ionosphere = "est-stec"` — Slant TEC estimation (better than dual-freq for AR)
+- `systems` includes all 5 constellations (GPS, GLONASS, Galileo, QZSS, BeiDou)
+
+**Expected accuracy:** Centimeter-level after convergence (Q=1 Fix).
+
+### PPP-AR with Ionospheric Correction
+
+The highest-accuracy mode, using MADOCA ionospheric corrections:
+
+```bash
+mrtk post -k conf/madocalib/rnx2rtkp_pppar_iono.toml \
+  -ts 2025/04/01 0:00:00 -te 2025/04/01 0:59:30 -ti 30 \
+  -o output_madoca_pppar_iono.pos \
+  tests/data/madocalib/MIZU00JPN_R_20250910000_01D_30S_MO.obs \
+  tests/data/madocalib/BRDM00DLR_S_20250910000_01D_MN.rnx \
+  tests/data/madocalib/2025091A.204.l6 \
+  tests/data/madocalib/2025091A.206.l6
+```
+
+This adds `receiver.iono_correction = true`, enabling MADOCA-specific
+ionospheric corrections for faster convergence.
+
+---
+
+## Key Configuration Points
+
+### Ephemeris Source
+
+```toml
+[positioning]
+satellite_ephemeris = "brdc+ssrapc"
+```
+
+MADOCA provides SSR corrections that are applied to broadcast ephemeris.
+`brdc+ssrapc` uses antenna phase center-corrected SSR orbits.
+
+### Signal Selection
+
+```toml
+[signals]
+gps = "L1/L2/L5"
+qzs = "L1/L5/L2"
+galileo = "E1/E5a/E5b/E6"
+bds2 = "B1I/B3I/B2I"
+bds3 = "B1I/B3I/B2a"
+```
+
+The `[signals]` section controls which frequency pairs are used for each
+constellation. These settings affect which observations enter the PPP filter
+and must match the available MADOCA bias corrections.
+
+### AR Thresholds (PPP-AR)
+
+```toml
+[ambiguity_resolution.thresholds]
+ratio = 1.5     # LAMBDA validation ratio
+ratio1 = 1.5    # Max 3D position std-dev to start narrow-lane AR (m)
+```
+
+`ratio1` gates AR activation — narrow-lane integer search only begins when
+the float solution's 3D position standard deviation drops below this value.
+This prevents premature AR attempts during initial convergence.
+
+### Measurement Error Model
+
+```toml
+[kalman_filter.measurement_error]
+code_phase_ratio_L1 = 300.0
+code_phase_ratio_L2 = 300.0
+ura_ratio = 0.1
+```
+
+- **Code/phase ratio** of 300 (vs 100 for RTK) reflects PPP's heavier
+  reliance on carrier phase measurements.
+- **URA ratio** scales satellite weighting by broadcast User Range Accuracy.
+
+---
+
+## Comparison: MADOCA-PPP vs CLAS PPP-RTK
+
+| | MADOCA-PPP | CLAS PPP-RTK |
+|:---|:-----------|:-------------|
+| **Coverage** | Global | Japan only |
+| **Signal** | QZSS L6E | QZSS L6D |
+| **Convergence** | 10-30 minutes | 1-2 minutes |
+| **Accuracy (converged)** | cm-level (PPP-AR) | cm-level |
+| **Reference frame** | ITRF2020 (IGS20) | ITRF2014 (IGS14) |
+| **ANTEX file** | `igs20.atx` | `igs14.atx` |
+| **Grid files needed** | No | Yes (Japan grid) |
+| **ISB table needed** | No | Yes |
+
+---
+
+## Troubleshooting
+
+### No Convergence (Position Jumps)
+
+1. **Wrong ANTEX** — Ensure `igs20.atx` is used (not `igs14.atx`).
+2. **Missing L6E data** — Verify both L6E files are passed as arguments.
+3. **Elevation mask too high** — 10 degrees is standard for PPP; higher
+   values reduce satellite count and slow convergence.
+
+### PPP-AR Not Fixing
+
+1. **`ratio1` too tight** — If the float solution is noisy, AR won't
+   activate. Try increasing `ratio1` to 2.0-3.0 m.
+2. **Short observation span** — PPP-AR typically needs 15-30 minutes of
+   data to converge and resolve ambiguities.
+3. **Constellation limitation** — Ensure `systems` includes all available
+   constellations for maximum satellite geometry.
+
+---
+
+## Next Steps
+
+- [Configuration Options Reference](../reference/config-options.md) — Full options list with PPP-specific modes
+- [Quick Start: CLAS PPP-RTK](quickstart-clas.md) — For Japan-specific centimeter-level positioning
+- [Configuration Guide](configuration.md) — TOML format overview

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -1,382 +1,418 @@
 # Configuration Options Reference
 
-TOML configuration options available in MRTKLIB (generated from the internal mapping table).
+TOML configuration options available in MRTKLIB.
 Options are grouped by their TOML section.
 
 !!! tip "Auto-generated"
     This page is auto-generated from the internal option mapping table.
     Run `python scripts/docs/gen_config_ref.py > docs/reference/config-options.md` to regenerate.
 
+## Mode Abbreviations
+
+| Abbreviation | Positioning Mode(s) |
+|:-------------|:--------------------|
+| **All** | All modes |
+| **SPP** | Single Point Positioning (`single`) |
+| **DGPS** | Differential GPS (`dgps`) |
+| **RTK** | `kinematic` · `static` · `movingbase` · `fixed` |
+| **PPP** | `ppp-kine` · `ppp-static` · `ppp-fixed` |
+| **PPP-RTK** | `ppp-rtk` (CLAS PPP-RTK) |
+| **SSR2OSR** | `ssr2osr` · `ssr2osr-fixed` |
+| **VRS** | `vrs-rtk` |
+| **RT** | Real-time only (`mrtk run` / `rtkrcv`) |
+| **PP** | Post-processing only (`mrtk post` / `rnx2rtkp`) |
+
 ## Positioning
 
 TOML section: `[positioning]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `mode` | enum | `0:single,1:dgps,2:kinematic,3:static,4:movingbase,5:fixed,6:ppp-kine,7:ppp-static,8:ppp-fixed,9:ppp-rtk,10:ssr2osr,11:ssr2osr-fixed,12:vrs-rtk` | `pos1-posmode` |
-| `frequency` | enum | `1:l1,2:l1+2,3:l1+2+3,4:l1+2+3+4,5:l1+2+3+4+5` | `pos1-frequency` |
-| `solution_type` | enum | `0:forward,1:backward,2:combined` | `pos1-soltype` |
-| `elevation_mask` | float | — | `pos1-elmask` |
-| `dynamics` | boolean | `true` / `false` | `pos1-dynamics` |
-| `satellite_ephemeris` | enum | `0:brdc,1:precise,2:brdc+sbas,3:brdc+ssrapc,4:brdc+ssrcom` | `pos1-sateph` |
-| `systems` | string[] | e.g. `["GPS", "Galileo", "QZSS"]` | `pos1-navsys` |
-| `excluded_sats` | string | — | `pos1-exclsats` |
-| `signals` | string[] | e.g. `["G1C", "G2W", "E1C"]` | `pos1-signals` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `mode` | enum | All | Positioning mode selector. `single` · `dgps` · `kinematic` · `static` · `movingbase` · `fixed` · `ppp-kine` · `ppp-static` · `ppp-fixed` · `ppp-rtk` · `ssr2osr` · `ssr2osr-fixed` · `vrs-rtk` |
+| `frequency` | enum | All | Number of carrier frequencies to use. CLAS PPP-RTK requires `l1+2` (nf=2). `l1` · `l1+2` · `l1+2+3` · `l1+2+3+4` · `l1+2+3+4+5` |
+| `solution_type` | enum | PP | Filter direction for post-processing. `forward` · `backward` · `combined` |
+| `elevation_mask` | float | All | Minimum satellite elevation angle (degrees). Satellites below this are excluded. |
+| `dynamics` | boolean | All | Enable receiver dynamics model (velocity/acceleration state estimation). |
+| `satellite_ephemeris` | enum | All | Satellite ephemeris source. SSR modes (`brdc+ssrapc`, `brdc+ssrcom`) are used for PPP and PPP-RTK. `brdc` · `precise` · `brdc+sbas` · `brdc+ssrapc` · `brdc+ssrcom` |
+| `systems` | string[] | All | GNSS constellations to use. Accepts a human-readable string list like `["GPS", "Galileo"]`. |
+| `excluded_sats` | string | All | Satellites to exclude. Space-separated PRN list (e.g., `G01 G02`). Prefix `+` to include only. |
+| `signals` | string[] | All | Explicit signal code list. Overrides default observation definition when set. e.g. `["G1C", "G2W", "E1C"]` |
+
+### Frequency Index Mapping
+
+The `frequency` option selects how many frequency slots to use (`l1` = 1, `l1+2` = 2, etc.).
+Each slot maps to a different signal depending on the constellation:
+
+| | L1 (idx 0) | L2 (idx 1) | L3 (idx 2) | L4 (idx 3) | L5 (idx 4) |
+|:---|:-----------|:-----------|:-----------|:-----------|:-----------|
+| **GPS** | L1 | L2 | L5 | — | — |
+| **GLONASS** | G1 | G2 | G3 | — | — |
+| **Galileo** | E1 | E5a | E5b | E6 | E5a+b |
+| **QZSS** | L1 | L5 | L2 | L6 | — |
+| **BDS** | B1I/B1C/B1A | B3I/B3A | B2I/B2b | B2a | B2a+b |
+| **SBAS** | L1 | L5 | — | — | — |
+| **NavIC** | L5 | S | — | — | — |
+
+!!! warning "CLAS PPP-RTK: Use `l1+2` (nf=2)"
+    With `l1+2`, GPS uses L1+L2 and Galileo uses E1+E5a.
+    CLAS does not provide E5b bias corrections. Using `l1+2+3` (nf=3)
+    adds the E5b slot without valid bias, causing false cycle slips on
+    Galileo and degrading fix rate from >99% to ~67%.
 
 ## Positioning — CLAS
 
 TOML section: `[positioning.clas]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `grid_selection_radius` | integer | — | `pos1-gridsel` |
-| `receiver_type` | string | — | `pos1-rectype` |
-| `position_uncertainty_x` | float | — | `pos1-rux` |
-| `position_uncertainty_y` | float | — | `pos1-ruy` |
-| `position_uncertainty_z` | float | — | `pos1-ruz` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `grid_selection_radius` | integer | PPP-RTK, VRS | CLAS grid search radius (m). Controls how far from the rover to search for grid-based tropospheric/ionospheric corrections. |
+| `receiver_type` | string | PPP-RTK, VRS | Rover receiver type identifier. Used for ISB (inter-system bias) table lookup. |
+| `position_uncertainty_x` | float | PPP-RTK, VRS | Rover approximate position X in ECEF (m). Used for initial CLAS grid search before first fix. |
+| `position_uncertainty_y` | float | PPP-RTK, VRS | Rover approximate position Y in ECEF (m). |
+| `position_uncertainty_z` | float | PPP-RTK, VRS | Rover approximate position Z in ECEF (m). |
 
 ## Positioning — SNR Mask
 
 TOML section: `[positioning.snr_mask]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `rover_enabled` | boolean | `true` / `false` | `pos1-snrmask_r` |
-| `base_enabled` | boolean | `true` / `false` | `pos1-snrmask_b` |
-| `L1` | array[int] | 9-element array (0-45 dBHz per 5°) | `pos1-snrmask_L1` |
-| `L2` | array[int] | 9-element array (0-45 dBHz per 5°) | `pos1-snrmask_L2` |
-| `L5` | array[int] | 9-element array (0-45 dBHz per 5°) | `pos1-snrmask_L5` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `rover_enabled` | boolean | All | Enable elevation-dependent SNR mask for the rover receiver. |
+| `base_enabled` | boolean | RTK | Enable elevation-dependent SNR mask for the base station. |
+| `L1` | array[int] | All | L1 SNR mask values per elevation bin (dBHz). 9-element array (0–45 dBHz per 5° elevation bin). |
+| `L2` | array[int] | All | L2 SNR mask values per elevation bin (dBHz). 9-element array (0–45 dBHz per 5° elevation bin). |
+| `L5` | array[int] | All | L5 SNR mask values per elevation bin (dBHz). 9-element array (0–45 dBHz per 5° elevation bin). |
 
 ## Positioning — Corrections
 
 TOML section: `[positioning.corrections]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `satellite_antenna` | boolean | `true` / `false` | `pos1-posopt1` |
-| `receiver_antenna` | boolean | `true` / `false` | `pos1-posopt2` |
-| `phase_windup` | enum | `0:off,1:on,2:precise` | `pos1-posopt3` |
-| `exclude_eclipse` | boolean | `true` / `false` | `pos1-posopt4` |
-| `raim_fde` | boolean | `true` / `false` | `pos1-posopt5` |
-| `iono_compensation` | enum | `0:off,1:ssr,2:meas` | `pos1-posopt6` |
-| `partial_ar` | boolean | `true` / `false` | `pos1-posopt7` |
-| `shapiro_delay` | boolean | `true` / `false` | `pos1-posopt8` |
-| `exclude_qzs_ref` | boolean | `true` / `false` | `pos1-posopt9` |
-| `no_phase_bias_adj` | boolean | `true` / `false` | `pos1-posopt10` |
-| `gps_frequency` | enum | `1:l1,2:l1+l2,3:l1+l5,4:l1+l2+l5,5:l1+l5(l2)` | `pos1-posopt11` |
-| `reserved` | boolean | `true` / `false` | `pos1-posopt12` |
-| `qzs_frequency` | enum | `1:l1,2:l1+l2,3:l1+l5,4:l1+l2+l5,5:l1+l5(l2)` | `pos1-posopt13` |
-| `tidal_correction` | enum | `0:off,1:on,2:otl,3:solid+otl-clasgrid+pole` | `pos1-tidecorr` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `satellite_antenna` | boolean | All | Apply satellite antenna phase center offset correction using ANTEX file. |
+| `receiver_antenna` | boolean | All | Apply receiver antenna phase center offset/variation correction. |
+| `phase_windup` | enum | PPP, PPP-RTK, VRS | Phase wind-up correction. `off` · `on` · `precise` |
+| `exclude_eclipse` | boolean | PPP, PPP-RTK | Exclude satellites in eclipse (yaw maneuver period) to avoid degraded orbit/clock. |
+| `raim_fde` | boolean | SPP | RAIM fault detection and exclusion for single-point positioning. |
+| `iono_compensation` | enum | PPP-RTK, VRS, SSR2OSR | Ionospheric compensation method for SSR-based processing. `off` · `ssr` · `meas` |
+| `partial_ar` | boolean | PPP-RTK, VRS | Enable partial ambiguity resolution (fix a satellite subset). |
+| `shapiro_delay` | boolean | PPP, PPP-RTK, VRS | Apply relativistic Shapiro time delay correction. |
+| `exclude_qzs_ref` | boolean | PPP-RTK, VRS | Exclude QZS satellites from reference satellite selection in DD processing. |
+| `no_phase_bias_adj` | boolean | PPP-RTK, VRS | Disable phase bias adjustment. Used when phase bias is already applied by SSR corrections. |
+| `gps_frequency` | enum | PPP-RTK, VRS | GPS frequency pair selection for CLAS processing. `l1` · `l1+l2` · `l1+l5` · `l1+l2+l5` · `l1+l5(l2)` |
+| `reserved` | boolean | — | Reserved for future use. |
+| `qzs_frequency` | enum | PPP-RTK, VRS | QZS frequency pair selection for CLAS processing. `l1` · `l1+l2` · `l1+l5` · `l1+l2+l5` · `l1+l5(l2)` |
+| `tidal_correction` | enum | PPP, PPP-RTK, VRS | Tidal displacement correction. Option `solid+otl-clasgrid+pole` uses CLAS grid-based ocean tide loading. `off` · `on` · `otl` · `solid+otl-clasgrid+pole` |
 
 ## Positioning — Atmosphere
 
 TOML section: `[positioning.atmosphere]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `ionosphere` | enum | `0:off,1:brdc,2:sbas,3:dual-freq,4:est-stec,5:ionex-tec,6:qzs-brdc,9:est-adaptive` | `pos1-ionoopt` |
-| `troposphere` | enum | `0:off,1:saas,2:sbas,3:est-ztd,4:est-ztdgrad` | `pos1-tropopt` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `ionosphere` | enum | All | Ionospheric correction model. PPP uses `dual-freq` or `est-stec`. PPP-RTK uses `est-stec` or `est-adaptive`. RTK typically uses `dual-freq`. `off` · `brdc` · `sbas` · `dual-freq` · `est-stec` · `ionex-tec` · `qzs-brdc` · `est-adaptive` |
+| `troposphere` | enum | All | Tropospheric correction model. PPP/PPP-RTK use `est-ztd` or `est-ztdgrad`. SPP/RTK typically use `saas`. `off` · `saas` · `sbas` · `est-ztd` · `est-ztdgrad` |
 
 ## Ambiguity Resolution
 
 TOML section: `[ambiguity_resolution]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `mode` | enum | `0:off,1:continuous,2:instantaneous,3:fix-and-hold` | `pos2-armode` |
-| `gps_ar` | boolean | `true` / `false` | `pos2-gpsarmode` |
-| `glonass_ar` | enum | `0:off,1:on` | `pos2-gloarmode` |
-| `bds_ar` | boolean | `true` / `false` | `pos2-bdsarmode` |
-| `qzs_ar` | boolean | `true` / `false` | `pos2-qzsarmode` |
-| `systems` | integer | — | `pos2-arsys` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `mode` | enum | RTK, PPP, PPP-RTK, VRS | Ambiguity resolution strategy. `off` · `continuous` · `instantaneous` · `fix-and-hold` |
+| `gps_ar` | boolean | RTK | GPS AR mode for GLONASS fix-and-hold second pass. |
+| `glonass_ar` | enum | RTK | GLONASS ambiguity resolution mode. `off` · `on` |
+| `bds_ar` | boolean | RTK, PPP-RTK | BDS ambiguity resolution enable/disable. |
+| `qzs_ar` | boolean | PPP-RTK, VRS | QZS ambiguity resolution mode. |
+| `systems` | integer | RTK, PPP-RTK, VRS | Constellation bitmask for AR. Limits which systems participate in integer ambiguity resolution. |
 
 ## Ambiguity Resolution — Thresholds
 
 TOML section: `[ambiguity_resolution.thresholds]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `ratio` | float | — | `pos2-arthres` |
-| `ratio1` | float | — | `pos2-arthres1` |
-| `ratio2` | float | — | `pos2-arthres2` |
-| `ratio3` | float | — | `pos2-arthres3` |
-| `ratio4` | float | — | `pos2-arthres4` |
-| `ratio5` | float | — | `pos2-arthres5` |
-| `ratio6` | float | — | `pos2-arthres6` |
-| `alpha` | enum | `0:0.1%,1:0.5%,2:1%,3:5%,4:10%,5:20%` | `pos2-aralpha` |
-| `elevation_mask` | float | — | `pos2-arelmask` |
-| `hold_elevation` | float | — | `pos2-elmaskhold` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `ratio` | float | RTK, PPP, PPP-RTK, VRS | LAMBDA ratio test threshold (2nd-best / best). Typical value: 3.0. |
+| `ratio1` | float | RTK, PPP, PPP-RTK | Secondary AR threshold. In MADOCA-PPP: max 3D position std-dev to start narrow-lane AR. |
+| `ratio2` | float | RTK, PPP-RTK | Additional AR threshold parameter. |
+| `ratio3` | float | RTK, PPP-RTK | Additional AR threshold parameter. |
+| `ratio4` | float | RTK | Additional AR threshold parameter. |
+| `ratio5` | float | PPP-RTK | Chi-square threshold for hold validation. |
+| `ratio6` | float | PPP-RTK | Chi-square threshold for fix validation. |
+| `alpha` | enum | PPP-RTK, VRS | AR significance level (ILS success rate). `0.1%` · `0.5%` · `1%` · `5%` · `10%` · `20%` |
+| `elevation_mask` | float | RTK, PPP-RTK, VRS | Minimum satellite elevation for AR participation (degrees). |
+| `hold_elevation` | float | RTK, PPP-RTK, VRS | Minimum satellite elevation for fix-and-hold constraint application (degrees). |
 
 ## Ambiguity Resolution — Counters
 
 TOML section: `[ambiguity_resolution.counters]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `lock_count` | integer | — | `pos2-arlockcnt` |
-| `min_fix` | integer | — | `pos2-arminfix` |
-| `max_iterations` | integer | — | `pos2-armaxiter` |
-| `out_count` | integer | — | `pos2-aroutcnt` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `lock_count` | integer | RTK, PPP-RTK, VRS | Minimum continuous lock count before a satellite participates in AR. |
+| `min_fix` | integer | RTK, PPP-RTK | Minimum fix epochs before applying fix-and-hold constraint. |
+| `max_iterations` | integer | RTK, PPP-RTK | Maximum LAMBDA search iterations per epoch. |
+| `out_count` | integer | RTK, PPP-RTK, VRS | Reset ambiguity after this many continuous outage epochs. |
 
 ## Ambiguity Resolution — Partial AR
 
 TOML section: `[ambiguity_resolution.partial_ar]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `min_ambiguities` | integer | — | `pos2-arminamb` |
-| `max_excluded_sats` | integer | — | `pos2-armaxdelsat` |
-| `min_fix_sats` | integer | — | `pos2-arminfixsats` |
-| `min_drop_sats` | integer | — | `pos2-armindropsats` |
-| `min_hold_sats` | integer | — | `pos2-arminholdsats` |
-| `ar_filter` | boolean | `true` / `false` | `pos2-arfilter` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `min_ambiguities` | integer | PPP-RTK, VRS | Minimum number of ambiguities required for partial AR attempt. |
+| `max_excluded_sats` | integer | PPP-RTK, VRS | Maximum satellites to exclude during partial AR satellite rotation. |
+| `min_fix_sats` | integer | RTK, PPP-RTK | Minimum DD pairs required for a valid fix. 0 = disabled. |
+| `min_drop_sats` | integer | RTK | Minimum DD pairs before excluding the weakest satellite in partial AR. 0 = disabled. |
+| `min_hold_sats` | integer | RTK | Minimum DD pairs for fix-and-hold mode activation. 0 = no minimum. |
+| `ar_filter` | boolean | RTK, PPP-RTK | Exclude newly-locked satellites that degrade the AR ratio. |
 
 ## Ambiguity Resolution — Hold
 
 TOML section: `[ambiguity_resolution.hold]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `variance` | float | — | `pos2-varholdamb` |
-| `gain` | float | — | `pos2-gainholdamb` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `variance` | float | PPP-RTK, VRS | Variance of held ambiguity pseudo-observation (cyc²). Controls how tightly held ambiguities constrain the filter. |
+| `gain` | float | RTK | Gain factor for fractional GLONASS/SBAS inter-channel bias update in fix-and-hold. |
 
 ## Rejection Criteria
 
 TOML section: `[rejection]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `innovation` | float | — | `pos2-rejionno` |
-| `l1_l2_residual` | float | — | `pos2-rejionno1` |
-| `dispersive` | float | — | `pos2-rejionno2` |
-| `non_dispersive` | float | — | `pos2-rejionno3` |
-| `hold_chi_square` | float | — | `pos2-rejionno4` |
-| `fix_chi_square` | float | — | `pos2-rejionno5` |
-| `gdop` | float | — | `pos2-rejgdop` |
-| `pseudorange_diff` | float | — | `pos2-rejdiffpse` |
-| `position_error_count` | integer | — | `pos2-poserrcnt` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `innovation` | float | RTK, PPP | Innovation (pre-fit residual) threshold (m). Observations exceeding this are rejected. |
+| `l1_l2_residual` | float | PPP-RTK, VRS | L1/L2 residual rejection threshold (σ). |
+| `dispersive` | float | PPP-RTK, VRS | Dispersive (ionospheric) residual rejection threshold (σ). |
+| `non_dispersive` | float | PPP-RTK, VRS | Non-dispersive (geometric) residual rejection threshold (σ). |
+| `hold_chi_square` | float | PPP-RTK, VRS | Chi-square threshold for hold-mode outlier detection. |
+| `fix_chi_square` | float | PPP-RTK, VRS | Chi-square threshold for fix-mode outlier detection. |
+| `gdop` | float | All | Maximum GDOP for valid solution output. |
+| `pseudorange_diff` | float | VRS | Pseudorange consistency check threshold (m). Rejects satellites with large code-phase disagreement. |
+| `position_error_count` | integer | VRS | Number of consecutive position error epochs before filter reset. |
 
 ## Slip Detection
 
 TOML section: `[slip_detection]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `threshold` | float | — | `pos2-slipthres` |
-| `doppler` | float | — | `pos2-thresdop` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `threshold` | float | RTK, PPP, PPP-RTK, VRS | Geometry-free (LG) cycle slip detection threshold (m). |
+| `doppler` | float | RTK, PPP, PPP-RTK | Doppler-phase rate cycle slip detection threshold (cyc/s). 0 = disabled. |
 
 ## Kalman Filter
 
 TOML section: `[kalman_filter]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `iterations` | integer | — | `pos2-niter` |
-| `sync_solution` | boolean | `true` / `false` | `pos2-syncsol` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `iterations` | integer | RTK, PPP, PPP-RTK, VRS | Number of measurement update iterations per epoch. More iterations improve linearization accuracy. |
+| `sync_solution` | boolean | RT | Synchronize solution output with observation time in real-time mode. |
 
 ## Kalman Filter — Measurement Error
 
 TOML section: `[kalman_filter.measurement_error]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `code_phase_ratio_L1` | float | — | `stats-eratio1` |
-| `code_phase_ratio_L2` | float | — | `stats-eratio2` |
-| `code_phase_ratio_L5` | float | — | `stats-eratio3` |
-| `phase` | float | — | `stats-errphase` |
-| `phase_elevation` | float | — | `stats-errphaseel` |
-| `phase_baseline` | float | — | `stats-errphasebl` |
-| `doppler` | float | — | `stats-errdoppler` |
-| `ura_ratio` | float | — | `stats-uraratio` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `code_phase_ratio_L1` | float | All | Code/phase measurement error ratio for L1. Code error = phase error × ratio. Typical: 100. |
+| `code_phase_ratio_L2` | float | All | Code/phase measurement error ratio for L2. |
+| `code_phase_ratio_L5` | float | All | Code/phase measurement error ratio for L5. |
+| `phase` | float | All | Base carrier phase measurement error (m). Used in elevation-dependent weighting: error = phase + phase_elevation / sin(el). |
+| `phase_elevation` | float | All | Elevation-dependent carrier phase error coefficient (m). |
+| `phase_baseline` | float | RTK | Baseline-length-dependent phase error (m/10km). Proportional to rover–base distance. |
+| `doppler` | float | All | Doppler measurement error (Hz). |
+| `ura_ratio` | float | PPP | User Range Accuracy scaling ratio. Adjusts satellite-specific weighting based on broadcast URA. |
 
 ## Kalman Filter — Initial Std. Deviation
 
 TOML section: `[kalman_filter.initial_std]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `bias` | float | — | `stats-stdbias` |
-| `ionosphere` | float | — | `stats-stdiono` |
-| `troposphere` | float | — | `stats-stdtrop` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `bias` | float | RTK, PPP, PPP-RTK, VRS | Initial standard deviation for carrier phase bias states (m). |
+| `ionosphere` | float | PPP-RTK, VRS | Initial standard deviation for ionospheric delay states (m). |
+| `troposphere` | float | PPP, PPP-RTK, VRS | Initial standard deviation for tropospheric delay states (m). |
 
 ## Kalman Filter — Process Noise
 
 TOML section: `[kalman_filter.process_noise]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `bias` | float | — | `stats-prnbias` |
-| `ionosphere` | float | — | `stats-prniono` |
-| `iono_max` | float | — | `stats-prnionomax` |
-| `troposphere` | float | — | `stats-prntrop` |
-| `accel_h` | float | — | `stats-prnaccelh` |
-| `accel_v` | float | — | `stats-prnaccelv` |
-| `position_h` | float | — | `stats-prnposith` |
-| `position_v` | float | — | `stats-prnpositv` |
-| `position` | float | — | `stats-prnpos` |
-| `ifb` | float | — | `stats-prnifb` |
-| `iono_time_const` | float | — | `stats-tconstiono` |
-| `clock_stability` | float | — | `stats-clkstab` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `bias` | float | RTK, PPP, PPP-RTK, VRS | Process noise for carrier phase bias states (m/√s). |
+| `ionosphere` | float | PPP-RTK, VRS | Process noise for ionospheric delay states (m/√s). |
+| `iono_max` | float | PPP-RTK, VRS | Maximum ionospheric process noise clamp (m). Prevents excessive iono state growth. |
+| `troposphere` | float | PPP, PPP-RTK, VRS | Process noise for tropospheric delay states (m/√s). |
+| `accel_h` | float | All | Horizontal acceleration process noise (m/s²). Active when `dynamics = true`. |
+| `accel_v` | float | All | Vertical acceleration process noise (m/s²). Active when `dynamics = true`. |
+| `position_h` | float | PPP-RTK, VRS | Horizontal position process noise (m). |
+| `position_v` | float | PPP-RTK, VRS | Vertical position process noise (m). |
+| `position` | float | All | General position process noise (m). Fallback when h/v not specified. |
+| `ifb` | float | PPP | Inter-frequency bias process noise (m). For multi-frequency PPP bias estimation. |
+| `iono_time_const` | float | PPP-RTK, VRS | Ionospheric time constant (s). Controls iono state temporal correlation in the adaptive filter. |
+| `clock_stability` | float | PPP | Receiver clock stability (s/s). Used in PPP clock state prediction. |
 
 ## Adaptive Filter
 
 TOML section: `[adaptive_filter]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `enabled` | boolean | `true` / `false` | `pos2-prnadpt` |
-| `iono_forgetting` | float | — | `pos2-forgetion` |
-| `iono_gain` | float | — | `pos2-afgainion` |
-| `pva_forgetting` | float | — | `pos2-forgetpva` |
-| `pva_gain` | float | — | `pos2-afgainpva` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `enabled` | boolean | PPP-RTK, VRS | Enable adaptive Kalman filter process noise scaling. |
+| `iono_forgetting` | float | PPP-RTK, VRS | Forgetting factor for ionospheric state (0–1). Lower = faster adaptation. |
+| `iono_gain` | float | PPP-RTK, VRS | Adaptive gain for ionospheric process noise adjustment. |
+| `pva_forgetting` | float | PPP-RTK, VRS | Forgetting factor for position/velocity/acceleration states (0–1). |
+| `pva_gain` | float | PPP-RTK, VRS | Adaptive gain for PVA process noise adjustment. |
 
 ## Signal Selection
 
 TOML section: `[signals]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `gps` | enum | `0:L1/L2,1:L1/L5,2:L1/L2/L5` | `pos2-siggps` |
-| `qzs` | enum | `0:L1/L5,1:L1/L2,2:L1/L5/L2` | `pos2-sigqzs` |
-| `galileo` | enum | `0:E1/E5a,1:E1/E5b,2:E1/E6,3:E1/E5a/E5b/E6,4:E1/E5a/E6/E5b` | `pos2-siggal` |
-| `bds2` | enum | `0:B1I/B3I,1:B1I/B2I,2:B1I/B3I/B2I` | `pos2-sigbds2` |
-| `bds3` | enum | `0:B1I/B3I,1:B1I/B2a,2:B1I/B3I/B2a` | `pos2-sigbds3` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `gps` | enum | PPP, PPP-RTK | GPS frequency pair selection for PPP/PPP-RTK processing. `L1/L2` · `L1/L5` · `L1/L2/L5` |
+| `qzs` | enum | PPP, PPP-RTK | QZS frequency pair selection. `L1/L5` · `L1/L2` · `L1/L5/L2` |
+| `galileo` | enum | PPP, PPP-RTK | Galileo frequency pair selection. `E1/E5a` · `E1/E5b` · `E1/E6` · `E1/E5a/E5b/E6` · `E1/E5a/E6/E5b` |
+| `bds2` | enum | PPP, PPP-RTK | BDS-2 frequency pair selection. `B1I/B3I` · `B1I/B2I` · `B1I/B3I/B2I` |
+| `bds3` | enum | PPP, PPP-RTK | BDS-3 frequency pair selection. `B1I/B3I` · `B1I/B2a` · `B1I/B3I/B2a` |
 
 ## Receiver
 
 TOML section: `[receiver]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `iono_correction` | boolean | `true` / `false` | `pos2-ionocorr` |
-| `ignore_chi_error` | boolean | `true` / `false` | `pos2-ign_chierr` |
-| `bds2_bias` | boolean | `true` / `false` | `pos2-bds2bias` |
-| `ppp_sat_clock_bias` | integer | — | `pos2-pppsatcb` |
-| `ppp_sat_phase_bias` | integer | — | `pos2-pppsatpb` |
-| `uncorr_bias` | integer | — | `pos2-uncorrbias` |
-| `max_bias_dt` | integer | — | `pos2-maxbiasdt` |
-| `satellite_mode` | integer | — | `pos2-sattmode` |
-| `phase_shift` | enum | `0:off,1:table` | `pos2-phasshft` |
-| `isb` | boolean | `true` / `false` | `pos2-isb` |
-| `reference_type` | string | — | `pos2-rectype` |
-| `max_age` | float | — | `pos2-maxage` |
-| `baseline_length` | float | — | `pos2-baselen` |
-| `baseline_sigma` | float | — | `pos2-basesig` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `iono_correction` | boolean | PPP | Enable ionospheric correction in MADOCA-PPP processing. |
+| `ignore_chi_error` | boolean | SPP | Ignore chi-square test errors in SPP solution validation. |
+| `bds2_bias` | boolean | PPP | Enable BDS-2 code bias correction (satellite-dependent group delay). |
+| `ppp_sat_clock_bias` | integer | PPP | PPP satellite code bias source selection. |
+| `ppp_sat_phase_bias` | integer | PPP | PPP satellite phase bias source selection. |
+| `uncorr_bias` | integer | PPP | Uncorrelated bias parameter for PPP processing. |
+| `max_bias_dt` | integer | PPP | Maximum age of bias correction data (s) before invalidation. |
+| `satellite_mode` | integer | PPP | Satellite processing mode selector. |
+| `phase_shift` | enum | PPP-RTK, VRS | Phase cycle shift correction. Corrects quarter-cycle shifts between systems. `off` · `table` |
+| `isb` | boolean | PPP-RTK, VRS | Inter-system bias estimation mode. |
+| `reference_type` | string | PPP-RTK, VRS | Reference station receiver type for ISB table lookup. |
+| `max_age` | float | RTK, PPP-RTK | Maximum age of differential correction (s). |
+| `baseline_length` | float | RTK | Baseline length constraint (m). 0 = no constraint. |
+| `baseline_sigma` | float | RTK | Standard deviation of baseline length constraint (m). |
 
 ## Antenna — Rover
 
 TOML section: `[antenna.rover]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `position_type` | enum | `0:llh,1:xyz,2:single,3:posfile,4:rinexhead,5:rtcm,6:raw` | `ant1-postype` |
-| `position_1` | float | — | `ant1-pos1` |
-| `position_2` | float | — | `ant1-pos2` |
-| `position_3` | float | — | `ant1-pos3` |
-| `type` | string | — | `ant1-anttype` |
-| `delta_e` | float | — | `ant1-antdele` |
-| `delta_n` | float | — | `ant1-antdeln` |
-| `delta_u` | float | — | `ant1-antdelu` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `position_type` | enum | All | Rover position input type. `llh` · `xyz` · `single` · `posfile` · `rinexhead` · `rtcm` · `raw` |
+| `position_1` | float | All | Rover position coordinate 1 (latitude or X, depending on `position_type`). |
+| `position_2` | float | All | Rover position coordinate 2 (longitude or Y). |
+| `position_3` | float | All | Rover position coordinate 3 (height or Z). |
+| `type` | string | All | Rover antenna type (must match ANTEX file entry). `*` = use RINEX header. |
+| `delta_e` | float | All | Rover antenna delta East offset (m). |
+| `delta_n` | float | All | Rover antenna delta North offset (m). |
+| `delta_u` | float | All | Rover antenna delta Up offset (m). |
 
 ## Antenna — Base
 
 TOML section: `[antenna.base]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `position_type` | enum | `0:llh,1:xyz,2:single,3:posfile,4:rinexhead,5:rtcm,6:raw` | `ant2-postype` |
-| `position_1` | float | — | `ant2-pos1` |
-| `position_2` | float | — | `ant2-pos2` |
-| `position_3` | float | — | `ant2-pos3` |
-| `type` | string | — | `ant2-anttype` |
-| `delta_e` | float | — | `ant2-antdele` |
-| `delta_n` | float | — | `ant2-antdeln` |
-| `delta_u` | float | — | `ant2-antdelu` |
-| `max_average_epochs` | integer | — | `ant2-maxaveep` |
-| `init_reset` | boolean | `true` / `false` | `ant2-initrst` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `position_type` | enum | RTK, VRS | Base station position input type. `llh` · `xyz` · `single` · `posfile` · `rinexhead` · `rtcm` · `raw` |
+| `position_1` | float | RTK, VRS | Base position coordinate 1. |
+| `position_2` | float | RTK, VRS | Base position coordinate 2. |
+| `position_3` | float | RTK, VRS | Base position coordinate 3. |
+| `type` | string | RTK, VRS | Base antenna type. |
+| `delta_e` | float | RTK, VRS | Base antenna delta East offset (m). |
+| `delta_n` | float | RTK, VRS | Base antenna delta North offset (m). |
+| `delta_u` | float | RTK, VRS | Base antenna delta Up offset (m). |
+| `max_average_epochs` | integer | RT | Maximum epochs for base position averaging in real-time mode. |
+| `init_reset` | boolean | RT | Reset base position averaging on restart. |
 
 ## Output
 
 TOML section: `[output]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `format` | enum | `0:llh,1:xyz,2:enu,3:nmea` | `out-solformat` |
-| `header` | boolean | `true` / `false` | `out-outhead` |
-| `options` | boolean | `true` / `false` | `out-outopt` |
-| `velocity` | boolean | `true` / `false` | `out-outvel` |
-| `time_system` | enum | `0:gpst,1:utc,2:jst` | `out-timesys` |
-| `time_format` | enum | `0:tow,1:hms` | `out-timeform` |
-| `time_decimals` | integer | — | `out-timendec` |
-| `coordinate_format` | enum | `0:deg,1:dms` | `out-degform` |
-| `field_separator` | string | — | `out-fieldsep` |
-| `single_output` | boolean | `true` / `false` | `out-outsingle` |
-| `max_solution_std` | float | — | `out-maxsolstd` |
-| `height_type` | enum | `0:ellipsoidal,1:geodetic` | `out-height` |
-| `geoid_model` | enum | `0:internal,1:egm96,2:egm08_2.5,3:egm08_1,4:gsi2000` | `out-geoid` |
-| `static_solution` | enum | `0:all,1:single` | `out-solstatic` |
-| `nmea_interval_1` | float | — | `out-nmeaintv1` |
-| `nmea_interval_2` | float | — | `out-nmeaintv2` |
-| `solution_status` | enum | `0:off,1:state,2:residual` | `out-outstat` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `format` | enum | All | Solution output format. `llh` · `xyz` · `enu` · `nmea` |
+| `header` | boolean | All | Output header line with option summary. |
+| `options` | boolean | All | Output processing options in header. |
+| `velocity` | boolean | All | Include velocity in solution output. |
+| `time_system` | enum | All | Time system for output. `gpst` · `utc` · `jst` |
+| `time_format` | enum | All | Time format. `tow` · `hms` |
+| `time_decimals` | integer | All | Number of decimal digits for time output. |
+| `coordinate_format` | enum | All | Coordinate format. `deg` · `dms` |
+| `field_separator` | string | All | Field separator character for output. |
+| `single_output` | boolean | All | Output SPP solution alongside fixed solution. |
+| `max_solution_std` | float | All | Maximum solution standard deviation for output (m). Solutions exceeding this are suppressed. |
+| `height_type` | enum | All | Height output type. `ellipsoidal` · `geodetic` |
+| `geoid_model` | enum | All | Geoid model for geodetic height conversion. `internal` · `egm96` · `egm08_2.5` · `egm08_1` · `gsi2000` |
+| `static_solution` | enum | PP | Static mode output control. `all` · `single` |
+| `nmea_interval_1` | float | All | NMEA GGA/RMC output interval (s). |
+| `nmea_interval_2` | float | All | NMEA GSA/GSV output interval (s). |
+| `solution_status` | enum | All | Solution status output level. `off` · `state` · `residual` |
 
 ## Files
 
 TOML section: `[files]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `satellite_atx` | string | — | `file-satantfile` |
-| `receiver_atx` | string | — | `file-rcvantfile` |
-| `station_pos` | string | — | `file-staposfile` |
-| `geoid` | string | — | `file-geoidfile` |
-| `ionosphere` | string | — | `file-ionofile` |
-| `dcb` | string | — | `file-dcbfile` |
-| `eop` | string | — | `file-eopfile` |
-| `ocean_loading` | string | — | `file-blqfile` |
-| `elevation_mask_file` | string | — | `file-elmaskfile` |
-| `temp_dir` | string | — | `file-tempdir` |
-| `geexe` | string | — | `file-geexefile` |
-| `solution_stat` | string | — | `file-solstatfile` |
-| `trace` | string | — | `file-tracefile` |
-| `fcb` | string | — | `file-fcbfile` |
-| `bias_sinex` | string | — | `file-biafile` |
-| `cssr_grid` | string | — | `file-cssrgridfile` |
-| `isb_table` | string | — | `file-isbfile` |
-| `phase_cycle` | string | — | `file-phacycfile` |
-| `cmd_file_1` | string | — | `file-cmdfile1` |
-| `cmd_file_2` | string | — | `file-cmdfile2` |
-| `cmd_file_3` | string | — | `file-cmdfile3` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `satellite_atx` | string | All | Satellite antenna ANTEX file. Required for satellite antenna PCV correction. |
+| `receiver_atx` | string | All | Receiver antenna ANTEX file. Required for receiver antenna PCV correction. |
+| `station_pos` | string | All | Station position file for fixed/known positions. |
+| `geoid` | string | All | Geoid data file for geodetic height conversion. |
+| `ionosphere` | string | All | IONEX ionosphere map file. Used when `ionosphere = ionex-tec`. |
+| `dcb` | string | PPP | Differential code bias file. |
+| `eop` | string | PPP, PPP-RTK | Earth orientation parameter file for precise coordinate frame. |
+| `ocean_loading` | string | PPP, PPP-RTK | BLQ ocean tide loading file. Required when `tidal_correction` includes OTL. |
+| `elevation_mask_file` | string | All | Azimuth-dependent elevation mask file. |
+| `temp_dir` | string | All | Temporary directory for intermediate files. |
+| `geexe` | string | All | Google Earth executable path (legacy GUI feature). |
+| `solution_stat` | string | All | Solution statistics output file path. |
+| `trace` | string | All | Debug trace output file path. |
+| `fcb` | string | PPP | Fractional cycle bias file for PPP-AR. |
+| `bias_sinex` | string | PPP | Bias SINEX file for PPP satellite bias correction. |
+| `cssr_grid` | string | PPP-RTK, VRS | CLAS CSSR grid definition file. Required for CLAS grid-based corrections. |
+| `isb_table` | string | PPP-RTK, VRS | Inter-system bias correction table file. |
+| `phase_cycle` | string | PPP-RTK, VRS | Phase cycle shift correction table file. |
+| `cmd_file_1` | string | RT | Receiver command file for input stream 1. |
+| `cmd_file_2` | string | RT | Receiver command file for input stream 2. |
+| `cmd_file_3` | string | RT | Receiver command file for input stream 3. |
 
 ## Server (rtkrcv)
 
 TOML section: `[server]`
 
-| TOML Key | Type | Values | Legacy Key |
-|----------|------|--------|------------|
-| `cycle_ms` | integer | — | `misc-svrcycle` |
-| `timeout_ms` | integer | — | `misc-timeout` |
-| `reconnect_ms` | integer | — | `misc-reconnect` |
-| `nmea_cycle_ms` | integer | — | `misc-nmeacycle` |
-| `buffer_size` | integer | — | `misc-buffsize` |
-| `nav_msg_select` | string | — | `misc-navmsgsel` |
-| `proxy` | string | — | `misc-proxyaddr` |
-| `swap_margin` | integer | — | `misc-fswapmargin` |
-| `time_interpolation` | boolean | `true` / `false` | `misc-timeinterp` |
-| `sbas_satellite` | string | — | `misc-sbasatsel` |
-| `max_obs_loss` | float | — | `misc-maxobsloss` |
-| `float_count` | integer | — | `misc-floatcnt` |
-| `rinex_option_1` | string | — | `misc-rnxopt1` |
-| `rinex_option_2` | string | — | `misc-rnxopt2` |
-| `ppp_option` | string | — | `misc-pppopt` |
-| `rtcm_option` | string | — | `misc-rtcmopt` |
-| `l6_margin` | integer | — | `misc-l6mrg` |
-| `regularly` | integer | — | `misc-regularly` |
-| `start_cmd` | string | — | `misc-startcmd` |
-| `stop_cmd` | string | — | `misc-stopcmd` |
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `cycle_ms` | integer | RT | Server main loop cycle interval (ms). Controls processing rate. |
+| `timeout_ms` | integer | RT | Stream read timeout (ms). After timeout, stream is considered disconnected. |
+| `reconnect_ms` | integer | RT | Stream reconnection interval (ms) after disconnect. |
+| `nmea_cycle_ms` | integer | RT | NMEA request transmission cycle (ms) for NTRIP caster position updates. |
+| `buffer_size` | integer | RT | Stream input buffer size (bytes). |
+| `nav_msg_select` | string | RT | Navigation message type selection for multi-source environments. |
+| `proxy` | string | RT | HTTP proxy address for NTRIP connections. |
+| `swap_margin` | integer | RT | File swap margin (s) for continuous logging across file boundaries. |
+| `time_interpolation` | boolean | RT | Enable time interpolation between observation epochs. |
+| `sbas_satellite` | string | RT | SBAS satellite selection. |
+| `max_obs_loss` | float | RT | Maximum observation gap duration before filter reset (s). |
+| `float_count` | integer | RT | Number of float epochs before triggering filter reset. |
+| `rinex_option_1` | string | All | RINEX conversion option string for rover stream. |
+| `rinex_option_2` | string | All | RINEX conversion option string for base stream. |
+| `ppp_option` | string | PPP | PPP processing option string (passed to PPP engine). |
+| `rtcm_option` | string | RT | RTCM decoder option string. |
+| `l6_margin` | integer | RT | L6 message margin (epochs) for CLAS L6 real-time synchronization. |
+| `regularly` | integer | VRS | Regular filter reset interval (s). 0 = disabled. |
+| `start_cmd` | string | RT | Shell command executed on server start. |
+| `stop_cmd` | string | RT | Shell command executed on server stop. |
 
-## `[streams]`
+## Streams
 
-**Stream Configuration (rtkrcv only)**
+TOML section: `[streams]` — **Real-time only** (`mrtk run` / `rtkrcv`)
 
 Stream configuration uses a hierarchical structure:
 
@@ -400,12 +436,12 @@ type = "file"
 path = "rover.log"
 ```
 
-| Key | Description |
-|-----|-------------|
-| `type` | Stream type: `serial`, `file`, `tcpsvr`, `tcpcli`, `ntrip`, `off` |
-| `path` | Stream path (device, file, URL) |
-| `format` | Data format: `rtcm3`, `ubx`, `sbf`, `binex`, `rinex`, `clas`, `l6e`, etc. |
-| `nmeareq` | Send NMEA request to stream (boolean) |
-| `nmealat` | NMEA request latitude (float) |
-| `nmealon` | NMEA request longitude (float) |
+| Key | Type | Description |
+|:----|:-----|:------------|
+| `type` | string | Stream type: `serial` · `file` · `tcpsvr` · `tcpcli` · `ntrip` · `off` |
+| `path` | string | Stream path (serial device, file path, or URL) |
+| `format` | string | Data format: `rtcm3` · `ubx` · `sbf` · `binex` · `rinex` · `clas` · `l6e` |
+| `nmeareq` | boolean | Send NMEA position request to stream |
+| `nmealat` | float | NMEA request latitude (degrees) |
+| `nmealon` | float | NMEA request longitude (degrees) |
 

--- a/docs/reference/rtkrcv-clas-realtime.md
+++ b/docs/reference/rtkrcv-clas-realtime.md
@@ -61,7 +61,7 @@ Use `conf/claslib/rtkrcv.toml` (single-channel) or `rtkrcv_2ch.toml`
 ```toml
 [positioning]
 mode                = "ppp-rtk"
-frequency           = "l1+2"       # CLAS does not provide E5a bias; use nf=2
+frequency           = "l1+2"       # CLAS does not provide E5b bias; use nf=2
 satellite_ephemeris = "brdc+ssrapc"
 constellations      = 25           # GPS + Galileo + QZSS
 
@@ -93,9 +93,9 @@ phase_cycle   = "./tests/data/claslib/l2csft.tbl"
 ```
 
 > **Important:** Use `frequency = "l1+2"` (nf=2) for CLAS.  CLAS does not
-> provide Galileo E5a bias corrections; using `"l1+2+3"` (nf=3) causes
-> false L1-L5 geometry-free cycle slip detection that destroys Galileo
-> ambiguities and severely degrades AR fix rate.
+> provide Galileo E5b bias corrections; using `"l1+2+3"` (nf=3) adds the
+> E5b slot without valid bias, causing false geometry-free cycle slip
+> detection that destroys Galileo ambiguities and severely degrades AR fix rate.
 
 ### 3. Run
 
@@ -257,7 +257,7 @@ conflicts with the MADOCA `rtkrcv_rt` test.
 | TOML Key | Value | Description |
 |----------|-------|-------------|
 | `positioning.mode` | `"ppp-rtk"` | CLAS PPP-RTK positioning mode |
-| `positioning.frequency` | `"l1+2"` | **Must be nf=2** (CLAS has no E5a bias) |
+| `positioning.frequency` | `"l1+2"` | **Must be nf=2** (CLAS has no E5b bias) |
 | `positioning.satellite_ephemeris` | `"brdc+ssrapc"` | Broadcast + SSR (antenna phase centre) |
 | `positioning.constellations` | `25` | GPS(1) + Galileo(8) + QZSS(16) |
 | `positioning.dynamics` | `true` | Enable kinematic dynamics model |
@@ -291,9 +291,9 @@ conflicts with the MADOCA `rtkrcv_rt` test.
 levels, with frequent ambiguity resets on Galileo satellites.
 
 **Cause:** `frequency = "l1+2+3"` (nf=3) in the config.  CLAS does not
-provide Galileo E5a (L5) phase bias corrections.  With nf=3, the L1-L5
-geometry-free cycle slip detector (`detslp_gf()` in `mrtk_ppp_rtk.c`)
-fires false slips at every epoch because `pbias[2]` remains invalid.
+provide Galileo E5b phase bias corrections.  With nf=3, the E5b frequency
+slot has no valid bias, causing the geometry-free cycle slip detector
+(`detslp_gf()` in `mrtk_ppp_rtk.c`) to fire false slips at every epoch.
 This destroys Galileo ambiguities and prevents AR convergence.
 
 **Fix:** Set `frequency = "l1+2"` (nf=2).  This skips the L1-L5 GF

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,8 @@ nav:
   - User Guide:
     - CLI Reference: guide/cli.md
     - Configuration (TOML): guide/configuration.md
+    - "Quick Start: CLAS PPP-RTK": guide/quickstart-clas.md
+    - "Quick Start: MADOCA-PPP": guide/quickstart-madoca-ppp.md
   - Reference:
     - Configuration Options: reference/config-options.md
     - API Reference (Doxygen): reference/api.md

--- a/scripts/docs/gen_config_ref.py
+++ b/scripts/docs/gen_config_ref.py
@@ -22,6 +22,276 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
 from conf2toml import MAPPING, _KEY_ENUM, _ENUM_STRINGS  # noqa: E402
 
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# Option metadata: description and applicable positioning modes
+#
+# Modes abbreviations:
+#   All      — All positioning modes
+#   SPP      — Single Point Positioning
+#   DGPS     — Differential GPS
+#   RTK      — Kinematic / Static / Moving-base / Fixed
+#   PPP      — PPP-Kinematic / PPP-Static / PPP-Fixed
+#   PPP-RTK  — CLAS PPP-RTK
+#   SSR2OSR  — SSR to OSR conversion
+#   VRS      — VRS-RTK
+#   RT       — Real-time only (rtkrcv / mrtk run)
+#   PP       — Post-processing only (rnx2rtkp / mrtk post)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# {legacy_key: (modes, description)}
+# Description for enum types should NOT include the values — they are appended
+# automatically from _ENUM_STRINGS.
+_OPTION_META: dict[str, tuple[str, str]] = {
+    # ── positioning ──────────────────────────────────────────────────────────
+    "pos1-posmode":    ("All", "Positioning mode selector."),
+    "pos1-frequency":  ("All", "Number of carrier frequencies to use. CLAS PPP-RTK requires `l1+2` (nf=2)."),
+    "pos1-soltype":    ("PP", "Filter direction for post-processing."),
+    "pos1-elmask":     ("All", "Minimum satellite elevation angle (degrees). Satellites below this are excluded."),
+    "pos1-dynamics":   ("All", "Enable receiver dynamics model (velocity/acceleration state estimation)."),
+    "pos1-sateph":     ("All", "Satellite ephemeris source. SSR modes (`brdc+ssrapc`, `brdc+ssrcom`) are used for PPP and PPP-RTK."),
+    "pos1-navsys":     ("All", "GNSS constellations to use. Accepts a human-readable string list like `[\"GPS\", \"Galileo\"]`."),
+    "pos1-exclsats":   ("All", "Satellites to exclude. Space-separated PRN list (e.g., `G01 G02`). Prefix `+` to include only."),
+    "pos1-signals":    ("All", "Explicit signal code list. Overrides default observation definition when set."),
+
+    # ── positioning.clas ─────────────────────────────────────────────────────
+    "pos1-gridsel":    ("PPP-RTK, VRS", "CLAS grid search radius (m). Controls how far from the rover to search for grid-based tropospheric/ionospheric corrections."),
+    "pos1-rectype":    ("PPP-RTK, VRS", "Rover receiver type identifier. Used for ISB (inter-system bias) table lookup."),
+    "pos1-rux":        ("PPP-RTK, VRS", "Rover approximate position X in ECEF (m). Used for initial CLAS grid search before first fix."),
+    "pos1-ruy":        ("PPP-RTK, VRS", "Rover approximate position Y in ECEF (m)."),
+    "pos1-ruz":        ("PPP-RTK, VRS", "Rover approximate position Z in ECEF (m)."),
+
+    # ── positioning.snr_mask ─────────────────────────────────────────────────
+    "pos1-snrmask_r":  ("All", "Enable elevation-dependent SNR mask for the rover receiver."),
+    "pos1-snrmask_b":  ("RTK", "Enable elevation-dependent SNR mask for the base station."),
+    "pos1-snrmask_L1": ("All", "L1 SNR mask values per elevation bin (dBHz)."),
+    "pos1-snrmask_L2": ("All", "L2 SNR mask values per elevation bin (dBHz)."),
+    "pos1-snrmask_L5": ("All", "L5 SNR mask values per elevation bin (dBHz)."),
+
+    # ── positioning.corrections ──────────────────────────────────────────────
+    "pos1-posopt1":    ("All", "Apply satellite antenna phase center offset correction using ANTEX file."),
+    "pos1-posopt2":    ("All", "Apply receiver antenna phase center offset/variation correction."),
+    "pos1-posopt3":    ("PPP, PPP-RTK, VRS", "Phase wind-up correction."),
+    "pos1-posopt4":    ("PPP, PPP-RTK", "Exclude satellites in eclipse (yaw maneuver period) to avoid degraded orbit/clock."),
+    "pos1-posopt5":    ("SPP", "RAIM fault detection and exclusion for single-point positioning."),
+    "pos1-posopt6":    ("PPP-RTK, VRS, SSR2OSR", "Ionospheric compensation method for SSR-based processing."),
+    "pos1-posopt7":    ("PPP-RTK, VRS", "Enable partial ambiguity resolution (fix a satellite subset)."),
+    "pos1-posopt8":    ("PPP, PPP-RTK, VRS", "Apply relativistic Shapiro time delay correction."),
+    "pos1-posopt9":    ("PPP-RTK, VRS", "Exclude QZS satellites from reference satellite selection in DD processing."),
+    "pos1-posopt10":   ("PPP-RTK, VRS", "Disable phase bias adjustment. Used when phase bias is already applied by SSR corrections."),
+    "pos1-posopt11":   ("PPP-RTK, VRS", "GPS frequency pair selection for CLAS processing."),
+    "pos1-posopt12":   ("—", "Reserved for future use."),
+    "pos1-posopt13":   ("PPP-RTK, VRS", "QZS frequency pair selection for CLAS processing."),
+    "pos1-tidecorr":   ("PPP, PPP-RTK, VRS", "Tidal displacement correction. Option `solid+otl-clasgrid+pole` uses CLAS grid-based ocean tide loading."),
+
+    # ── positioning.atmosphere ───────────────────────────────────────────────
+    "pos1-ionoopt":    ("All", "Ionospheric correction model. PPP uses `dual-freq` or `est-stec`. PPP-RTK uses `est-stec` or `est-adaptive`. RTK typically uses `dual-freq`."),
+    "pos1-tropopt":    ("All", "Tropospheric correction model. PPP/PPP-RTK use `est-ztd` or `est-ztdgrad`. SPP/RTK typically use `saas`."),
+
+    # ── ambiguity_resolution ─────────────────────────────────────────────────
+    "pos2-armode":     ("RTK, PPP, PPP-RTK, VRS", "Ambiguity resolution strategy."),
+    "pos2-gpsarmode":  ("RTK", "GPS AR mode for GLONASS fix-and-hold second pass."),
+    "pos2-gloarmode":  ("RTK", "GLONASS ambiguity resolution mode."),
+    "pos2-bdsarmode":  ("RTK, PPP-RTK", "BDS ambiguity resolution enable/disable."),
+    "pos2-qzsarmode":  ("PPP-RTK, VRS", "QZS ambiguity resolution mode."),
+    "pos2-arsys":      ("RTK, PPP-RTK, VRS", "Constellation bitmask for AR. Limits which systems participate in integer ambiguity resolution."),
+
+    # ── ambiguity_resolution.thresholds ──────────────────────────────────────
+    "pos2-arthres":    ("RTK, PPP, PPP-RTK, VRS", "LAMBDA ratio test threshold (2nd-best / best). Typical value: 3.0."),
+    "pos2-arthres1":   ("RTK, PPP, PPP-RTK", "Secondary AR threshold. In MADOCA-PPP: max 3D position std-dev to start narrow-lane AR."),
+    "pos2-arthres2":   ("RTK, PPP-RTK", "Additional AR threshold parameter."),
+    "pos2-arthres3":   ("RTK, PPP-RTK", "Additional AR threshold parameter."),
+    "pos2-arthres4":   ("RTK", "Additional AR threshold parameter."),
+    "pos2-arthres5":   ("PPP-RTK", "Chi-square threshold for hold validation."),
+    "pos2-arthres6":   ("PPP-RTK", "Chi-square threshold for fix validation."),
+    "pos2-aralpha":    ("PPP-RTK, VRS", "AR significance level (ILS success rate)."),
+    "pos2-arelmask":   ("RTK, PPP-RTK, VRS", "Minimum satellite elevation for AR participation (degrees)."),
+    "pos2-elmaskhold": ("RTK, PPP-RTK, VRS", "Minimum satellite elevation for fix-and-hold constraint application (degrees)."),
+
+    # ── ambiguity_resolution.counters ────────────────────────────────────────
+    "pos2-arlockcnt":  ("RTK, PPP-RTK, VRS", "Minimum continuous lock count before a satellite participates in AR."),
+    "pos2-arminfix":   ("RTK, PPP-RTK", "Minimum fix epochs before applying fix-and-hold constraint."),
+    "pos2-armaxiter":  ("RTK, PPP-RTK", "Maximum LAMBDA search iterations per epoch."),
+    "pos2-aroutcnt":   ("RTK, PPP-RTK, VRS", "Reset ambiguity after this many continuous outage epochs."),
+
+    # ── ambiguity_resolution.partial_ar ──────────────────────────────────────
+    "pos2-arminamb":       ("PPP-RTK, VRS", "Minimum number of ambiguities required for partial AR attempt."),
+    "pos2-armaxdelsat":    ("PPP-RTK, VRS", "Maximum satellites to exclude during partial AR satellite rotation."),
+    "pos2-arminfixsats":   ("RTK, PPP-RTK", "Minimum DD pairs required for a valid fix. 0 = disabled."),
+    "pos2-armindropsats":  ("RTK", "Minimum DD pairs before excluding the weakest satellite in partial AR. 0 = disabled."),
+    "pos2-arminholdsats":  ("RTK", "Minimum DD pairs for fix-and-hold mode activation. 0 = no minimum."),
+    "pos2-arfilter":       ("RTK, PPP-RTK", "Exclude newly-locked satellites that degrade the AR ratio."),
+
+    # ── ambiguity_resolution.hold ────────────────────────────────────────────
+    "pos2-varholdamb":  ("PPP-RTK, VRS", "Variance of held ambiguity pseudo-observation (cyc\u00b2). Controls how tightly held ambiguities constrain the filter."),
+    "pos2-gainholdamb": ("RTK", "Gain factor for fractional GLONASS/SBAS inter-channel bias update in fix-and-hold."),
+
+    # ── rejection ────────────────────────────────────────────────────────────
+    "pos2-rejionno":   ("RTK, PPP", "Innovation (pre-fit residual) threshold (m). Observations exceeding this are rejected."),
+    "pos2-rejionno1":  ("PPP-RTK, VRS", "L1/L2 residual rejection threshold (\u03c3)."),
+    "pos2-rejionno2":  ("PPP-RTK, VRS", "Dispersive (ionospheric) residual rejection threshold (\u03c3)."),
+    "pos2-rejionno3":  ("PPP-RTK, VRS", "Non-dispersive (geometric) residual rejection threshold (\u03c3)."),
+    "pos2-rejionno4":  ("PPP-RTK, VRS", "Chi-square threshold for hold-mode outlier detection."),
+    "pos2-rejionno5":  ("PPP-RTK, VRS", "Chi-square threshold for fix-mode outlier detection."),
+    "pos2-rejgdop":    ("All", "Maximum GDOP for valid solution output."),
+    "pos2-rejdiffpse": ("VRS", "Pseudorange consistency check threshold (m). Rejects satellites with large code-phase disagreement."),
+    "pos2-poserrcnt":  ("VRS", "Number of consecutive position error epochs before filter reset."),
+
+    # ── slip_detection ───────────────────────────────────────────────────────
+    "pos2-slipthres":  ("RTK, PPP, PPP-RTK, VRS", "Geometry-free (LG) cycle slip detection threshold (m)."),
+    "pos2-thresdop":   ("RTK, PPP, PPP-RTK", "Doppler-phase rate cycle slip detection threshold (cyc/s). 0 = disabled."),
+
+    # ── kalman_filter ────────────────────────────────────────────────────────
+    "pos2-niter":      ("RTK, PPP, PPP-RTK, VRS", "Number of measurement update iterations per epoch. More iterations improve linearization accuracy."),
+    "pos2-syncsol":    ("RT", "Synchronize solution output with observation time in real-time mode."),
+
+    # ── kalman_filter.measurement_error ──────────────────────────────────────
+    "stats-eratio1":    ("All", "Code/phase measurement error ratio for L1. Code error = phase error \u00d7 ratio. Typical: 100."),
+    "stats-eratio2":    ("All", "Code/phase measurement error ratio for L2."),
+    "stats-eratio3":    ("All", "Code/phase measurement error ratio for L5."),
+    "stats-errphase":   ("All", "Base carrier phase measurement error (m). Used in elevation-dependent weighting: error = phase + phase_elevation / sin(el)."),
+    "stats-errphaseel": ("All", "Elevation-dependent carrier phase error coefficient (m)."),
+    "stats-errphasebl": ("RTK", "Baseline-length-dependent phase error (m/10km). Proportional to rover\u2013base distance."),
+    "stats-errdoppler": ("All", "Doppler measurement error (Hz)."),
+    "stats-uraratio":   ("PPP", "User Range Accuracy scaling ratio. Adjusts satellite-specific weighting based on broadcast URA."),
+
+    # ── kalman_filter.initial_std ────────────────────────────────────────────
+    "stats-stdbias":   ("RTK, PPP, PPP-RTK, VRS", "Initial standard deviation for carrier phase bias states (m)."),
+    "stats-stdiono":   ("PPP-RTK, VRS", "Initial standard deviation for ionospheric delay states (m)."),
+    "stats-stdtrop":   ("PPP, PPP-RTK, VRS", "Initial standard deviation for tropospheric delay states (m)."),
+
+    # ── kalman_filter.process_noise ──────────────────────────────────────────
+    "stats-prnbias":      ("RTK, PPP, PPP-RTK, VRS", "Process noise for carrier phase bias states (m/\u221as)."),
+    "stats-prniono":      ("PPP-RTK, VRS", "Process noise for ionospheric delay states (m/\u221as)."),
+    "stats-prnionomax":   ("PPP-RTK, VRS", "Maximum ionospheric process noise clamp (m). Prevents excessive iono state growth."),
+    "stats-prntrop":      ("PPP, PPP-RTK, VRS", "Process noise for tropospheric delay states (m/\u221as)."),
+    "stats-prnaccelh":    ("All", "Horizontal acceleration process noise (m/s\u00b2). Active when `dynamics = true`."),
+    "stats-prnaccelv":    ("All", "Vertical acceleration process noise (m/s\u00b2). Active when `dynamics = true`."),
+    "stats-prnposith":    ("PPP-RTK, VRS", "Horizontal position process noise (m)."),
+    "stats-prnpositv":    ("PPP-RTK, VRS", "Vertical position process noise (m)."),
+    "stats-prnpos":       ("All", "General position process noise (m). Fallback when h/v not specified."),
+    "stats-prnifb":       ("PPP", "Inter-frequency bias process noise (m). For multi-frequency PPP bias estimation."),
+    "stats-prndcb":       ("PPP", "Alias for `ifb` (legacy name)."),
+    "stats-tconstiono":   ("PPP-RTK, VRS", "Ionospheric time constant (s). Controls iono state temporal correlation in the adaptive filter."),
+    "stats-clkstab":      ("PPP", "Receiver clock stability (s/s). Used in PPP clock state prediction."),
+
+    # ── adaptive_filter ──────────────────────────────────────────────────────
+    "pos2-prnadpt":    ("PPP-RTK, VRS", "Enable adaptive Kalman filter process noise scaling."),
+    "pos2-forgetion":  ("PPP-RTK, VRS", "Forgetting factor for ionospheric state (0\u20131). Lower = faster adaptation."),
+    "pos2-afgainion":  ("PPP-RTK, VRS", "Adaptive gain for ionospheric process noise adjustment."),
+    "pos2-forgetpva":  ("PPP-RTK, VRS", "Forgetting factor for position/velocity/acceleration states (0\u20131)."),
+    "pos2-afgainpva":  ("PPP-RTK, VRS", "Adaptive gain for PVA process noise adjustment."),
+
+    # ── signals ──────────────────────────────────────────────────────────────
+    "pos2-siggps":     ("PPP, PPP-RTK", "GPS frequency pair selection for PPP/PPP-RTK processing."),
+    "pos2-sigqzs":     ("PPP, PPP-RTK", "QZS frequency pair selection."),
+    "pos2-siggal":     ("PPP, PPP-RTK", "Galileo frequency pair selection."),
+    "pos2-sigbds2":    ("PPP, PPP-RTK", "BDS-2 frequency pair selection."),
+    "pos2-sigbds3":    ("PPP, PPP-RTK", "BDS-3 frequency pair selection."),
+
+    # ── receiver ─────────────────────────────────────────────────────────────
+    "pos2-ionocorr":   ("PPP", "Enable ionospheric correction in MADOCA-PPP processing."),
+    "pos2-ign_chierr": ("SPP", "Ignore chi-square test errors in SPP solution validation."),
+    "pos2-bds2bias":   ("PPP", "Enable BDS-2 code bias correction (satellite-dependent group delay)."),
+    "pos2-pppsatcb":   ("PPP", "PPP satellite code bias source selection."),
+    "pos2-pppsatpb":   ("PPP", "PPP satellite phase bias source selection."),
+    "pos2-uncorrbias": ("PPP", "Uncorrelated bias parameter for PPP processing."),
+    "pos2-maxbiasdt":  ("PPP", "Maximum age of bias correction data (s) before invalidation."),
+    "pos2-sattmode":   ("PPP", "Satellite processing mode selector."),
+    "pos2-phasshft":   ("PPP-RTK, VRS", "Phase cycle shift correction. Corrects quarter-cycle shifts between systems."),
+    "pos2-isb":        ("PPP-RTK, VRS", "Inter-system bias estimation mode."),
+    "pos2-rectype":    ("PPP-RTK, VRS", "Reference station receiver type for ISB table lookup."),
+    "pos2-maxage":     ("RTK, PPP-RTK", "Maximum age of differential correction (s)."),
+    "pos2-baselen":    ("RTK", "Baseline length constraint (m). 0 = no constraint."),
+    "pos2-basesig":    ("RTK", "Standard deviation of baseline length constraint (m)."),
+
+    # ── antenna.rover ────────────────────────────────────────────────────────
+    "ant1-postype":    ("All", "Rover position input type."),
+    "ant1-pos1":       ("All", "Rover position coordinate 1 (latitude or X, depending on `position_type`)."),
+    "ant1-pos2":       ("All", "Rover position coordinate 2 (longitude or Y)."),
+    "ant1-pos3":       ("All", "Rover position coordinate 3 (height or Z)."),
+    "ant1-anttype":    ("All", "Rover antenna type (must match ANTEX file entry). `*` = use RINEX header."),
+    "ant1-antdele":    ("All", "Rover antenna delta East offset (m)."),
+    "ant1-antdeln":    ("All", "Rover antenna delta North offset (m)."),
+    "ant1-antdelu":    ("All", "Rover antenna delta Up offset (m)."),
+
+    # ── antenna.base ─────────────────────────────────────────────────────────
+    "ant2-postype":    ("RTK, VRS", "Base station position input type."),
+    "ant2-pos1":       ("RTK, VRS", "Base position coordinate 1."),
+    "ant2-pos2":       ("RTK, VRS", "Base position coordinate 2."),
+    "ant2-pos3":       ("RTK, VRS", "Base position coordinate 3."),
+    "ant2-anttype":    ("RTK, VRS", "Base antenna type."),
+    "ant2-antdele":    ("RTK, VRS", "Base antenna delta East offset (m)."),
+    "ant2-antdeln":    ("RTK, VRS", "Base antenna delta North offset (m)."),
+    "ant2-antdelu":    ("RTK, VRS", "Base antenna delta Up offset (m)."),
+    "ant2-maxaveep":   ("RT", "Maximum epochs for base position averaging in real-time mode."),
+    "ant2-initrst":    ("RT", "Reset base position averaging on restart."),
+
+    # ── output ───────────────────────────────────────────────────────────────
+    "out-solformat":   ("All", "Solution output format."),
+    "out-outhead":     ("All", "Output header line with option summary."),
+    "out-outopt":      ("All", "Output processing options in header."),
+    "out-outvel":      ("All", "Include velocity in solution output."),
+    "out-timesys":     ("All", "Time system for output."),
+    "out-timeform":    ("All", "Time format."),
+    "out-timendec":    ("All", "Number of decimal digits for time output."),
+    "out-degform":     ("All", "Coordinate format."),
+    "out-fieldsep":    ("All", "Field separator character for output."),
+    "out-outsingle":   ("All", "Output SPP solution alongside fixed solution."),
+    "out-maxsolstd":   ("All", "Maximum solution standard deviation for output (m). Solutions exceeding this are suppressed."),
+    "out-height":      ("All", "Height output type."),
+    "out-geoid":       ("All", "Geoid model for geodetic height conversion."),
+    "out-solstatic":   ("PP", "Static mode output control."),
+    "out-nmeaintv1":   ("All", "NMEA GGA/RMC output interval (s)."),
+    "out-nmeaintv2":   ("All", "NMEA GSA/GSV output interval (s)."),
+    "out-outstat":     ("All", "Solution status output level."),
+
+    # ── files ────────────────────────────────────────────────────────────────
+    "file-satantfile":   ("All", "Satellite antenna ANTEX file. Required for satellite antenna PCV correction."),
+    "file-rcvantfile":   ("All", "Receiver antenna ANTEX file. Required for receiver antenna PCV correction."),
+    "file-staposfile":   ("All", "Station position file for fixed/known positions."),
+    "file-geoidfile":    ("All", "Geoid data file for geodetic height conversion."),
+    "file-ionofile":     ("All", "IONEX ionosphere map file. Used when `ionosphere = ionex-tec`."),
+    "file-dcbfile":      ("PPP", "Differential code bias file."),
+    "file-eopfile":      ("PPP, PPP-RTK", "Earth orientation parameter file for precise coordinate frame."),
+    "file-blqfile":      ("PPP, PPP-RTK", "BLQ ocean tide loading file. Required when `tidal_correction` includes OTL."),
+    "file-elmaskfile":   ("All", "Azimuth-dependent elevation mask file."),
+    "file-tempdir":      ("All", "Temporary directory for intermediate files."),
+    "file-geexefile":    ("All", "Google Earth executable path (legacy GUI feature)."),
+    "file-solstatfile":  ("All", "Solution statistics output file path."),
+    "file-tracefile":    ("All", "Debug trace output file path."),
+    "file-fcbfile":      ("PPP", "Fractional cycle bias file for PPP-AR."),
+    "file-biafile":      ("PPP", "Bias SINEX file for PPP satellite bias correction."),
+    "file-cssrgridfile": ("PPP-RTK, VRS", "CLAS CSSR grid definition file. Required for CLAS grid-based corrections."),
+    "file-isbfile":      ("PPP-RTK, VRS", "Inter-system bias correction table file."),
+    "file-phacycfile":   ("PPP-RTK, VRS", "Phase cycle shift correction table file."),
+    "file-cmdfile1":     ("RT", "Receiver command file for input stream 1."),
+    "file-cmdfile2":     ("RT", "Receiver command file for input stream 2."),
+    "file-cmdfile3":     ("RT", "Receiver command file for input stream 3."),
+
+    # ── server ───────────────────────────────────────────────────────────────
+    "misc-svrcycle":    ("RT", "Server main loop cycle interval (ms). Controls processing rate."),
+    "misc-timeout":     ("RT", "Stream read timeout (ms). After timeout, stream is considered disconnected."),
+    "misc-reconnect":   ("RT", "Stream reconnection interval (ms) after disconnect."),
+    "misc-nmeacycle":   ("RT", "NMEA request transmission cycle (ms) for NTRIP caster position updates."),
+    "misc-buffsize":    ("RT", "Stream input buffer size (bytes)."),
+    "misc-navmsgsel":   ("RT", "Navigation message type selection for multi-source environments."),
+    "misc-proxyaddr":   ("RT", "HTTP proxy address for NTRIP connections."),
+    "misc-fswapmargin": ("RT", "File swap margin (s) for continuous logging across file boundaries."),
+    "misc-timeinterp":  ("RT", "Enable time interpolation between observation epochs."),
+    "misc-sbasatsel":   ("RT", "SBAS satellite selection."),
+    "misc-maxobsloss":  ("RT", "Maximum observation gap duration before filter reset (s)."),
+    "misc-floatcnt":    ("RT", "Number of float epochs before triggering filter reset."),
+    "misc-rnxopt1":     ("All", "RINEX conversion option string for rover stream."),
+    "misc-rnxopt2":     ("All", "RINEX conversion option string for base stream."),
+    "misc-pppopt":      ("PPP", "PPP processing option string (passed to PPP engine)."),
+    "misc-rtcmopt":     ("RT", "RTCM decoder option string."),
+    "misc-l6mrg":       ("RT", "L6 message margin (epochs) for CLAS L6 real-time synchronization."),
+    "misc-regularly":   ("VRS", "Regular filter reset interval (s). 0 = disabled."),
+    "misc-startcmd":    ("RT", "Shell command executed on server start."),
+    "misc-stopcmd":     ("RT", "Shell command executed on server stop."),
+}
+
+
 def get_enum_values(legacy_key: str) -> str:
     """Get enum values string for a legacy key, if available."""
     if legacy_key not in _KEY_ENUM:
@@ -30,6 +300,22 @@ def get_enum_values(legacy_key: str) -> str:
     if enum_name not in _ENUM_STRINGS:
         return ""
     return _ENUM_STRINGS[enum_name]
+
+
+def format_enum_values(raw: str) -> str:
+    """Format raw enum string into readable middle-dot-separated list without numeric prefixes.
+
+    Input:  "0:single,1:dgps,2:kinematic"
+    Output: "`single` · `dgps` · `kinematic`"
+    """
+    if not raw:
+        return ""
+    parts = []
+    for item in raw.split(","):
+        _, _, name = item.partition(":")
+        if name:
+            parts.append(f"`{name}`")
+    return " · ".join(parts)
 
 
 def type_label(vtype: str) -> str:
@@ -86,12 +372,29 @@ def main() -> int:
     lines: list[str] = []
     lines.append("# Configuration Options Reference")
     lines.append("")
-    lines.append("TOML configuration options available in MRTKLIB (generated from the internal mapping table).")
+    lines.append("TOML configuration options available in MRTKLIB.")
     lines.append("Options are grouped by their TOML section.")
     lines.append("")
     lines.append("!!! tip \"Auto-generated\"")
     lines.append("    This page is auto-generated from the internal option mapping table.")
     lines.append("    Run `python scripts/docs/gen_config_ref.py > docs/reference/config-options.md` to regenerate.")
+    lines.append("")
+
+    # Mode abbreviation legend
+    lines.append("## Mode Abbreviations")
+    lines.append("")
+    lines.append("| Abbreviation | Positioning Mode(s) |")
+    lines.append("|:-------------|:--------------------|")
+    lines.append("| **All** | All modes |")
+    lines.append("| **SPP** | Single Point Positioning (`single`) |")
+    lines.append("| **DGPS** | Differential GPS (`dgps`) |")
+    lines.append("| **RTK** | `kinematic` · `static` · `movingbase` · `fixed` |")
+    lines.append("| **PPP** | `ppp-kine` · `ppp-static` · `ppp-fixed` |")
+    lines.append("| **PPP-RTK** | `ppp-rtk` (CLAS PPP-RTK) |")
+    lines.append("| **SSR2OSR** | `ssr2osr` · `ssr2osr-fixed` |")
+    lines.append("| **VRS** | `vrs-rtk` |")
+    lines.append("| **RT** | Real-time only (`mrtk run` / `rtkrcv`) |")
+    lines.append("| **PP** | Post-processing only (`mrtk post` / `rnx2rtkp`) |")
     lines.append("")
 
     # Generate each section
@@ -102,8 +405,8 @@ def main() -> int:
         lines.append("")
         lines.append(f"TOML section: `[{section}]`")
         lines.append("")
-        lines.append("| TOML Key | Type | Values | Legacy Key |")
-        lines.append("|----------|------|--------|------------|")
+        lines.append("| TOML Key | Type | Modes | Description |")
+        lines.append("|:---------|:-----|:------|:------------|")
 
         seen_keys: set[str] = set()
         for legacy_key, _, toml_key, vtype in entries:
@@ -113,30 +416,60 @@ def main() -> int:
             seen_keys.add(toml_key)
 
             tl = type_label(vtype)
-            enum_vals = get_enum_values(legacy_key)
 
+            # Get description and modes from metadata
+            modes, desc = _OPTION_META.get(legacy_key, ("", ""))
+
+            # Build description with enum values / type hints
             if vtype == "bool":
-                values = "`true` / `false`"
-            elif enum_vals:
-                # Format enum values for display
-                values = f"`{enum_vals}`"
+                pass  # No enum values needed for boolean
             elif vtype == "navsys":
-                values = 'e.g. `["GPS", "Galileo", "QZSS"]`'
+                if '["' not in desc:
+                    desc += ' e.g. `["GPS", "Galileo", "QZSS"]`'
             elif vtype == "siglist":
-                values = 'e.g. `["G1C", "G2W", "E1C"]`'
+                if '["' not in desc:
+                    desc += ' e.g. `["G1C", "G2W", "E1C"]`'
             elif vtype == "snr":
-                values = "9-element array (0-45 dBHz per 5°)"
+                if "9-element" not in desc:
+                    desc += " 9-element array (0–45 dBHz per 5° elevation bin)."
             else:
-                values = "—"
+                enum_vals = get_enum_values(legacy_key)
+                if enum_vals:
+                    formatted = format_enum_values(enum_vals)
+                    desc += f" {formatted}"
 
-            lines.append(f"| `{toml_key}` | {tl} | {values} | `{legacy_key}` |")
+            lines.append(f"| `{toml_key}` | {tl} | {modes} | {desc} |")
 
         lines.append("")
 
+        # Section-specific supplementary notes
+        if section == "positioning":
+            lines.append("### Frequency Index Mapping")
+            lines.append("")
+            lines.append("The `frequency` option selects how many frequency slots to use (`l1` = 1, `l1+2` = 2, etc.).")
+            lines.append("Each slot maps to a different signal depending on the constellation:")
+            lines.append("")
+            lines.append("| | L1 (idx 0) | L2 (idx 1) | L3 (idx 2) | L4 (idx 3) | L5 (idx 4) |")
+            lines.append("|:---|:-----------|:-----------|:-----------|:-----------|:-----------|")
+            lines.append("| **GPS** | L1 | L2 | L5 | — | — |")
+            lines.append("| **GLONASS** | G1 | G2 | G3 | — | — |")
+            lines.append("| **Galileo** | E1 | E5a | E5b | E6 | E5a+b |")
+            lines.append("| **QZSS** | L1 | L5 | L2 | L6 | — |")
+            lines.append("| **BDS** | B1I/B1C/B1A | B3I/B3A | B2I/B2b | B2a | B2a+b |")
+            lines.append("| **SBAS** | L1 | L5 | — | — | — |")
+            lines.append("| **NavIC** | L5 | S | — | — | — |")
+            lines.append("")
+            lines.append("!!! warning \"CLAS PPP-RTK: Use `l1+2` (nf=2)\"")
+            lines.append("    With `l1+2`, GPS uses L1+L2 and Galileo uses E1+E5a.")
+            lines.append("    CLAS does not provide E5b bias corrections. Using `l1+2+3` (nf=3)")
+            lines.append("    adds the E5b slot without valid bias, causing false cycle slips on")
+            lines.append("    Galileo and degrading fix rate from >99% to ~67%.")
+            lines.append("")
+
     # Stream configuration (not in MAPPING)
-    lines.append("## `[streams]`")
+    lines.append("## Streams")
     lines.append("")
-    lines.append("**Stream Configuration (rtkrcv only)**")
+    lines.append("TOML section: `[streams]` — **Real-time only** (`mrtk run` / `rtkrcv`)")
     lines.append("")
     lines.append("Stream configuration uses a hierarchical structure:")
     lines.append("")
@@ -160,14 +493,14 @@ def main() -> int:
     lines.append('path = "rover.log"')
     lines.append("```")
     lines.append("")
-    lines.append("| Key | Description |")
-    lines.append("|-----|-------------|")
-    lines.append("| `type` | Stream type: `serial`, `file`, `tcpsvr`, `tcpcli`, `ntrip`, `off` |")
-    lines.append("| `path` | Stream path (device, file, URL) |")
-    lines.append("| `format` | Data format: `rtcm3`, `ubx`, `sbf`, `binex`, `rinex`, `clas`, `l6e`, etc. |")
-    lines.append("| `nmeareq` | Send NMEA request to stream (boolean) |")
-    lines.append("| `nmealat` | NMEA request latitude (float) |")
-    lines.append("| `nmealon` | NMEA request longitude (float) |")
+    lines.append("| Key | Type | Description |")
+    lines.append("|:----|:-----|:------------|")
+    lines.append("| `type` | string | Stream type: `serial` · `file` · `tcpsvr` · `tcpcli` · `ntrip` · `off` |")
+    lines.append("| `path` | string | Stream path (serial device, file path, or URL) |")
+    lines.append("| `format` | string | Data format: `rtcm3` · `ubx` · `sbf` · `binex` · `rinex` · `clas` · `l6e` |")
+    lines.append("| `nmeareq` | boolean | Send NMEA position request to stream |")
+    lines.append("| `nmealat` | float | NMEA request latitude (degrees) |")
+    lines.append("| `nmealon` | float | NMEA request longitude (degrees) |")
     lines.append("")
 
     print("\n".join(lines))


### PR DESCRIPTION
This pull request adds comprehensive quick start guides for CLAS PPP-RTK and MADOCA-PPP positioning with MRTKLIB, and updates the documentation to clarify critical configuration settings for CLAS PPP-RTK, especially regarding Galileo E5b bias support. The guides provide step-by-step instructions, required files, configuration tips, troubleshooting, and highlight key differences between CLAS and MADOCA modes. The navigation menu is also updated to include these new guides.

**New Quick Start Guides:**

* Added `quickstart-clas.md`: A detailed guide covering setup, required files, configuration, and troubleshooting for CLAS PPP-RTK (Japan, QZSS L6D).
* Added `quickstart-madoca-ppp.md`: A step-by-step guide for MADOCA-PPP, including both basic PPP and PPP-AR, with configuration and troubleshooting.

**Documentation Clarifications for CLAS PPP-RTK:**

* Clarified that CLAS does not provide Galileo E5b bias corrections (not E5a), and that using `l1+2+3` (nf=3) causes false geometry-free cycle slips and degraded fix rates. Updated comments, warnings, and tables accordingly in `rtkrcv-clas-realtime.md`. [[1]](diffhunk://#diff-1f2c3b01593760e8b264db930f4aa8a776df90537f738c05ba792c2e2e599257L64-R64) [[2]](diffhunk://#diff-1f2c3b01593760e8b264db930f4aa8a776df90537f738c05ba792c2e2e599257L96-R98) [[3]](diffhunk://#diff-1f2c3b01593760e8b264db930f4aa8a776df90537f738c05ba792c2e2e599257L260-R260) [[4]](diffhunk://#diff-1f2c3b01593760e8b264db930f4aa8a776df90537f738c05ba792c2e2e599257L294-R296)

**Navigation Updates:**

* Updated `mkdocs.yml` to add both new quick start guides to the user guide navigation.