### PR TITLE
NTRIP v2 Protocol Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to MRTKLIB are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.6.3] - 2026-03-31
+
+**Feature** — NTRIP v2 (HTTP/1.1) protocol support with auto-negotiation.
+
+### Added
+
+- **NTRIP v2 client** — HTTP/1.1 GET requests with `Host:` and `Ntrip-Version: Ntrip/2.0` headers; automatic `HTTP/1.1 200 OK` response parsing.
+- **NTRIP v2 server** — HTTP/1.1 POST requests with `Transfer-Encoding: chunked` (replaces legacy `SOURCE` command).
+- **Chunked transfer encoding** — Incremental, non-blocking decoder and stateless encoder in header-only `ntrip_chunk.h`.
+- **Version auto-detection** — Tries v2 first, falls back to v1 transparently; per-stream `?ver=N` override.
+- **`strsetntripver()`** — Public API for setting the global default NTRIP version.
+- **URL percent-decoding** — `%XX` sequences in NTRIP user/password fields are now decoded (e.g., `%40` -> `@`).
+- **NTRIP streams guide** — New documentation page (`docs/guide/ntrip.md`) with path format, version selection, TLS tunnel setup (stunnel/socat), and troubleshooting.
+- **`t_ntrip` unit test** — 17 tests for chunked codec and HTTP helpers.
+
+### Changed
+
+- `ntrip_t` struct extended with version negotiation, chunked state, and host fields.
+- `ntripc_con_t` struct extended with per-client NTRIP version tracking.
+- NTRIP caster sends chunked encoding to v2 clients, raw data to v1 clients.
+
+### Test Results
+
+63/63 tests pass (62 existing + 1 new; no regressions).
+
 ## [v0.6.2] - 2026-03-13
 
 **Enhancement** — Documentation site with MkDocs Material + Doxygen + GitHub Pages.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(MRTKLIB VERSION 0.6.2 LANGUAGES C)
+project(MRTKLIB VERSION 0.6.3 LANGUAGES C)
 
 # ── Version header generation ─────────────────────────────────────────────────
 set(MRTKLIB_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
@@ -207,6 +207,16 @@ foreach(test IN LISTS _UTEST_SOURCES)
              WORKING_DIRECTORY ${_UTEST_DIR})
     set_tests_properties(utest_${test} PROPERTIES LABELS "utest")
 endforeach()
+
+# NTRIP v2 chunked codec test (header-only, no library dependency)
+add_executable(t_ntrip ${_UTEST_DIR}/t_ntrip.c)
+# Override global -ansi (=C90) for this target, same as mrtklib target.
+# Note: set_property(C_STANDARD 11) and target_compile_features(c_std_11) do NOT
+# override -ansi from add_compile_options(); explicit -std=c11 is required.
+target_compile_options(t_ntrip PRIVATE -std=c11)
+add_test(NAME utest_t_ntrip COMMAND t_ntrip
+         WORKING_DIRECTORY ${_UTEST_DIR})
+set_tests_properties(utest_t_ntrip PROPERTIES LABELS "utest")
 
 # ── RINEX 4 test data fixture (decompress BRD400 NAV) ────────────────────────
 set(_RINEX4_DIR ${CMAKE_SOURCE_DIR}/tests/data/rinex4)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ incrementally back-ported to each engine:
 | **v0.6.0** | All | Single CLI App: Unified `mrtk` binary with subcommands (`run`, `post`, `relay`, `convert`, etc.); BSS reduced from 3 GB to 34 MB | ✅ Released |
 | **v0.6.1** | All | Config UX: `systems` string list, `excluded_sats` list, `taplo` formatter, section reorganization | ✅ Released |
 | **v0.6.2** | — | Documentation: MkDocs Material site + Doxygen API reference + GitHub Pages deployment | ✅ Released |
+| **v0.6.3** | Stream | NTRIP v2 (HTTP/1.1) protocol support with auto-negotiation, chunked transfer encoding, URL percent-decoding | ✅ Released |
 | **v0.6.x** | All | Doxygen docstring coverage expansion | 💭 Backlog |
 
 > [!NOTE]

--- a/docs/guide/ntrip.md
+++ b/docs/guide/ntrip.md
@@ -1,0 +1,215 @@
+# NTRIP Streams
+
+This guide covers how to connect MRTKLIB to NTRIP casters for real-time
+GNSS correction data, including NTRIP version selection and TLS (encrypted)
+connections.
+
+---
+
+## NTRIP Path Format
+
+All NTRIP stream paths follow this format:
+
+```
+[user[:password]@]host[:port]/mountpoint[?ver=N][&host=HOSTNAME]
+```
+
+| Component | Description | Default |
+|:----------|:------------|:--------|
+| `user` | Username for authentication | _(none)_ |
+| `password` | Password (special chars: use `%XX` encoding) | _(none)_ |
+| `host` | Caster hostname or IP | _(required)_ |
+| `port` | TCP port | 2101 (client), 80 (server) |
+| `mountpoint` | Stream mountpoint name | _(required)_ |
+| `?ver=N` | NTRIP version override (1 or 2) | auto |
+| `&host=HOSTNAME` | Host header override (for TLS tunnels) | _(from addr:port)_ |
+
+### Special Characters in Passwords
+
+Characters that conflict with the path syntax must be percent-encoded:
+
+| Character | Encoding |
+|:----------|:---------|
+| `@` | `%40` |
+| `:` | `%3A` |
+| `/` | `%2F` |
+| `%` | `%25` |
+
+MRTKLIB automatically decodes these before authentication.
+
+**Example:** password `p@ss:word` becomes `p%40ss%3Aword` in the path.
+
+---
+
+## NTRIP Versions
+
+MRTKLIB supports both NTRIP v1 and v2.
+
+| Feature | v1 | v2 |
+|:--------|:---|:---|
+| Protocol | ICY / HTTP/1.0 | HTTP/1.1 |
+| Server request | `SOURCE` command | `POST` with chunked encoding |
+| Transfer encoding | Raw stream | Chunked (RFC 7230) |
+| Typical port | 2101 | 2101 |
+
+### Version Selection
+
+By default, MRTKLIB uses **auto-detection**: it sends a v2 request first
+and falls back to v1 if the caster responds with an ICY (v1) header or
+rejects the connection.
+
+To force a specific version, append `?ver=N` to the mountpoint:
+
+=== "Auto (default)"
+
+    ```toml
+    [streams.input.correction]
+    type = "ntripcli"
+    path = "user:passwd@caster.example.com:2101/RTCM3_MOUNT"
+    ```
+
+=== "Force v1"
+
+    ```toml
+    [streams.input.correction]
+    type = "ntripcli"
+    path = "user:passwd@caster.example.com:2101/RTCM3_MOUNT?ver=1"
+    ```
+
+=== "Force v2"
+
+    ```toml
+    [streams.input.correction]
+    type = "ntripcli"
+    path = "user:passwd@caster.example.com:2101/RTCM3_MOUNT?ver=2"
+    ```
+
+CLI usage with `mrtk relay`:
+
+```bash
+mrtk relay -in ntrip://user:passwd@caster.example.com:2101/MOUNT?ver=2 \
+           -out file://output.rtcm3
+```
+
+---
+
+## TLS Connections (NTRIP 2s)
+
+Some casters require TLS-encrypted connections on port 443 (often called
+"NTRIP 2s"). Examples include NASA Earthdata CDDIS.
+
+MRTKLIB does not currently include a built-in TLS stack. Use **stunnel**
+to create a local TLS tunnel.
+
+### Setup with stunnel
+
+#### 1. Install stunnel
+
+=== "macOS"
+
+    ```bash
+    brew install stunnel
+    ```
+
+=== "Ubuntu / Debian"
+
+    ```bash
+    sudo apt install stunnel4
+    ```
+
+#### 2. Create a configuration file
+
+Create `ntrip-tls.conf`:
+
+```ini
+[ntrip-tls]
+client = yes
+accept = 127.0.0.1:2101
+connect = caster.cddis.eosdis.nasa.gov:443
+```
+
+This listens on local port 2101 and forwards traffic over TLS to the
+remote caster on port 443.
+
+#### 3. Start the tunnel
+
+```bash
+stunnel ntrip-tls.conf
+```
+
+#### 4. Connect MRTKLIB through the tunnel
+
+Point MRTKLIB at the local stunnel endpoint. Use `&host=` to set the
+correct Host header for the remote caster:
+
+```toml
+[streams.input.correction]
+type = "ntripcli"
+path = "user:p%40ssword@127.0.0.1:2101/MOUNT?ver=2&host=caster.cddis.eosdis.nasa.gov"
+```
+
+Or via CLI:
+
+```bash
+mrtk relay -in "ntrip://user:p%40ssword@127.0.0.1:2101/MOUNT?ver=2&host=caster.cddis.eosdis.nasa.gov" \
+           -out file://output.rtcm3
+```
+
+!!! warning "Host header is required for most TLS casters"
+    When connecting through stunnel, the NTRIP v2 `Host:` header defaults
+    to `localhost:2101`. Many casters use this header for routing and will
+    return 404 if it doesn't match. Always add `&host=<real-hostname>` when
+    using a TLS tunnel with NTRIP v2.
+
+!!! note "NASA Earthdata Credentials"
+    NASA Earthdata uses your Earthdata Login credentials.
+    Register at [https://urs.earthdata.nasa.gov/](https://urs.earthdata.nasa.gov/).
+    Passwords often contain special characters --- remember to percent-encode
+    `@` as `%40` and `:` as `%3A` in the path.
+
+### Alternative: socat (one-liner)
+
+For quick testing without a configuration file:
+
+```bash
+socat TCP-LISTEN:2101,fork,reuseaddr \
+      OPENSSL:caster.cddis.eosdis.nasa.gov:443
+```
+
+Then connect MRTKLIB to `127.0.0.1:2101` as above.
+
+---
+
+## Troubleshooting
+
+### Authentication failure (401)
+
+- Verify credentials are correct.
+- Check that `@` and `:` in the password are percent-encoded (`%40`, `%3A`).
+- Some casters require NTRIP v2 --- try `?ver=2`.
+
+### Connection refused or timeout
+
+- Confirm the caster hostname and port are reachable:
+  ```bash
+  nc -zv caster.example.com 2101
+  ```
+- For TLS casters (port 443), verify the stunnel tunnel is running:
+  ```bash
+  nc -zv 127.0.0.1 2101
+  ```
+
+### Source table received instead of data
+
+- The mountpoint name is incorrect or does not exist on the caster.
+- Request the source table to list available mountpoints:
+  ```bash
+  mrtk relay -in ntrip://user:passwd@caster.example.com:2101/ \
+             -out file://sourcetable.txt
+  ```
+
+### v2 handshake fails, falls back to v1
+
+- This is normal for v1-only casters. No action needed.
+- Check `mrtk run` status output: `ver_neg = 1` confirms v1 negotiation.
+- To suppress the fallback attempt, use `?ver=1`.

--- a/docs/releases/release-notes-v0.6.3.md
+++ b/docs/releases/release-notes-v0.6.3.md
@@ -1,0 +1,91 @@
+# Release Notes — v0.6.3
+
+## NTRIP v2 Protocol Support
+
+**Release date:** 2026-03-31
+**Type:** Feature — NTRIP v2 (HTTP/1.1) protocol support with auto-negotiation
+**Branch:** `feat/ntrip-v2`
+
+---
+
+### Overview
+
+MRTKLIB now supports the NTRIP v2 protocol (RTCM 10410.1) alongside the
+existing v1 implementation. NTRIP v2 uses standard HTTP/1.1 with chunked
+transfer encoding, replacing the non-standard ICY/HTTP/1.0 protocol of v1.
+
+By default, new connections use **auto-detection**: the client sends a v2
+request first and transparently falls back to v1 if the caster does not
+support it. Per-stream version override is available via the `?ver=N`
+query parameter.
+
+---
+
+### What's New
+
+#### NTRIP v2 Client
+
+- HTTP/1.1 GET requests with `Host:` and `Ntrip-Version: Ntrip/2.0` headers
+- Automatic parsing of `HTTP/1.1 200 OK` responses (v2) alongside `ICY 200 OK` (v1)
+- Chunked transfer decoding for incoming data streams
+- Version auto-detection with seamless v1 fallback
+
+#### NTRIP v2 Server
+
+- HTTP/1.1 POST requests replace the legacy `SOURCE` command
+- Chunked transfer encoding for outbound data streams
+
+#### NTRIP v2 Caster
+
+- Extended existing v2 response generation to include chunked data delivery
+- Per-client version tracking (v1 clients receive raw data, v2 clients receive chunked)
+
+#### Chunked Transfer Encoding
+
+- Header-only codec (`ntrip_chunk.h`) with incremental, non-blocking state machine decoder
+- Stateless encoder for outbound chunk framing
+- HTTP header helpers for status code extraction and header lookup
+
+#### URL Percent-Encoding
+
+- `decodetcppath()` now decodes `%XX` sequences in user and password fields
+- Enables passwords containing `@` (`%40`), `:` (`%3A`), and other special characters
+
+#### Version Selection
+
+- **Auto (default):** Try v2, fall back to v1 on failure or ICY response
+- **`?ver=1`:** Force NTRIP v1 (original behavior)
+- **`?ver=2`:** Force NTRIP v2 (HTTP/1.1)
+- `strsetntripver()` API for setting the global default version
+
+#### Documentation
+
+- New **NTRIP Streams** guide (`docs/guide/ntrip.md`) covering path format,
+  version selection, TLS tunnel setup with stunnel/socat, and troubleshooting
+
+---
+
+### Files Added
+
+| File | Description |
+|------|-------------|
+| `src/stream/ntrip_chunk.h` | Header-only chunked transfer codec and HTTP helpers |
+| `tests/utest/t_ntrip.c` | 17 unit tests for chunked codec and HTTP helpers |
+| `docs/guide/ntrip.md` | NTRIP streams user guide |
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `src/stream/mrtk_stream.c` | v2 protocol support: struct extensions, request/response handlers, chunked data path, URL decoding, version negotiation |
+| `include/mrtklib/mrtk_stream.h` | `strsetntripver()` declaration |
+| `CMakeLists.txt` | Version 0.6.2 -> 0.6.3; `t_ntrip` test target |
+| `CHANGELOG.md` | v0.6.3 entry |
+| `README.md` | v0.6.3 in roadmap |
+| `mkdocs.yml` | NTRIP Streams guide in navigation |
+
+---
+
+### Test Results
+
+63/63 tests pass (62 existing + 1 new `utest_t_ntrip`; no regressions).

--- a/include/mrtklib/mrtk_stream.h
+++ b/include/mrtklib/mrtk_stream.h
@@ -262,6 +262,16 @@ void strsetdir(const char* dir);
  */
 void strsetproxy(const char* addr);
 
+/**
+ * @brief Set default NTRIP version for new connections.
+ * @param[in] ver  NTRIP version (0:auto, 1:v1, 2:v2)
+ *
+ * When set to auto (0), the client tries NTRIP v2 first and falls back to v1
+ * if the caster does not support it.  Per-stream override is available via
+ * the ?ver=N query parameter in the stream path.
+ */
+void strsetntripver(int ver);
+
 /*============================================================================
  * Stream Server Functions
  *===========================================================================*/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
     - Configuration (TOML): guide/configuration.md
     - "Quick Start: CLAS PPP-RTK": guide/quickstart-clas.md
     - "Quick Start: MADOCA-PPP": guide/quickstart-madoca-ppp.md
+    - NTRIP Streams: guide/ntrip.md
   - Reference:
     - Configuration Options: reference/config-options.md
     - API Reference (Doxygen): reference/api.md
@@ -103,6 +104,7 @@ nav:
     - Test Methodology: reference/test-accuracy-methodology.md
   - Releases:
     - Changelog: releases/changelog.md
+    - v0.6.3: releases/release-notes-v0.6.3.md
     - v0.6.2: releases/release-notes-v0.6.2.md
     - v0.6.1: releases/release-notes-v0.6.1.md
     - v0.6.0: releases/release-notes-v0.6.0.md

--- a/src/stream/mrtk_stream.c
+++ b/src/stream/mrtk_stream.c
@@ -45,6 +45,7 @@
 #include <termios.h>
 
 #include "mrtklib/mrtk_trace.h"
+#include "ntrip_chunk.h"
 
 /* constants -----------------------------------------------------------------*/
 
@@ -160,18 +161,25 @@ typedef struct {      /* serial control type */
 typedef struct {                /* ntrip control type */
     int state;                  /* state (0:close,1:wait,2:connect) */
     int type;                   /* type (0:server,1:client) */
+    int ver;                    /* requested version (NTRIP_VER_AUTO/1/2) */
+    int ver_neg;                /* negotiated version after handshake */
+    int chunked;                /* chunked transfer encoding flag */
+    int v2_tried;               /* v2 attempt flag for AUTO fallback */
     int nb;                     /* response buffer size */
     char url[MAXSTRPATH];       /* url for proxy */
+    char host[256];             /* host header value (addr:port) */
     char mntpnt[256];           /* mountpoint */
     char user[256];             /* user */
     char passwd[256];           /* password */
     char str[NTRIP_MAXSTR];     /* mountpoint string for server */
     uint8_t buff[NTRIP_MAXRSP]; /* response buffer */
     tcpcli_t* tcp;              /* tcp client */
+    chunk_dec_t cdec;           /* chunked transfer decoder */
 } ntrip_t;
 
 typedef struct {                /* ntrip client/server connection type */
     int state;                  /* state (0:close,1:connect) */
+    int ver;                    /* detected NTRIP version */
     char mntpnt[256];           /* mountpoint */
     char str[NTRIP_MAXSTR];     /* mountpoint string for server */
     int nb;                     /* request buffer size */
@@ -233,7 +241,8 @@ static int ticonnect = 10000;    /* interval to re-connect (ms) */
 static int tirate = 1000;        /* averaging time for data rate (ms) */
 static int buffsize = 32768;     /* receive/send buffer size (bytes) */
 static char localdir[1024] = ""; /* local directory for ftp/http */
-static char proxyaddr[256] = ""; /* http/ntrip/ftp proxy address */
+static char proxyaddr[256] = "";           /* http/ntrip/ftp proxy address */
+static int ntrip_ver_default = NTRIP_VER_AUTO; /* default ntrip version */
 static uint32_t tick_master = 0; /* time tick master for replay */
 static int fswapmargin = 30;     /* file swap margin (s) */
 
@@ -825,6 +834,31 @@ static void syncfile(file_t* file1, file_t* file2) {
     file2->repmode = 1;
     file2->offset = (int)(file1->tick_f - file2->tick_f);
 }
+/* decode percent-encoded characters in-place (%XX -> char) -----------------*/
+static void urldecode(char* str) {
+    char *src = str, *dst = str;
+    while (*src) {
+        if (*src == '%' && src[1] && src[2]) {
+            int hi = src[1], lo = src[2];
+            hi = (hi >= '0' && hi <= '9') ? hi - '0' : (hi >= 'A' && hi <= 'F') ? hi - 'A' + 10 : (hi >= 'a' && hi <= 'f') ? hi - 'a' + 10 : -1;
+            lo = (lo >= '0' && lo <= '9') ? lo - '0' : (lo >= 'A' && lo <= 'F') ? lo - 'A' + 10 : (lo >= 'a' && lo <= 'f') ? lo - 'a' + 10 : -1;
+            if (hi >= 0 && lo >= 0) {
+                char ch = (char)((hi << 4) | lo);
+                if (ch == '\0' || ch == '\r' || ch == '\n' || ch == ' ') {
+                    /* reject NUL, CR, LF, space to prevent string truncation,
+                     * request injection, and v1 SOURCE command delimiter issues */
+                    src += 3;
+                    continue;
+                }
+                *dst++ = ch;
+                src += 3;
+                continue;
+            }
+        }
+        *dst++ = *src++;
+    }
+    *dst = '\0';
+}
 /* decode tcp/ntrip path (path=[user[:passwd]@]addr[:port][/mntpnt[:str]]) ---*/
 static void decodetcppath(const char* path, char* addr, char* port, char* user, char* passwd, char* mntpnt, char* str) {
     char buff[MAXSTRPATH], *p, *q;
@@ -875,6 +909,10 @@ static void decodetcppath(const char* path, char* addr, char* port, char* user, 
         }
         if (user) {
             sprintf(user, "%.255s", buff);
+            urldecode(user);
+        }
+        if (passwd) {
+            urldecode(passwd);
         }
     } else {
         p = buff;
@@ -1436,76 +1474,182 @@ static int encbase64(char* str, const uint8_t* byte, int n) {
     tracet(NULL, 5, "encbase64: str=%s\n", str);
     return j;
 }
+/* safe append to buffer with overflow tracking */
+#define BUFADD(p, rem, ...) do { \
+    int _n = snprintf(p, rem, __VA_ARGS__); \
+    if (_n > 0 && _n < (rem)) { (p) += _n; (rem) -= _n; } \
+    else { (rem) = 0; } \
+} while (0)
 /* send ntrip server request -------------------------------------------------*/
 static int reqntrip_s(ntrip_t* ntrip, char* msg) {
-    char buff[1024 + NTRIP_MAXSTR], *p = buff;
+    char buff[2048], user[514], *p = buff;
+    int rem = (int)sizeof(buff);
+    int use_v2 = (ntrip->ver == NTRIP_VER_2 ||
+                  (ntrip->ver == NTRIP_VER_AUTO &&
+                   (!ntrip->v2_tried || ntrip->ver_neg == NTRIP_VER_2)));
 
-    tracet(NULL, 3, "reqntrip_s: state=%d\n", ntrip->state);
+    tracet(NULL, 3, "reqntrip_s: state=%d ver=%d\n", ntrip->state, ntrip->ver);
 
-    p += sprintf(p, "SOURCE %s %s\r\n", ntrip->passwd, ntrip->mntpnt);
-    p += sprintf(p, "Source-Agent: NTRIP %s\r\n", NTRIP_AGENT);
-    p += sprintf(p, "STR: %s\r\n", ntrip->str);
-    p += sprintf(p, "\r\n");
+    if (use_v2) {
+        /* NTRIP v2: POST with HTTP/1.1 (use absolute URL for proxy) */
+        if (*ntrip->url) {
+            BUFADD(p, rem, "POST %s/%s HTTP/1.1\r\n", ntrip->url, ntrip->mntpnt);
+        } else {
+            BUFADD(p, rem, "POST /%s HTTP/1.1\r\n", ntrip->mntpnt);
+        }
+        BUFADD(p, rem, "Host: %s\r\n", ntrip->host);
+        BUFADD(p, rem, "Ntrip-Version: Ntrip/2.0\r\n");
+        BUFADD(p, rem, "User-Agent: NTRIP %s\r\n", NTRIP_AGENT);
+        if (*ntrip->user) {
+            snprintf(user, sizeof(user), "%s:%s", ntrip->user, ntrip->passwd);
+            BUFADD(p, rem, "Authorization: Basic ");
+            if (rem > 0) {
+                int b64_need = (int)(((strlen(user) + 2) / 3) * 4 + 1);
+                if (b64_need > rem) { sprintf(msg, "request buffer overflow"); return 0; }
+                int n = encbase64(p, (uint8_t*)user, strlen(user));
+                p += n;
+                rem -= n;
+            }
+            BUFADD(p, rem, "\r\n");
+        }
+        BUFADD(p, rem, "Transfer-Encoding: chunked\r\n");
+        BUFADD(p, rem, "\r\n");
+    } else {
+        /* NTRIP v1: SOURCE command */
+        BUFADD(p, rem, "SOURCE %s %s\r\n", ntrip->passwd, ntrip->mntpnt);
+        BUFADD(p, rem, "Source-Agent: NTRIP %s\r\n", NTRIP_AGENT);
+        BUFADD(p, rem, "STR: %s\r\n", ntrip->str);
+        BUFADD(p, rem, "\r\n");
+    }
 
-    if (writetcpcli(ntrip->tcp, (uint8_t*)buff, p - buff, msg) != p - buff) {
+    if (rem <= 0) {
+        sprintf(msg, "request buffer overflow");
+        return 0;
+    }
+    if (writetcpcli(ntrip->tcp, (uint8_t*)buff, (int)(p - buff), msg) != (int)(p - buff)) {
         return 0;
     }
 
-    tracet(NULL, 3, "reqntrip_s: send request state=%d ns=%d\n", ntrip->state, p - buff);
-    tracet(NULL, 5, "reqntrip_s: n=%d buff=\n%s\n", p - buff, buff);
+    tracet(NULL, 3, "reqntrip_s: send request state=%d ns=%d v2=%d\n", ntrip->state, (int)(p - buff), use_v2);
+    tracet(NULL, 5, "reqntrip_s: n=%d buff=\n%s\n", (int)(p - buff), buff);
     ntrip->state = 1;
     return 1;
 }
 /* send ntrip client request -------------------------------------------------*/
 static int reqntrip_c(ntrip_t* ntrip, char* msg) {
-    char buff[MAXSTRPATH + 1024], user[514], *p = buff;
+    char buff[2048], user[514], *p = buff;
+    int rem = (int)sizeof(buff);
+    int use_v2 = (ntrip->ver == NTRIP_VER_2 ||
+                  (ntrip->ver == NTRIP_VER_AUTO &&
+                   (!ntrip->v2_tried || ntrip->ver_neg == NTRIP_VER_2)));
 
-    tracet(NULL, 3, "reqntrip_c: state=%d\n", ntrip->state);
+    tracet(NULL, 3, "reqntrip_c: state=%d ver=%d\n", ntrip->state, ntrip->ver);
 
-    p += sprintf(p, "GET %s/%s HTTP/1.0\r\n", ntrip->url, ntrip->mntpnt);
-    p += sprintf(p, "User-Agent: NTRIP %s\r\n", NTRIP_AGENT);
+    if (use_v2) {
+        /* NTRIP v2: HTTP/1.1 with Host and Ntrip-Version headers */
+        BUFADD(p, rem, "GET %s/%s HTTP/1.1\r\n", ntrip->url, ntrip->mntpnt);
+        BUFADD(p, rem, "Host: %s\r\n", ntrip->host);
+        BUFADD(p, rem, "Ntrip-Version: Ntrip/2.0\r\n");
+        BUFADD(p, rem, "User-Agent: NTRIP %s\r\n", NTRIP_AGENT);
 
-    if (!*ntrip->user) {
-        p += sprintf(p, "Accept: */*\r\n");
-        p += sprintf(p, "Connection: close\r\n");
+        if (*ntrip->user) {
+            snprintf(user, sizeof(user), "%s:%s", ntrip->user, ntrip->passwd);
+            BUFADD(p, rem, "Authorization: Basic ");
+            if (rem > 0) {
+                int b64_need = (int)(((strlen(user) + 2) / 3) * 4 + 1);
+                if (b64_need > rem) { sprintf(msg, "request buffer overflow"); return 0; }
+                int n = encbase64(p, (uint8_t*)user, strlen(user));
+                p += n;
+                rem -= n;
+            }
+            BUFADD(p, rem, "\r\n");
+        }
+        BUFADD(p, rem, "Connection: close\r\n");
+        BUFADD(p, rem, "\r\n");
     } else {
-        sprintf(user, "%s:%s", ntrip->user, ntrip->passwd);
-        p += sprintf(p, "Authorization: Basic ");
-        p += encbase64(p, (uint8_t*)user, strlen(user));
-        p += sprintf(p, "\r\n");
-    }
-    p += sprintf(p, "\r\n");
+        /* NTRIP v1: HTTP/1.0 (original) */
+        BUFADD(p, rem, "GET %s/%s HTTP/1.0\r\n", ntrip->url, ntrip->mntpnt);
+        BUFADD(p, rem, "User-Agent: NTRIP %s\r\n", NTRIP_AGENT);
 
-    if (writetcpcli(ntrip->tcp, (uint8_t*)buff, p - buff, msg) != p - buff) {
+        if (!*ntrip->user) {
+            BUFADD(p, rem, "Accept: */*\r\n");
+            BUFADD(p, rem, "Connection: close\r\n");
+        } else {
+            snprintf(user, sizeof(user), "%s:%s", ntrip->user, ntrip->passwd);
+            BUFADD(p, rem, "Authorization: Basic ");
+            if (rem > 0) {
+                int b64_need = (int)(((strlen(user) + 2) / 3) * 4 + 1);
+                if (b64_need > rem) { sprintf(msg, "request buffer overflow"); return 0; }
+                int n = encbase64(p, (uint8_t*)user, strlen(user));
+                p += n;
+                rem -= n;
+            }
+            BUFADD(p, rem, "\r\n");
+        }
+        BUFADD(p, rem, "\r\n");
+    }
+
+    if (rem <= 0) {
+        sprintf(msg, "request buffer overflow");
+        return 0;
+    }
+    if (writetcpcli(ntrip->tcp, (uint8_t*)buff, (int)(p - buff), msg) != (int)(p - buff)) {
         return 0;
     }
 
-    tracet(NULL, 3, "reqntrip_c: send request state=%d ns=%d\n", ntrip->state, p - buff);
-    tracet(NULL, 5, "reqntrip_c: n=%d buff=\n%s\n", p - buff, buff);
+    tracet(NULL, 3, "reqntrip_c: send request state=%d ns=%d v2=%d\n", ntrip->state, (int)(p - buff), use_v2);
+    tracet(NULL, 5, "reqntrip_c: n=%d buff=\n%s\n", (int)(p - buff), buff);
     ntrip->state = 1;
     return 1;
 }
 /* test ntrip server response ------------------------------------------------*/
 static int rspntrip_s(ntrip_t* ntrip, char* msg) {
-    int i, nb;
+    int i, nb, body_off, status;
     char *p, *q;
 
     tracet(NULL, 3, "rspntrip_s: state=%d nb=%d\n", ntrip->state, ntrip->nb);
-    ntrip->buff[ntrip->nb] = '0';
+    ntrip->buff[ntrip->nb] = '\0';
     tracet(NULL, 5, "rspntrip_s: n=%d buff=\n%s\n", ntrip->nb, ntrip->buff);
 
-    if ((p = strstr((char*)ntrip->buff, NTRIP_RSP_OK_SVR))) { /* ok */
+    if ((p = strstr((char*)ntrip->buff, NTRIP_RSP_OK_SVR))) { /* v1 ok */
         q = (char*)ntrip->buff;
         p += strlen(NTRIP_RSP_OK_SVR);
-        ntrip->nb -= p - q;
+        ntrip->nb -= (int)(p - q);
         for (i = 0; i < ntrip->nb; i++) {
             *q++ = *p++;
         }
         ntrip->state = 2;
+        ntrip->ver_neg = NTRIP_VER_1;
         sprintf(msg, "%s/%s", ntrip->tcp->svr.saddr, ntrip->mntpnt);
-        tracet(NULL, 3, "rspntrip_s: response ok nb=%d\n", ntrip->nb);
+        tracet(NULL, 3, "rspntrip_s: v1 response ok nb=%d\n", ntrip->nb);
         return 1;
-    } else if ((p = strstr((char*)ntrip->buff, NTRIP_RSP_ERROR))) { /* error */
+    }
+    /* check for HTTP/1.1 response (NTRIP v2 caster) */
+    if ((body_off = http_header_end(ntrip->buff, ntrip->nb)) > 0) {
+        status = http_status_code(ntrip->buff, ntrip->nb);
+
+        if (status == 200) {
+            ntrip->state = 2;
+            ntrip->ver_neg = NTRIP_VER_2;
+            /* shift remaining data to start of buffer */
+            ntrip->nb -= body_off;
+            if (ntrip->nb > 0) {
+                memmove(ntrip->buff, ntrip->buff + body_off, ntrip->nb);
+            }
+            sprintf(msg, "%s/%s", ntrip->tcp->svr.saddr, ntrip->mntpnt);
+            tracet(NULL, 3, "rspntrip_s: v2 response ok nb=%d\n", ntrip->nb);
+            return 1;
+        }
+        /* HTTP error response */
+        snprintf(msg, MAXSTATMSG, "%s", (char*)ntrip->buff);
+        tracet(NULL, 3, "rspntrip_s: http error %s nb=%d\n", msg, ntrip->nb);
+        ntrip->nb = 0;
+        ntrip->buff[0] = '\0';
+        ntrip->state = 0;
+        discontcp(&ntrip->tcp->svr, ntrip->tcp->tirecon);
+        return 0;
+    }
+    if ((p = strstr((char*)ntrip->buff, NTRIP_RSP_ERROR))) { /* v1 error */
         nb = ntrip->nb < MAXSTATMSG ? ntrip->nb : MAXSTATMSG;
         sprintf(msg, "%.*s", nb, (char*)ntrip->buff);
         if ((p = strchr(msg, '\r'))) {
@@ -1529,28 +1673,100 @@ static int rspntrip_s(ntrip_t* ntrip, char* msg) {
 }
 /* test ntrip client response ------------------------------------------------*/
 static int rspntrip_c(ntrip_t* ntrip, char* msg) {
-    int i;
-    char *p, *q;
+    int i, body_off, status;
+    char *p, *q, val[256];
 
     tracet(NULL, 3, "rspntrip_c: state=%d nb=%d\n", ntrip->state, ntrip->nb);
-    ntrip->buff[ntrip->nb] = '0';
+    ntrip->buff[ntrip->nb] = '\0';
     tracet(NULL, 5, "rspntrip_c: n=%d buff=\n%s\n", ntrip->nb, ntrip->buff);
 
-    if ((p = strstr((char*)ntrip->buff, NTRIP_RSP_OK_CLI))) { /* ok */
+    if ((p = strstr((char*)ntrip->buff, NTRIP_RSP_OK_CLI))) { /* v1 ok: ICY 200 OK */
         q = (char*)ntrip->buff;
         p += strlen(NTRIP_RSP_OK_CLI);
-        ntrip->nb -= p - q;
+        ntrip->nb -= (int)(p - q);
         for (i = 0; i < ntrip->nb; i++) {
             *q++ = *p++;
         }
         ntrip->state = 2;
+        ntrip->ver_neg = NTRIP_VER_1;
+        ntrip->chunked = 0;
+        if (ntrip->ver == NTRIP_VER_AUTO) {
+            ntrip->v2_tried = 1; /* accepted v2 request with v1 response */
+        }
         sprintf(msg, "%s/%s", ntrip->tcp->svr.saddr, ntrip->mntpnt);
-        tracet(NULL, 3, "rspntrip_c: response ok nb=%d\n", ntrip->nb);
+        tracet(NULL, 3, "rspntrip_c: v1 response ok nb=%d\n", ntrip->nb);
         return 1;
     }
-    if ((p = strstr((char*)ntrip->buff, NTRIP_RSP_SRCTBL))) { /* source table */
+    /* check for HTTP/1.1 response (NTRIP v2) */
+    if ((body_off = http_header_end(ntrip->buff, ntrip->nb)) > 0) {
+        status = http_status_code(ntrip->buff, ntrip->nb);
+
+        if (status == 200) {
+            /* check for NTRIP v2 source table */
+            if (http_find_header(ntrip->buff, body_off, "Content-Type", val, sizeof(val)) &&
+                strstr(val, "sourcetable")) {
+                if (!*ntrip->mntpnt) { /* source table request */
+                    int is_chunked = 0;
+                    ntrip->state = 2;
+                    ntrip->ver_neg = NTRIP_VER_2;
+                    /* check for chunked encoding before shifting headers away */
+                    if (http_find_header(ntrip->buff, body_off, "Transfer-Encoding", val, sizeof(val)) &&
+                        stristr(val, "chunked")) {
+                        is_chunked = 1;
+                    }
+                    /* shift body to start of buffer */
+                    ntrip->nb -= body_off;
+                    memmove(ntrip->buff, ntrip->buff + body_off, ntrip->nb);
+                    /* enable persistent chunked decoding for incremental reads.
+                     * ntrip->buff remains encoded; readntrip() decodes on demand */
+                    if (is_chunked) {
+                        ntrip->chunked = 1;
+                        chunk_dec_init(&ntrip->cdec);
+                    }
+                    sprintf(msg, "source table received");
+                    tracet(NULL, 3, "rspntrip_c: v2 source table nb=%d\n", ntrip->nb);
+                    return 1;
+                }
+                sprintf(msg, "no mountp. reconnect...");
+                tracet(NULL, 2, "rspntrip_c: v2 no mount point nb=%d\n", ntrip->nb);
+                ntrip->nb = 0;
+                ntrip->buff[0] = '\0';
+                ntrip->state = 0;
+                discontcp(&ntrip->tcp->svr, ntrip->tcp->tirecon);
+                return 0;
+            }
+            /* NTRIP v2 data stream OK */
+            ntrip->state = 2;
+            ntrip->ver_neg = NTRIP_VER_2;
+
+            /* detect chunked transfer encoding */
+            if (http_find_header(ntrip->buff, body_off, "Transfer-Encoding", val, sizeof(val)) &&
+                stristr(val, "chunked")) {
+                ntrip->chunked = 1;
+                chunk_dec_init(&ntrip->cdec);
+            }
+            /* shift remaining body data to start of buffer */
+            ntrip->nb -= body_off;
+            if (ntrip->nb > 0) {
+                memmove(ntrip->buff, ntrip->buff + body_off, ntrip->nb);
+            }
+            sprintf(msg, "%s/%s", ntrip->tcp->svr.saddr, ntrip->mntpnt);
+            tracet(NULL, 3, "rspntrip_c: v2 response ok chunked=%d nb=%d\n", ntrip->chunked, ntrip->nb);
+            return 1;
+        }
+        /* HTTP error response */
+        snprintf(msg, MAXSTATMSG, "%s", (char*)ntrip->buff);
+        tracet(NULL, 3, "rspntrip_c: http error %s nb=%d\n", msg, ntrip->nb);
+        ntrip->nb = 0;
+        ntrip->buff[0] = '\0';
+        ntrip->state = 0;
+        discontcp(&ntrip->tcp->svr, ntrip->tcp->tirecon);
+        return 0;
+    }
+    if ((p = strstr((char*)ntrip->buff, NTRIP_RSP_SRCTBL))) { /* v1 source table */
         if (!*ntrip->mntpnt) {                                /* source table request */
             ntrip->state = 2;
+            ntrip->ver_neg = NTRIP_VER_1;
             sprintf(msg, "source table received");
             tracet(NULL, 3, "rspntrip_c: receive source table nb=%d\n", ntrip->nb);
             return 1;
@@ -1561,21 +1777,9 @@ static int rspntrip_c(ntrip_t* ntrip, char* msg) {
         ntrip->buff[0] = '\0';
         ntrip->state = 0;
         discontcp(&ntrip->tcp->svr, ntrip->tcp->tirecon);
-    } else if ((p = strstr((char*)ntrip->buff, NTRIP_RSP_HTTP))) { /* http response */
-        if ((q = strchr(p, '\r'))) {
-            *q = '\0';
-        } else {
-            ntrip->buff[128] = '\0';
-        }
-        strcpy(msg, p);
-        tracet(NULL, 3, "rspntrip_s: %s nb=%d\n", msg, ntrip->nb);
-        ntrip->nb = 0;
-        ntrip->buff[0] = '\0';
-        ntrip->state = 0;
-        discontcp(&ntrip->tcp->svr, ntrip->tcp->tirecon);
     } else if (ntrip->nb >= NTRIP_MAXRSP) { /* buffer overflow */
         sprintf(msg, "response overflow");
-        tracet(NULL, 2, "rspntrip_s: response overflow nb=%d\n", ntrip->nb);
+        tracet(NULL, 2, "rspntrip_c: response overflow nb=%d\n", ntrip->nb);
         ntrip->nb = 0;
         ntrip->buff[0] = '\0';
         ntrip->state = 0;
@@ -1597,6 +1801,15 @@ static int waitntrip(ntrip_t* ntrip, char* msg) {
 
     if (ntrip->tcp->svr.state < 2) {
         ntrip->state = 0; /* tcp disconnected */
+
+        /* AUTO fallback: only switch to v1 if connection dropped before any
+         * response was received. If an HTTP response was seen (nb>0), the
+         * caster supports v2 and the error is auth/mountpoint, not protocol */
+        if (ntrip->ver == NTRIP_VER_AUTO && ntrip->v2_tried && ntrip->ver_neg == 0 &&
+            ntrip->nb == 0) {
+            tracet(NULL, 3, "waitntrip: v2 failed before response, falling back to v1\n");
+            ntrip->v2_tried = 2; /* mark as fallen back */
+        }
     }
 
     if (ntrip->state == 0) { /* send request */
@@ -1608,6 +1821,10 @@ static int waitntrip(ntrip_t* ntrip, char* msg) {
         }
         if (!req_ok) {
             return 0;
+        }
+        /* mark v2 as tried for AUTO mode */
+        if (ntrip->ver == NTRIP_VER_AUTO && !ntrip->v2_tried) {
+            ntrip->v2_tried = 1;
         }
         tracet(NULL, 3, "waitntrip: state=%d nb=%d\n", ntrip->state, ntrip->nb);
     }
@@ -1629,6 +1846,69 @@ static int waitntrip(ntrip_t* ntrip, char* msg) {
     }
     return 1;
 }
+/* parse query parameters from mountpoint string
+ * supported: ?ver=N (NTRIP version), &host=HOSTNAME (Host header override)
+ * strips the query string from mntpnt
+ * query string is copied to a local buffer to avoid modifying mntpnt beyond '?' */
+static int parse_ntrip_query(char* mntpnt, char* host_override, int host_size) {
+    char params[256], *p, *next;
+    char *q;
+    int ver = ntrip_ver_default;
+
+    host_override[0] = '\0';
+
+    q = strchr(mntpnt, '?');
+    if (!q) {
+        return ver;
+    }
+
+    /* copy query string to local buffer before truncating mntpnt */
+    snprintf(params, sizeof(params), "%s", q + 1);
+    *q = '\0'; /* strip query string from mountpoint */
+
+    tracet(NULL, 3, "parse_ntrip_query: mntpnt=%s params=%s\n", mntpnt, params);
+
+    /* parse &-separated parameters manually (no strtok) */
+    p = params;
+    while (*p) {
+        /* find end of current parameter */
+        next = strchr(p, '&');
+        if (next) {
+            *next = '\0';
+        }
+
+        if (strncmp(p, "ver=", 4) == 0) {
+            int v = atoi(p + 4);
+            if (v == 1) {
+                ver = NTRIP_VER_1;
+            } else if (v == 2) {
+                ver = NTRIP_VER_2;
+            }
+        } else if (strncmp(p, "host=", 5) == 0) {
+            const char *h = p + 5;
+            int valid = 1, hlen = 0;
+            /* reject control characters and whitespace to prevent header injection */
+            while (h[hlen]) {
+                if ((unsigned char)h[hlen] <= 0x20 || h[hlen] == 0x7F) {
+                    valid = 0;
+                    break;
+                }
+                hlen++;
+            }
+            if (valid && hlen > 0) {
+                snprintf(host_override, host_size, "%s", h);
+            }
+        }
+
+        if (next) {
+            p = next + 1;
+        } else {
+            break;
+        }
+    }
+    tracet(NULL, 3, "parse_ntrip_query: ver=%d host_override=%s\n", ver, host_override);
+    return ver;
+}
 /* open ntrip ----------------------------------------------------------------*/
 static ntrip_t* openntrip(const char* path, int type, char* msg) {
     ntrip_t* ntrip;
@@ -1644,20 +1924,39 @@ static ntrip_t* openntrip(const char* path, int type, char* msg) {
     ntrip->state = 0;
     ntrip->type = type; /* 0:server,1:client */
     ntrip->nb = 0;
+    ntrip->ver = NTRIP_VER_AUTO;
+    ntrip->ver_neg = 0;
+    ntrip->chunked = 0;
+    ntrip->v2_tried = 0;
     ntrip->url[0] = '\0';
+    ntrip->host[0] = '\0';
     ntrip->mntpnt[0] = ntrip->user[0] = ntrip->passwd[0] = ntrip->str[0] = '\0';
     for (i = 0; i < NTRIP_MAXRSP; i++) {
         ntrip->buff[i] = 0;
     }
+    chunk_dec_init(&ntrip->cdec);
 
     /* decode tcp/ntrip path */
     decodetcppath(path, addr, port, ntrip->user, ntrip->passwd, ntrip->mntpnt, ntrip->str);
 
-    /* use default port if no port specified */
-    if (!*port) {
-        sprintf(port, "%d", type ? NTRIP_CLI_PORT : NTRIP_SVR_PORT);
+    /* parse query parameters (?ver=N&host=HOSTNAME) from mountpoint */
+    {
+        char host_override[256] = "";
+        ntrip->ver = parse_ntrip_query(ntrip->mntpnt, host_override, sizeof(host_override));
+
+        /* use default port if no port specified */
+        if (!*port) {
+            sprintf(port, "%d", type ? NTRIP_CLI_PORT : NTRIP_SVR_PORT);
+        }
+        sprintf(tpath, "%s:%s", addr, port);
+
+        /* save host header value (host= override takes priority) */
+        if (*host_override) {
+            snprintf(ntrip->host, sizeof(ntrip->host), "%s", host_override);
+        } else {
+            snprintf(ntrip->host, sizeof(ntrip->host), "%s:%s", addr, port);
+        }
     }
-    sprintf(tpath, "%s:%s", addr, port);
 
     /* ntrip access via proxy server */
     if (*proxyaddr) {
@@ -1670,12 +1969,19 @@ static ntrip_t* openntrip(const char* path, int type, char* msg) {
         free(ntrip);
         return NULL;
     }
+    tracet(NULL, 3, "openntrip: ver=%d host=%s mntpnt=%s\n", ntrip->ver, ntrip->host, ntrip->mntpnt);
     return ntrip;
 }
 /* close ntrip ---------------------------------------------------------------*/
 static void closentrip(ntrip_t* ntrip) {
     tracet(NULL, 3, "closentrip: state=%d\n", ntrip->state);
 
+    /* send chunked terminator for v2 server before closing */
+    if (ntrip->ver_neg == NTRIP_VER_2 && ntrip->type == 0 && ntrip->state == 2) {
+        char msg_tmp[MAXSTRMSG] = "";
+        uint8_t term[] = "0\r\n\r\n";
+        writetcpcli(ntrip->tcp, term, 5, msg_tmp);
+    }
     closetcpcli(ntrip->tcp);
     free(ntrip);
 }
@@ -1690,10 +1996,60 @@ static int readntrip(ntrip_t* ntrip, uint8_t* buff, int n, char* msg) {
     }
 
     if (ntrip->nb > 0) { /* read response buffer first */
+        if (ntrip->chunked) {
+            /* decode directly from ntrip->buff into caller's buff */
+            const uint8_t* in = ntrip->buff;
+            int nin = ntrip->nb;
+            int nd = chunk_decode(&ntrip->cdec, &in, &nin, buff, n);
+            if (nd < 0) {
+                tracet(NULL, 2, "readntrip: chunk decode error, resetting\n");
+                ntrip->nb = 0;
+                chunk_dec_init(&ntrip->cdec);
+                return 0;
+            }
+            /* compact: remove consumed bytes from ntrip->buff */
+            if (nin > 0) {
+                memmove(ntrip->buff, in, nin);
+            }
+            ntrip->nb = nin;
+            return nd;
+        }
         nb = ntrip->nb <= n ? ntrip->nb : n;
-        memcpy(buff, ntrip->buff + ntrip->nb - nb, nb);
-        ntrip->nb = 0;
+        memcpy(buff, ntrip->buff, nb);
+        if (nb < ntrip->nb) {
+            memmove(ntrip->buff, ntrip->buff + nb, ntrip->nb - nb);
+        }
+        ntrip->nb -= nb;
         return nb;
+    }
+    if (ntrip->chunked) {
+        /* read raw TCP data and decode chunks */
+        uint8_t raw[4096];
+        int nr = readtcpcli(ntrip->tcp, raw, sizeof(raw), msg);
+        if (nr <= 0) {
+            return 0;
+        }
+        const uint8_t* in = raw;
+        int nin = nr;
+        int nd = chunk_decode(&ntrip->cdec, &in, &nin, buff, n);
+        if (nd < 0) {
+            tracet(NULL, 2, "readntrip: chunk decode error, resetting\n");
+            ntrip->nb = 0;
+            chunk_dec_init(&ntrip->cdec);
+            return 0;
+        }
+        /* preserve unconsumed encoded bytes to response buffer */
+        if (nin > 0) {
+            if (ntrip->nb + nin <= NTRIP_MAXRSP) {
+                memcpy(ntrip->buff + ntrip->nb, in, nin);
+                ntrip->nb += nin;
+            } else {
+                tracet(NULL, 2, "readntrip: chunk buffer overflow, resetting\n");
+                ntrip->nb = 0;
+                chunk_dec_init(&ntrip->cdec);
+            }
+        }
+        return nd;
     }
     return readtcpcli(ntrip->tcp, buff, n, msg);
 }
@@ -1705,6 +2061,22 @@ static int writentrip(ntrip_t* ntrip, uint8_t* buff, int n, char* msg) {
         return 0;
     }
 
+    /* v2 server: use chunked transfer encoding */
+    if (ntrip->ver_neg == NTRIP_VER_2 && ntrip->type == 0) {
+        uint8_t cbuf[4096 + 20];
+        int remaining = n, sent = 0;
+
+        while (remaining > 0) {
+            int chunk = remaining < 4096 ? remaining : 4096;
+            int cn = chunk_encode(cbuf, sizeof(cbuf), buff + sent, chunk);
+            if (cn < 0 || writetcpcli(ntrip->tcp, cbuf, cn, msg) != cn) {
+                return sent;
+            }
+            sent += chunk;
+            remaining -= chunk;
+        }
+        return sent;
+    }
     return writetcpcli(ntrip->tcp, buff, n, msg);
 }
 /* get state ntrip -----------------------------------------------------------*/
@@ -1723,8 +2095,12 @@ static int statexntrip(ntrip_t* ntrip, char* msg) {
     }
     p += sprintf(p, "  state   = %d\n", state);
     p += sprintf(p, "  type    = %d\n", ntrip->type);
+    p += sprintf(p, "  ver     = %d\n", ntrip->ver);
+    p += sprintf(p, "  ver_neg = %d\n", ntrip->ver_neg);
+    p += sprintf(p, "  chunked = %d\n", ntrip->chunked);
     p += sprintf(p, "  nb      = %d\n", ntrip->nb);
     p += sprintf(p, "  url     = %s\n", ntrip->url);
+    p += sprintf(p, "  host    = %s\n", ntrip->host);
     p += sprintf(p, "  mntpnt  = %s\n", ntrip->mntpnt);
     p += sprintf(p, "  user    = %s\n", ntrip->user);
     p += sprintf(p, "  passwd  = %s\n", ntrip->passwd);
@@ -1749,6 +2125,7 @@ static ntripc_t* openntripc(const char* path, char* msg) {
     ntripc->mntpnt[0] = ntripc->user[0] = ntripc->passwd[0] = ntripc->srctbl[0] = '\0';
     for (i = 0; i < MAXCLI; i++) {
         ntripc->con[i].state = 0;
+        ntripc->con[i].ver = 1;
         ntripc->con[i].nb = 0;
         memset(ntripc->con[i].buff, 0, NTRIP_MAXRSP);
     }
@@ -1776,8 +2153,16 @@ static ntripc_t* openntripc(const char* path, char* msg) {
 }
 /* close ntrip-caster --------------------------------------------------------*/
 static void closentripc(ntripc_t* ntripc) {
+    int i;
     tracet(NULL, 3, "closentripc: state=%d\n", ntripc->state);
 
+    /* send chunked terminator for all connected v2 clients */
+    for (i = 0; i < MAXCLI; i++) {
+        if (ntripc->con[i].state && ntripc->con[i].ver >= 2) {
+            uint8_t term[] = "0\r\n\r\n";
+            send_nb(ntripc->tcp->cli[i].sock, term, 5);
+        }
+    }
     closetcpsvr(ntripc->tcp);
     free(ntripc);
 }
@@ -1785,9 +2170,15 @@ static void closentripc(ntripc_t* ntripc) {
 static void discon_ntripc(ntripc_t* ntripc, int i) {
     tracet(NULL, 3, "discon_ntripc: i=%d\n", i);
 
+    /* send chunked terminator for v2 clients before disconnecting */
+    if (ntripc->con[i].ver >= 2 && ntripc->con[i].state) {
+        uint8_t term[] = "0\r\n\r\n";
+        send_nb(ntripc->tcp->cli[i].sock, term, 5);
+    }
     discontcp(&ntripc->tcp->cli[i], ticonnect);
     ntripc->con[i].nb = 0;
     ntripc->con[i].buff[0] = '\0';
+    ntripc->con[i].ver = 1;
     ntripc->con[i].state = 0;
 }
 /* http date-time string -----------------------------------------------------*/
@@ -1836,6 +2227,7 @@ static void send_rsp_ok(int ver, socket_t sock) {
         p += sprintf(p, "Date: %s\r\n", tstr);
         p += sprintf(p, "Cache-Control: no-store, no-cache, max-age=0\r\n");
         p += sprintf(p, "Pragma: no-cache\r\n");
+        p += sprintf(p, "Transfer-Encoding: chunked\r\n");
         p += sprintf(p, "Connection: close\r\n");
         p += sprintf(p, "Content-Type: gnss/data\r\n\r\n");
     }
@@ -1891,9 +2283,12 @@ static void rsp_ntripc(ntripc_t* ntripc, int i) {
         discon_ntripc(ntripc, i);
         return;
     }
-    /* test NTRIP version */
+    /* test NTRIP version (clamp to 1 or 2) */
     if ((p = strstr((char*)con->buff, "Ntrip-Version:"))) {
         sscanf(p + 14, " Ntrip/%d", &ver);
+        if (ver < 1 || ver > 2) {
+            ver = 1; /* treat unsupported versions as v1 */
+        }
     }
     if ((p = strchr(url, '/'))) {
         strcpy(mntpnt, p + 1);
@@ -1929,6 +2324,7 @@ static void rsp_ntripc(ntripc_t* ntripc, int i) {
     send_rsp_ok(ver, ntripc->tcp->cli[i].sock);
 
     con->state = 1;
+    con->ver = ver;
     strcpy(con->mntpnt, mntpnt);
 }
 /* handle ntrip client connect request ---------------------------------------*/
@@ -2009,15 +2405,43 @@ static int writentripc(ntripc_t* ntripc, uint8_t* buff, int n, char* msg) {
             continue;
         }
 
-        ns = send_nb(ntripc->tcp->cli[i].sock, buff, n);
+        if (ntripc->con[i].ver >= 2) {
+            /* v2 client: use chunked transfer encoding */
+            uint8_t cbuf[4096 + 20];
+            int remaining = n, sent = 0;
 
-        if (ns < n) {
-            if ((err = errsock())) {
-                tracet(NULL, 2, "writentripc: send error i=%d sock=%d err=%d\n", i, ntripc->tcp->cli[i].sock, err);
+            while (remaining > 0) {
+                int chunk = remaining < 4096 ? remaining : 4096;
+                int cn = chunk_encode(cbuf, sizeof(cbuf), buff + sent, chunk);
+                if (cn < 0) {
+                    break;
+                }
+                if (send_nb(ntripc->tcp->cli[i].sock, cbuf, cn) < cn) {
+                    if ((err = errsock())) {
+                        tracet(NULL, 2, "writentripc: send error i=%d err=%d\n", i, err);
+                    }
+                    discon_ntripc(ntripc, i);
+                    break;
+                }
+                sent += chunk;
+                remaining -= chunk;
             }
-            discon_ntripc(ntripc, i);
+            if (remaining <= 0) {
+                ntripc->tcp->cli[i].tact = tickget();
+                ns = n; /* return payload bytes, not encoded bytes */
+            }
         } else {
-            ntripc->tcp->cli[i].tact = tickget();
+            /* v1 client: raw data */
+            ns = send_nb(ntripc->tcp->cli[i].sock, buff, n);
+
+            if (ns < n) {
+                if ((err = errsock())) {
+                    tracet(NULL, 2, "writentripc: send error i=%d sock=%d err=%d\n", i, ntripc->tcp->cli[i].sock, err);
+                }
+                discon_ntripc(ntripc, i);
+            } else {
+                ntripc->tcp->cli[i].tact = tickget();
+            }
         }
     }
     return ns;
@@ -3223,6 +3647,18 @@ extern void strsetproxy(const char* addr) {
     tracet(NULL, 3, "strsetproxy: addr=%s\n", addr);
 
     strcpy(proxyaddr, addr);
+}
+/* set default ntrip version ---------------------------------------------------
+ * set default NTRIP version for new connections
+ * args   : int ver     I   NTRIP version (0:auto, 1:v1, 2:v2)
+ * return : none
+ *-----------------------------------------------------------------------------*/
+extern void strsetntripver(int ver) {
+    tracet(NULL, 3, "strsetntripver: ver=%d\n", ver);
+
+    if (ver >= 0 && ver <= 2) {
+        ntrip_ver_default = ver;
+    }
 }
 /* get stream time -------------------------------------------------------------
  * get stream time

--- a/src/stream/ntrip_chunk.h
+++ b/src/stream/ntrip_chunk.h
@@ -1,0 +1,347 @@
+/*------------------------------------------------------------------------------
+ * ntrip_chunk.h : NTRIP v2 chunked transfer encoding and HTTP helpers
+ *
+ * Copyright (C) 2026 H.SHIONO (MRTKLIB Project)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This is a header-only implementation intended to be #included by both
+ * mrtk_stream.c and test code (t_ntrip.c).  All functions are static.
+ *----------------------------------------------------------------------------*/
+#ifndef NTRIP_CHUNK_H
+#define NTRIP_CHUNK_H
+
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#if defined(_WIN32) || defined(_WIN64)
+#ifndef strncasecmp
+#define strncasecmp _strnicmp
+#endif
+#else
+#include <strings.h> /* strncasecmp on POSIX (Linux, macOS, BSD, etc.) */
+#endif
+
+/*============================================================================
+ * NTRIP Version Constants
+ *===========================================================================*/
+
+#define NTRIP_VER_AUTO 0 /* auto-detect (try v2, fallback v1) */
+#define NTRIP_VER_1 1    /* NTRIP version 1.0 */
+#define NTRIP_VER_2 2    /* NTRIP version 2.0 */
+
+/*============================================================================
+ * Chunked Transfer Encoding Types
+ *===========================================================================*/
+
+#define CHUNK_HDR_MAX 16       /* max chunk-size header length ("FFFFFFFF\r\n") */
+#define CHUNK_SIZE_MAX 0xFFFFFF /* max chunk size (~16 MB, well within int range) */
+
+typedef struct {               /* chunked transfer decoder state */
+    int state;                 /* 0:size, 1:data, 2:trail, 3:done, 4:final_trail */
+    int remain;                /* remaining bytes in current chunk */
+    char hdr[CHUNK_HDR_MAX];   /* partial chunk-size line buffer (hex digits only) */
+    int nhdr;                  /* bytes in hdr[] (-1: frozen after extension) */
+    int at_sol;                /* final_trail: at start of line flag */
+} chunk_dec_t;
+
+/*============================================================================
+ * Chunked Transfer Decoder
+ *===========================================================================*/
+
+/* initialize chunked decoder state */
+static void chunk_dec_init(chunk_dec_t *dec) {
+    dec->state = 0;
+    dec->remain = 0;
+    dec->nhdr = 0;
+    dec->at_sol = 1;
+}
+
+/* decode chunked transfer encoding (incremental, non-blocking)
+ *
+ * Reads from *pin (length *pnin), writes decoded payload to out (max nout).
+ * Advances *pin and decrements *pnin as input is consumed.
+ * Returns number of decoded bytes written to out, or -1 on error.
+ *
+ * State machine:
+ *   0 (SIZE)  : accumulate hex digits + optional extension until \r\n
+ *   1 (DATA)  : copy `remain` bytes from input to output
+ *   2 (TRAIL) : consume trailing \r\n after chunk data
+ *   3 (DONE)  : terminal state (zero-length chunk received)
+ */
+static int chunk_decode(chunk_dec_t *dec, const uint8_t **pin, int *pnin,
+                        uint8_t *out, int nout) {
+    const uint8_t *in = *pin;
+    int nin = *pnin;
+    int nw = 0; /* bytes written to out */
+
+    while (nin > 0 && dec->state != 3) { /* 3 = DONE (terminal) */
+        switch (dec->state) {
+        case 0: /* SIZE: read chunk-size line
+                 * Only hex digits are stored in hdr[]. Once a non-hex char
+                 * (extension ';' etc.) is seen, remaining chars are skipped
+                 * until \r\n, so extensions cannot overflow hdr[]. */
+            while (nin > 0) {
+                char c = (char)*in++;
+                nin--;
+
+                if (c == '\n') {
+                    /* end of chunk-size line: parse accumulated hex digits */
+                    unsigned long size = 0;
+                    int i, nhex, ndigits = 0;
+
+                    /* nhdr == -1 means frozen after extension; use strlen */
+                    nhex = (dec->nhdr >= 0) ? dec->nhdr : (int)strlen(dec->hdr);
+                    for (i = 0; i < nhex; i++) {
+                        int d;
+                        char h = dec->hdr[i];
+                        if (h >= '0' && h <= '9') {
+                            d = h - '0';
+                        } else if (h >= 'a' && h <= 'f') {
+                            d = h - 'a' + 10;
+                        } else if (h >= 'A' && h <= 'F') {
+                            d = h - 'A' + 10;
+                        } else {
+                            break;
+                        }
+                        size = (size << 4) | d;
+                        ndigits++;
+                    }
+                    dec->nhdr = 0;
+
+                    /* reject empty size line or overflow */
+                    if (ndigits == 0 || size > CHUNK_SIZE_MAX) {
+                        *pin = in;
+                        *pnin = nin;
+                        return -1;
+                    }
+                    dec->remain = (int)size;
+
+                    if (dec->remain == 0) {
+                        dec->state = 4; /* consume final trailer CRLF */
+                        dec->at_sol = 1; /* start at line beginning */
+                    } else {
+                        dec->state = 1; /* data follows */
+                    }
+                    break;
+                }
+                /* accumulate hex digits only; once a non-hex char is seen
+                 * (';' extension, space, etc.), stop accumulating.
+                 * Use nhdr == -1 as "frozen" flag to skip further chars */
+                if (dec->nhdr >= 0) {
+                    if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+                        (c >= 'A' && c <= 'F')) {
+                        if (dec->nhdr < CHUNK_HDR_MAX - 1) {
+                            dec->hdr[dec->nhdr++] = c;
+                        } else {
+                            /* too many hex digits: reject as malformed */
+                            *pin = in;
+                            *pnin = nin;
+                            return -1;
+                        }
+                    } else if (c != '\r') {
+                        /* non-hex, non-CR: freeze accumulation (extension/etc.) */
+                        dec->hdr[dec->nhdr] = '\0';
+                        dec->nhdr = -1;
+                    }
+                }
+                /* \r and chars after freeze are silently skipped until \n */
+            }
+            break;
+
+        case 1: { /* DATA: copy chunk payload */
+            int avail = nin < dec->remain ? nin : dec->remain;
+            int space = nout - nw;
+            int copy = avail < space ? avail : space;
+
+            if (copy > 0) {
+                memcpy(out + nw, in, copy);
+                nw += copy;
+                in += copy;
+                nin -= copy;
+                dec->remain -= copy;
+            }
+            if (dec->remain == 0) {
+                dec->state = 2; /* expect trailing \r\n */
+            }
+            if (nw >= nout) {
+                /* output full, return what we have */
+                goto done;
+            }
+            break;
+        }
+        case 2: /* TRAIL: consume \r\n after chunk data */
+            while (nin > 0) {
+                char c = (char)*in++;
+                nin--;
+
+                if (c == '\n') {
+                    dec->state = 0; /* next chunk */
+                    break;
+                }
+                /* skip \r, ignore other chars in trailer */
+            }
+            break;
+
+        case 4: /* FINAL_TRAIL: consume optional trailer headers + final \r\n
+                 * Per RFC 7230, the last-chunk (0\r\n) is followed by optional
+                 * trailer headers and terminated by an empty line (\r\n).
+                 * dec->at_sol persists across calls for incremental parsing. */
+            while (nin > 0 && dec->state != 3) {
+                char c = (char)*in++;
+                nin--;
+
+                if (c == '\r') {
+                    continue; /* skip CR, check LF next */
+                }
+                if (c == '\n') {
+                    if (dec->at_sol) {
+                        dec->state = 3; /* DONE: empty line = end of trailers */
+                        break;
+                    }
+                    dec->at_sol = 1; /* next char starts a new line */
+                } else {
+                    dec->at_sol = 0; /* non-empty line content (trailer header) */
+                }
+            }
+            break;
+        }
+    }
+done:
+    *pin = in;
+    *pnin = nin;
+    return nw;
+}
+
+/*============================================================================
+ * Chunked Transfer Encoder
+ *===========================================================================*/
+
+/* encode data as a single HTTP chunk: "<hex-size>\r\n<data>\r\n"
+ *
+ * Writes to out (max nout bytes).  Returns total bytes written, or -1 if
+ * output buffer is too small.  Caller must ensure nout >= ndata + 20.
+ */
+static int chunk_encode(uint8_t *out, int nout, const uint8_t *data,
+                        int ndata) {
+    char hdr[16];
+    int hlen = snprintf(hdr, sizeof(hdr), "%x\r\n", ndata);
+
+    if (hlen <= 0 || hlen >= (int)sizeof(hdr)) {
+        return -1; /* snprintf error or truncation */
+    }
+    if (hlen + ndata + 2 > nout) {
+        return -1; /* buffer too small */
+    }
+    memcpy(out, hdr, hlen);
+    if (ndata > 0) {
+        memcpy(out + hlen, data, ndata);
+    }
+    out[hlen + ndata] = '\r';
+    out[hlen + ndata + 1] = '\n';
+    return hlen + ndata + 2;
+}
+
+/*============================================================================
+ * HTTP Header Helpers
+ *===========================================================================*/
+
+/* case-insensitive substring search (portable replacement for strcasestr) */
+static const char *stristr(const char *haystack, const char *needle) {
+    int nlen = (int)strlen(needle);
+    if (nlen == 0) {
+        return haystack;
+    }
+    for (; *haystack; haystack++) {
+        if (strncasecmp(haystack, needle, nlen) == 0) {
+            return haystack;
+        }
+    }
+    return NULL;
+}
+
+/* find end of HTTP headers in buffer (bounded search for \r\n\r\n)
+ * returns offset to body start, or 0 if headers are incomplete */
+static int http_header_end(const uint8_t *buff, int nb) {
+    int i;
+    if (nb < 4) {
+        return 0;
+    }
+    for (i = 0; i <= nb - 4; i++) {
+        if (buff[i]     == '\r' && buff[i + 1] == '\n' &&
+            buff[i + 2] == '\r' && buff[i + 3] == '\n') {
+            return i + 4;
+        }
+    }
+    return 0;
+}
+
+/* extract HTTP status code from first line (e.g. "HTTP/1.1 200 OK\r\n")
+ * returns status code (e.g. 200), or 0 if not found */
+static int http_status_code(const uint8_t *buff, int nb) {
+    int i;
+    if (nb < 12) {
+        return 0;
+    }
+    if (strncmp((const char *)buff, "HTTP/", 5) != 0) {
+        return 0;
+    }
+    /* find first space within nb, then parse exactly 3 digits within bounds */
+    for (i = 5; i < nb; i++) {
+        if (buff[i] == ' ') {
+            if (i + 3 >= nb) {
+                return 0;
+            }
+            if (buff[i + 1] >= '0' && buff[i + 1] <= '9' &&
+                buff[i + 2] >= '0' && buff[i + 2] <= '9' &&
+                buff[i + 3] >= '0' && buff[i + 3] <= '9') {
+                return (buff[i + 1] - '0') * 100 +
+                       (buff[i + 2] - '0') * 10 +
+                       (buff[i + 3] - '0');
+            }
+            return 0;
+        }
+    }
+    return 0;
+}
+
+/* search for a specific HTTP header value (case-insensitive header name)
+ * copies value (up to vmax-1 chars) into val, returns 1 if found */
+static int http_find_header(const uint8_t *buff, int nb, const char *name,
+                            char *val, int vmax) {
+    int nlen = (int)strlen(name);
+    const char *p = (const char *)buff;
+    const char *end = p + nb;
+
+    while (p < end) {
+        /* check if enough room for "name:" */
+        if (p + nlen + 1 <= end &&
+            strncasecmp(p, name, nlen) == 0 && p[nlen] == ':') {
+            const char *v = p + nlen + 1;
+            int i = 0;
+            /* skip leading whitespace */
+            while (v < end && (*v == ' ' || *v == '\t')) {
+                v++;
+            }
+            /* copy until \r or \n or end */
+            while (v < end && *v != '\r' && *v != '\n' && i < vmax - 1) {
+                val[i++] = *v++;
+            }
+            val[i] = '\0';
+            return 1;
+        }
+        /* advance to next line */
+        while (p < end && *p != '\n') {
+            p++;
+        }
+        if (p < end) {
+            p++; /* skip \n */
+        }
+    }
+    val[0] = '\0';
+    return 0;
+}
+
+#endif /* NTRIP_CHUNK_H */

--- a/tests/utest/t_ntrip.c
+++ b/tests/utest/t_ntrip.c
@@ -1,0 +1,360 @@
+/*------------------------------------------------------------------------------
+ * t_ntrip.c : unit tests for NTRIP v2 chunked transfer encoding and helpers
+ *
+ * Copyright (C) 2026 H.SHIONO (MRTKLIB Project)
+ * SPDX-License-Identifier: BSD-2-Clause
+ *----------------------------------------------------------------------------*/
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+/* include header-only implementation directly for testing */
+#include "../../src/stream/ntrip_chunk.h"
+
+static int n_pass = 0;
+static int n_fail = 0;
+static int test_failed = 0; /* per-test failure flag */
+
+#define TEST(name)                                      \
+    static void name(void);                             \
+    static void name##_run(void) {                      \
+        printf("  %-50s ", #name);                      \
+        test_failed = 0;                                \
+        name();                                         \
+        if (test_failed) {                              \
+            n_fail++;                                   \
+        } else {                                        \
+            printf("PASS\n");                           \
+            n_pass++;                                   \
+        }                                               \
+    }                                                   \
+    static void name(void)
+
+#define ASSERT(cond)                                    \
+    do {                                                \
+        if (!(cond)) {                                  \
+            printf("FAIL\n    %s:%d: %s\n",             \
+                   __FILE__, __LINE__, #cond);           \
+            test_failed = 1;                            \
+            return;                                     \
+        }                                               \
+    } while (0)
+
+/* ========================================================================== */
+/* chunk_decode tests                                                         */
+/* ========================================================================== */
+
+/* single complete chunk */
+TEST(test_chunk_decode_single) {
+    chunk_dec_t dec;
+    chunk_dec_init(&dec);
+
+    const uint8_t input[] = "5\r\nHello\r\n0\r\n\r\n";
+    const uint8_t *pin = input;
+    int nin = (int)sizeof(input) - 1;
+    uint8_t out[64];
+
+    int nd = chunk_decode(&dec, &pin, &nin, out, sizeof(out));
+    ASSERT(nd == 5);
+    ASSERT(memcmp(out, "Hello", 5) == 0);
+    ASSERT(dec.state == 3);
+}
+
+/* multiple chunks in sequence */
+TEST(test_chunk_decode_multi) {
+    chunk_dec_t dec;
+    chunk_dec_init(&dec);
+
+    const uint8_t input[] = "5\r\nHello\r\n6\r\n World\r\n0\r\n\r\n";
+    const uint8_t *pin = input;
+    int nin = (int)sizeof(input) - 1;
+    uint8_t out[64];
+
+    int nd = chunk_decode(&dec, &pin, &nin, out, sizeof(out));
+    ASSERT(nd == 11);
+    ASSERT(memcmp(out, "Hello World", 11) == 0);
+    ASSERT(dec.state == 3);
+}
+
+/* partial input: feed one byte at a time */
+TEST(test_chunk_decode_partial) {
+    chunk_dec_t dec;
+    chunk_dec_init(&dec);
+
+    const uint8_t input[] = "a\r\n0123456789\r\n0\r\n\r\n";
+    int total_len = (int)sizeof(input) - 1;
+    uint8_t out[64];
+    int total_out = 0;
+
+    for (int i = 0; i < total_len; i++) {
+        const uint8_t *pin = &input[i];
+        int nin = 1;
+        int nd = chunk_decode(&dec, &pin, &nin, out + total_out,
+                              (int)sizeof(out) - total_out);
+        ASSERT(nd >= 0);
+        total_out += nd;
+    }
+    ASSERT(total_out == 10);
+    ASSERT(memcmp(out, "0123456789", 10) == 0);
+    ASSERT(dec.state == 3);
+}
+
+/* zero-length chunk (immediate terminator) */
+TEST(test_chunk_decode_zero) {
+    chunk_dec_t dec;
+    chunk_dec_init(&dec);
+
+    const uint8_t input[] = "0\r\n\r\n";
+    const uint8_t *pin = input;
+    int nin = (int)sizeof(input) - 1;
+    uint8_t out[64];
+
+    int nd = chunk_decode(&dec, &pin, &nin, out, sizeof(out));
+    ASSERT(nd == 0);
+    ASSERT(dec.state == 3);
+}
+
+/* hex size with uppercase letters */
+TEST(test_chunk_decode_hex_upper) {
+    chunk_dec_t dec;
+    chunk_dec_init(&dec);
+
+    const uint8_t input[] = "1A\r\nabcdefghijklmnopqrstuvwxyz\r\n0\r\n\r\n";
+    const uint8_t *pin = input;
+    int nin = (int)sizeof(input) - 1;
+    uint8_t out[64];
+
+    int nd = chunk_decode(&dec, &pin, &nin, out, sizeof(out));
+    ASSERT(nd == 26);
+    ASSERT(memcmp(out, "abcdefghijklmnopqrstuvwxyz", 26) == 0);
+    ASSERT(dec.state == 3);
+}
+
+/* chunk with extension (semicolon after hex size) */
+TEST(test_chunk_decode_extension) {
+    chunk_dec_t dec;
+    chunk_dec_init(&dec);
+
+    const uint8_t input[] = "5;ext=val\r\nHello\r\n0\r\n\r\n";
+    const uint8_t *pin = input;
+    int nin = (int)sizeof(input) - 1;
+    uint8_t out[64];
+
+    int nd = chunk_decode(&dec, &pin, &nin, out, sizeof(out));
+    ASSERT(nd == 5);
+    ASSERT(memcmp(out, "Hello", 5) == 0);
+}
+
+/* output buffer smaller than chunk data */
+TEST(test_chunk_decode_output_limited) {
+    chunk_dec_t dec;
+    chunk_dec_init(&dec);
+
+    const uint8_t input[] = "a\r\n0123456789\r\n0\r\n\r\n";
+    const uint8_t *pin = input;
+    int nin = (int)sizeof(input) - 1;
+    uint8_t out[5];
+
+    /* first call: only 5 bytes fit */
+    int nd = chunk_decode(&dec, &pin, &nin, out, 5);
+    ASSERT(nd == 5);
+    ASSERT(memcmp(out, "01234", 5) == 0);
+
+    /* second call: remaining 5 bytes */
+    nd = chunk_decode(&dec, &pin, &nin, out, 5);
+    ASSERT(nd == 5);
+    ASSERT(memcmp(out, "56789", 5) == 0);
+}
+
+/* ========================================================================== */
+/* chunk_encode tests                                                         */
+/* ========================================================================== */
+
+TEST(test_chunk_encode_basic) {
+    uint8_t out[64];
+    const uint8_t data[] = "Hello";
+
+    int n = chunk_encode(out, sizeof(out), data, 5);
+    ASSERT(n > 0);
+    ASSERT(memcmp(out, "5\r\nHello\r\n", 10) == 0);
+    ASSERT(n == 10);
+}
+
+TEST(test_chunk_encode_empty) {
+    uint8_t out[64];
+
+    int n = chunk_encode(out, sizeof(out), NULL, 0);
+    ASSERT(n > 0);
+    ASSERT(memcmp(out, "0\r\n\r\n", 5) == 0);
+    ASSERT(n == 5);
+}
+
+TEST(test_chunk_encode_buffer_too_small) {
+    uint8_t out[5];
+    const uint8_t data[] = "Hello World";
+
+    int n = chunk_encode(out, sizeof(out), data, 11);
+    ASSERT(n == -1);
+}
+
+/* ========================================================================== */
+/* round-trip: encode then decode                                             */
+/* ========================================================================== */
+
+TEST(test_chunk_roundtrip) {
+    const uint8_t original[] = "RTCM3 correction data payload for GNSS";
+    int orig_len = (int)sizeof(original) - 1;
+
+    /* encode */
+    uint8_t encoded[128];
+    int elen = chunk_encode(encoded, sizeof(encoded), original, orig_len);
+    ASSERT(elen > 0);
+
+    /* append terminator chunk */
+    int tlen = chunk_encode(encoded + elen, (int)sizeof(encoded) - elen, NULL, 0);
+    ASSERT(tlen > 0);
+    elen += tlen;
+
+    /* decode */
+    chunk_dec_t dec;
+    chunk_dec_init(&dec);
+    const uint8_t *pin = encoded;
+    int nin = elen;
+    uint8_t decoded[128];
+
+    int dlen = chunk_decode(&dec, &pin, &nin, decoded, sizeof(decoded));
+    ASSERT(dlen == orig_len);
+    ASSERT(memcmp(decoded, original, orig_len) == 0);
+    ASSERT(dec.state == 3);
+}
+
+/* final trailer split across calls: exercise FINAL_TRAIL state incrementally */
+TEST(test_chunk_decode_final_trailer_split) {
+    chunk_dec_t dec;
+    chunk_dec_init(&dec);
+
+    const uint8_t input1[] = "0\r\n\r";
+    const uint8_t input2[] = "\n";
+    const uint8_t *pin;
+    int nin;
+    uint8_t out[64];
+
+    pin = input1;
+    nin = (int)sizeof(input1) - 1;
+    ASSERT(chunk_decode(&dec, &pin, &nin, out, sizeof(out)) == 0);
+    ASSERT(dec.state == 4); /* in final_trail, waiting for \n */
+
+    pin = input2;
+    nin = (int)sizeof(input2) - 1;
+    ASSERT(chunk_decode(&dec, &pin, &nin, out, sizeof(out)) == 0);
+    ASSERT(dec.state == 3); /* done */
+}
+
+/* oversize chunk-size hex digits must be rejected */
+TEST(test_chunk_decode_header_too_long) {
+    chunk_dec_t dec;
+    chunk_dec_init(&dec);
+
+    uint8_t input[CHUNK_HDR_MAX + 3];
+    const uint8_t *pin = input;
+    int nin = (int)sizeof(input);
+    uint8_t out[64];
+
+    memset(input, 'F', CHUNK_HDR_MAX + 1);
+    input[CHUNK_HDR_MAX + 1] = '\r';
+    input[CHUNK_HDR_MAX + 2] = '\n';
+    ASSERT(chunk_decode(&dec, &pin, &nin, out, sizeof(out)) < 0);
+}
+
+/* ========================================================================== */
+/* HTTP header helper tests                                                   */
+/* ========================================================================== */
+
+TEST(test_http_header_end) {
+    const uint8_t hdr[] = "HTTP/1.1 200 OK\r\nContent-Type: gnss/data\r\n\r\nBODY";
+    int off = http_header_end(hdr, (int)sizeof(hdr) - 1);
+    ASSERT(off == 44);
+    ASSERT(memcmp(hdr + off, "BODY", 4) == 0);
+}
+
+TEST(test_http_header_end_incomplete) {
+    const uint8_t hdr[] = "HTTP/1.1 200 OK\r\nContent-Type: gnss/data\r\n";
+    int off = http_header_end(hdr, (int)sizeof(hdr) - 1);
+    ASSERT(off == 0);
+}
+
+TEST(test_http_status_code) {
+    const uint8_t hdr1[] = "HTTP/1.1 200 OK\r\n";
+    const uint8_t hdr2[] = "HTTP/1.1 401 Unauthorized\r\n";
+    const uint8_t hdr3[] = "ICY 200 OK\r\n";
+
+    ASSERT(http_status_code(hdr1, (int)sizeof(hdr1) - 1) == 200);
+    ASSERT(http_status_code(hdr2, (int)sizeof(hdr2) - 1) == 401);
+    ASSERT(http_status_code(hdr3, (int)sizeof(hdr3) - 1) == 0);
+}
+
+TEST(test_http_find_header) {
+    const uint8_t hdr[] =
+        "HTTP/1.1 200 OK\r\n"
+        "Transfer-Encoding: chunked\r\n"
+        "Content-Type: gnss/data\r\n"
+        "Ntrip-Version: Ntrip/2.0\r\n"
+        "\r\n";
+    int nb = (int)sizeof(hdr) - 1;
+    char val[256];
+
+    ASSERT(http_find_header(hdr, nb, "Transfer-Encoding", val, sizeof(val)));
+    ASSERT(strcmp(val, "chunked") == 0);
+
+    ASSERT(http_find_header(hdr, nb, "Content-Type", val, sizeof(val)));
+    ASSERT(strcmp(val, "gnss/data") == 0);
+
+    ASSERT(http_find_header(hdr, nb, "Ntrip-Version", val, sizeof(val)));
+    ASSERT(strcmp(val, "Ntrip/2.0") == 0);
+
+    /* case-insensitive header name */
+    ASSERT(http_find_header(hdr, nb, "transfer-encoding", val, sizeof(val)));
+    ASSERT(strcmp(val, "chunked") == 0);
+
+    /* not found */
+    ASSERT(!http_find_header(hdr, nb, "X-Custom", val, sizeof(val)));
+}
+
+/* ========================================================================== */
+/* main                                                                       */
+/* ========================================================================== */
+
+int main(void) {
+    printf("NTRIP v2 unit tests\n");
+    printf("====================\n");
+
+    /* chunk decoder */
+    test_chunk_decode_single_run();
+    test_chunk_decode_multi_run();
+    test_chunk_decode_partial_run();
+    test_chunk_decode_zero_run();
+    test_chunk_decode_hex_upper_run();
+    test_chunk_decode_extension_run();
+    test_chunk_decode_output_limited_run();
+    test_chunk_decode_final_trailer_split_run();
+    test_chunk_decode_header_too_long_run();
+
+    /* chunk encoder */
+    test_chunk_encode_basic_run();
+    test_chunk_encode_empty_run();
+    test_chunk_encode_buffer_too_small_run();
+
+    /* round-trip */
+    test_chunk_roundtrip_run();
+
+    /* HTTP helpers */
+    test_http_header_end_run();
+    test_http_header_end_incomplete_run();
+    test_http_status_code_run();
+    test_http_find_header_run();
+
+    printf("====================\n");
+    printf("Results: %d passed, %d failed\n", n_pass, n_fail);
+
+    return n_fail > 0 ? 1 : 0;
+}


### PR DESCRIPTION
This pull request introduces NTRIP v2 (HTTP/1.1) protocol support to MRTKLIB, including auto-negotiation between v1 and v2, chunked transfer encoding, and a new public API for version selection. It also adds comprehensive documentation and unit tests for the new features. The release is versioned as 0.6.3 and includes both code and documentation updates.

**NTRIP v2 Protocol and Chunked Encoding Support:**

* Added NTRIP v2 client and server support, including HTTP/1.1 requests, chunked transfer encoding, and per-stream version negotiation with auto-detection and override (`?ver=N`). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R32) [[2]](diffhunk://#diff-540a50d75df87d6718e5e3e07081c9baf62a1f4ccfae2956e92d4f36346c0edfR1-R91)
* Introduced a header-only chunked transfer codec (`ntrip_chunk.h`) and extended the `ntrip_t` and `ntripc_con_t` structs for v2 protocol state.
* Added a new public API function `strsetntripver()` for setting the default NTRIP protocol version.

**Documentation and Guides:**

* Added a new NTRIP Streams user guide (`docs/guide/ntrip.md`) covering path format, version selection, TLS tunneling, and troubleshooting. [[1]](diffhunk://#diff-ec182cf736e756f50bad2ad15ae346826551fa9b53053ffb929069915399ebfbR1-R215) [[2]](diffhunk://#diff-540a50d75df87d6718e5e3e07081c9baf62a1f4ccfae2956e92d4f36346c0edfR1-R91)
* Updated documentation navigation to include the new guide and release notes for v0.6.3. [[1]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R98) [[2]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R107)

**Testing and Build System:**

* Added a new unit test (`t_ntrip`) for the chunked codec and HTTP helpers; updated `CMakeLists.txt` to build and run this test and incremented the project version to 0.6.3. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL2-R2) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR211-R220) [[3]](diffhunk://#diff-540a50d75df87d6718e5e3e07081c9baf62a1f4ccfae2956e92d4f36346c0edfR1-R91)

**Changelog and Roadmap:**

* Documented all new features and changes in `CHANGELOG.md` and updated the project roadmap in `README.md`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R32) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58)

**Test Results:**

* All 63 tests (including the new chunked codec test) pass with no regressions. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R32) [[2]](diffhunk://#diff-540a50d75df87d6718e5e3e07081c9baf62a1f4ccfae2956e92d4f36346c0edfR1-R91)