### PR TITLE
Release: GitHub issue/PR templates and label scheme

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -47,11 +47,13 @@ cannot be shared, describe it (receiver, duration, constellations).
 
 ## Logs / output
 
+Paste stderr / trace output below. Keep it short; attach full logs as files if large.
+
 <details>
 <summary>Relevant log excerpt</summary>
 
 ```
-<!-- Paste stderr / trace output here. Keep it short; attach full logs as files if large. -->
+# paste log output here
 ```
 
 </details>

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,61 @@
+---
+name: Bug report
+about: Report a build failure, crash, or incorrect behavior unrelated to positioning accuracy
+title: "[Bug] <short summary>"
+labels: ["bug", "status:needs-triage"]
+assignees: []
+---
+
+<!--
+Thanks for reporting a bug. Please fill in each section so we can reproduce
+and triage quickly. For positioning-accuracy or Fix-rate regressions,
+use the "Positioning issue" template instead.
+-->
+
+## Summary
+
+<!-- One or two sentences: what went wrong? -->
+
+## Environment
+
+- MRTKLIB version / commit: <!-- e.g. v0.6.1 or 7cff756 -->
+- OS and version: <!-- e.g. macOS 14.5 (arm64), Ubuntu 22.04, Windows 11 -->
+- Compiler and version: <!-- e.g. Apple clang 15.0.0, gcc 11.4.0, MSVC 19.38 -->
+- CMake version: <!-- `cmake --version` -->
+- vcpkg commit (if relevant): <!-- `cd vcpkg && git rev-parse HEAD` -->
+- Subcommand involved: <!-- e.g. mrtk run, mrtk post, mrtk relay, build-only -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+<!--
+Include the exact command line, TOML config path, and input data source
+(SBF / RTCM3 / RINEX file, stream URL — redact credentials). If the data
+cannot be shared, describe it (receiver, duration, constellations).
+-->
+
+## Expected behavior
+
+<!-- What should have happened? -->
+
+## Actual behavior
+
+<!-- What actually happened? Include the error message verbatim. -->
+
+## Logs / output
+
+<details>
+<summary>Relevant log excerpt</summary>
+
+```
+<!-- Paste stderr / trace output here. Keep it short; attach full logs as files if large. -->
+```
+
+</details>
+
+## Additional context
+
+<!-- Anything else: recent changes, related issues, screenshots, etc. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: MRTKLIB documentation
+    url: https://h-shiono.github.io/MRTKLIB/
+    about: Browse the user guide and API reference before filing an issue.
+  - name: Upstream RTKLIB resources
+    url: https://www.rtklib.com/
+    about: Background on RTKLIB concepts, file formats, and positioning modes.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -10,9 +10,9 @@ assignees: []
 
 <!--
 Where is the problem? Prefer a precise pointer.
-- README: [README.md:42](../blob/develop/README.md#L42)
+- README: https://github.com/h-shiono/MRTKLIB/blob/main/README.md#L42
 - Doxygen: function name or header file
-- MkDocs: page URL
+- MkDocs: page URL (e.g. https://h-shiono.github.io/MRTKLIB/...)
 - Inline comment: src/... line N
 -->
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,32 @@
+---
+name: Documentation issue
+about: Report errors, omissions, or confusing wording in the docs
+title: "[Docs] <short summary>"
+labels: ["documentation", "status:needs-triage"]
+assignees: []
+---
+
+## Location
+
+<!--
+Where is the problem? Prefer a precise pointer.
+- README: [README.md:42](../blob/develop/README.md#L42)
+- Doxygen: function name or header file
+- MkDocs: page URL
+- Inline comment: src/... line N
+-->
+
+## What is wrong or missing
+
+<!-- Quote the current text (if any), then explain the issue. -->
+
+## Suggested wording
+
+<!--
+If you already have a fix in mind, paste it here. A pull request is
+also very welcome.
+-->
+
+## Additional context
+
+<!-- Who is the target reader? What were you trying to do when you hit this? -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,40 @@
+---
+name: Feature request
+about: Propose a new feature, enhancement, or refactor
+title: "[Feature] <short summary>"
+labels: ["enhancement", "status:needs-triage"]
+assignees: []
+---
+
+## Motivation
+
+<!--
+What problem does this solve? Who benefits? Link any related issues,
+discussions, or real-world use cases.
+-->
+
+## Proposed change
+
+<!--
+Describe the change from a user's perspective first (CLI, TOML keys,
+API surface), then implementation-level detail if you have one.
+-->
+
+## Affected modules
+
+<!-- e.g. PPP engine, rtkrcv, TOML loader, build system -->
+
+## Alternatives considered
+
+<!-- Other approaches, and why the proposed one is preferred. -->
+
+## Backward compatibility
+
+<!--
+Does this break existing configs, APIs, CLI flags, or file formats?
+If yes, describe the migration path.
+-->
+
+## Additional context
+
+<!-- Upstream references (MALIB / MADOCALIB / demo5), specs, papers, etc. -->

--- a/.github/ISSUE_TEMPLATE/positioning_issue.md
+++ b/.github/ISSUE_TEMPLATE/positioning_issue.md
@@ -2,7 +2,7 @@
 name: Positioning accuracy / Fix-rate issue
 about: Report unexpected positioning accuracy, Fix-rate degradation, or a regression against a known baseline
 title: "[Positioning] <mode> <short summary>"
-labels: ["regression", "status:needs-triage"]
+labels: ["bug", "status:needs-triage"]
 assignees: []
 ---
 
@@ -10,6 +10,9 @@ assignees: []
 Use this template when the code builds and runs, but the positioning
 solution is wrong or worse than expected (accuracy, Fix rate, convergence
 time, etc.). For crashes or build failures, use the "Bug report" template.
+
+Maintainers: re-label with `regression` once a reporter confirms this is
+a degradation vs. a known-good baseline (commit / version / dataset).
 -->
 
 ## Summary
@@ -56,17 +59,21 @@ Include commit hashes if known.
 
 ## Reproduction
 
+Paste the exact command line(s) below.
+
 ```
-<!-- Exact command line(s). -->
+# e.g. mrtk post -k conf/malib/ppp_rtk.toml rover.obs nav.nav -o out.pos
 ```
 
 ## Logs / plots
+
+Paste a trace excerpt, `.pos` tail, NMEA snippet, or similar below.
 
 <details>
 <summary>Relevant output</summary>
 
 ```
-<!-- trace excerpt, .pos tail, NMEA snippet, or similar -->
+# paste output here
 ```
 
 </details>

--- a/.github/ISSUE_TEMPLATE/positioning_issue.md
+++ b/.github/ISSUE_TEMPLATE/positioning_issue.md
@@ -1,0 +1,78 @@
+---
+name: Positioning accuracy / Fix-rate issue
+about: Report unexpected positioning accuracy, Fix-rate degradation, or a regression against a known baseline
+title: "[Positioning] <mode> <short summary>"
+labels: ["regression", "status:needs-triage"]
+assignees: []
+---
+
+<!--
+Use this template when the code builds and runs, but the positioning
+solution is wrong or worse than expected (accuracy, Fix rate, convergence
+time, etc.). For crashes or build failures, use the "Bug report" template.
+-->
+
+## Summary
+
+<!-- One or two sentences: which mode, what degraded, by how much. -->
+
+## Positioning configuration
+
+- Mode: <!-- SPP / RTK / PPP / PPP-AR / PPP-RTK / VRS-RTK -->
+- Processing type: <!-- real-time (mrtk run) or post-processing (mrtk post) -->
+- Correction source: <!-- CLAS (L6D) / MADOCA (L6E) / MADOCA-PPP / none -->
+- Constellations enabled: <!-- e.g. GPS + Galileo + QZSS -->
+- TOML config: <!-- path to config; attach if not upstream; redact secrets -->
+
+## Environment
+
+- MRTKLIB version / commit: <!-- e.g. v0.6.1 or 7cff756 -->
+- OS: <!-- e.g. macOS 14.5, Ubuntu 22.04 -->
+- Receiver (if relevant): <!-- e.g. Septentrio mosaic-G5, u-blox ZED-F9P -->
+
+## Dataset
+
+- Observation / input file: <!-- SBF / RTCM3 / RINEX; duration; date; location -->
+- Correction input: <!-- L6 stream, SBF with QZSL6 blocks, etc. -->
+- Is the dataset shareable? <!-- yes / no; if no, describe it -->
+
+## Observed vs. expected
+
+| Metric                | Expected    | Observed |
+|-----------------------|-------------|----------|
+| Fix rate              |             |          |
+| Horizontal accuracy   |             |          |
+| Vertical accuracy     |             |          |
+| Time to first fix     |             |          |
+| Longest continuous Fix|             |          |
+
+## Baseline for comparison
+
+<!--
+If this is a regression, what are you comparing against?
+e.g. "same dataset on v0.6.0 gave 99.4% Fix; on v0.6.1 gives 67%"
+Include commit hashes if known.
+-->
+
+## Reproduction
+
+```
+<!-- Exact command line(s). -->
+```
+
+## Logs / plots
+
+<details>
+<summary>Relevant output</summary>
+
+```
+<!-- trace excerpt, .pos tail, NMEA snippet, or similar -->
+```
+
+</details>
+
+<!-- Attach screenshots of ENU plots or scatter plots if available. -->
+
+## Additional context
+
+<!-- Anything else: related issues, upstream behavior, hypotheses. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,31 @@
+---
+name: Question / usage help
+about: Ask how to use MRTKLIB, interpret results, or configure a mode
+title: "[Question] <short summary>"
+labels: ["question", "status:needs-triage"]
+assignees: []
+---
+
+<!--
+If GitHub Discussions are enabled on this repository, usage questions
+are usually a better fit there. Use this template if you believe the
+answer may lead to a documentation or code change.
+-->
+
+## What are you trying to do?
+
+<!-- Goal first, specifics second. -->
+
+## What have you tried?
+
+<!-- Commands run, configs tried, outputs observed. -->
+
+## What documentation have you already consulted?
+
+<!-- README, MkDocs pages, prior issues, upstream RTKLIB docs, etc. -->
+
+## Environment (if relevant)
+
+- MRTKLIB version / commit:
+- OS:
+- Subcommand: <!-- mrtk run / post / relay / ... -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,56 @@
+<!--
+Thanks for contributing to MRTKLIB. Please fill in the sections below.
+Delete any section that does not apply.
+-->
+
+## Summary
+
+<!-- What does this PR change, and why? One short paragraph. -->
+
+## Related issues
+
+<!-- e.g. Closes #123, Refs #456 -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Refactor (no functional change)
+- [ ] Documentation only
+- [ ] Build / CI / tooling
+- [ ] Breaking change (describe migration below)
+
+## Testing
+
+<!-- How did you verify this change? Paste the `ctest` summary below. -->
+
+```
+$ cd build && ctest --output-on-failure
+<!-- paste the summary line, e.g. "62/62 tests passed" -->
+```
+
+- [ ] Existing test suite still passes
+- [ ] New tests added for new behavior (or explain why not)
+
+## Positioning regression check
+
+<!--
+For changes that touch the positioning pipeline (PPP, RTK, PPP-RTK, VRS-RTK,
+SPP, CLAS, MADOCA, RTCM decoding, etc.), confirm that Fix rate and accuracy
+on the relevant reference dataset did not regress. State the dataset and
+the observed numbers.
+-->
+
+- [ ] Not applicable (change does not affect the positioning pipeline)
+- [ ] Regression check performed; dataset and results:
+
+## Breaking changes / migration notes
+
+<!-- TOML keys renamed, CLI flags removed, public API changed, etc. -->
+
+## Checklist
+
+- [ ] I have read the coding standards in `CLAUDE.md`
+- [ ] Doxygen comments added/updated for new or changed public functions
+- [ ] `.clang-format` applied (or diff is formatting-clean)
+- [ ] No unrelated changes included in this PR

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,11 +22,11 @@ Delete any section that does not apply.
 
 ## Testing
 
-<!-- How did you verify this change? Paste the `ctest` summary below. -->
+How did you verify this change? Paste the `ctest` summary below (e.g. `62/62 tests passed`).
 
 ```
 $ cd build && ctest --output-on-failure
-<!-- paste the summary line, e.g. "62/62 tests passed" -->
+# paste summary line here
 ```
 
 - [ ] Existing test suite still passes

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,150 @@
+# MRTKLIB issue/PR labels
+#
+# Hybrid scheme:
+#   - The "what kind of work" axis reuses the GitHub default labels
+#     (`bug`, `enhancement`, `documentation`, `question`) so the vocabulary
+#     stays familiar to external contributors. Three extra type-like labels
+#     (`refactor`, `regression`, `performance`) are added to cover concepts
+#     the defaults do not express.
+#   - All other axes use prefix-based labels (`module:*`, `mode:*`, `gnss:*`,
+#     `priority:*`, `status:*`) so filters along each axis stay predictable.
+#
+# Conventions:
+#   - One "type" label per issue (choose from the Type section below).
+#   - Other axes may have multiple labels on the same issue.
+#   - Keep this list minimal; add new labels only when an existing one no
+#     longer fits.
+#
+# This file is a declarative source of truth. Syncing to GitHub (via e.g.
+# EndBug/label-sync) is deferred to a follow-up PR.
+
+# -----------------------------------------------------------------------------
+# Type — kind of work (GitHub defaults retained, plus three additions)
+# -----------------------------------------------------------------------------
+- name: "bug"
+  color: "d73a4a"
+  description: "Something is not working as intended"
+- name: "enhancement"
+  color: "a2eeef"
+  description: "New feature or enhancement request"
+- name: "documentation"
+  color: "0075ca"
+  description: "Improvements or additions to documentation"
+- name: "question"
+  color: "d876e3"
+  description: "Usage question or request for information"
+- name: "refactor"
+  color: "c5def5"
+  description: "Internal code change with no behavior change"
+- name: "regression"
+  color: "b60205"
+  description: "Previously-working behavior has degraded"
+- name: "performance"
+  color: "fbca04"
+  description: "Speed, memory, or resource-usage improvement"
+
+# -----------------------------------------------------------------------------
+# module:* — which part of the codebase is affected
+# (cssr2rtcm3 label deliberately omitted until that tool is publicly released)
+# -----------------------------------------------------------------------------
+- name: "module:ppp"
+  color: "5319e7"
+  description: "PPP / PPP-AR engines and related corrections"
+- name: "module:rtk"
+  color: "5319e7"
+  description: "RTK / PPP-RTK / VRS-RTK engines"
+- name: "module:rtkrcv"
+  color: "5319e7"
+  description: "Real-time server (mrtk run)"
+- name: "module:rnx2rtkp"
+  color: "5319e7"
+  description: "Post-processing binary (mrtk post)"
+- name: "module:clas"
+  color: "5319e7"
+  description: "QZSS CLAS L6D decoding and correction handling"
+- name: "module:madoca"
+  color: "5319e7"
+  description: "MADOCA L6E / MADOCA-PPP decoding and correction handling"
+- name: "module:toml-config"
+  color: "5319e7"
+  description: "TOML configuration loader and schema"
+- name: "module:build"
+  color: "5319e7"
+  description: "CMake, vcpkg, CI, packaging"
+
+# -----------------------------------------------------------------------------
+# mode:* — processing type
+# -----------------------------------------------------------------------------
+- name: "mode:realtime"
+  color: "0e8a16"
+  description: "Real-time processing path"
+- name: "mode:post-processing"
+  color: "0e8a16"
+  description: "Post-processing path"
+
+# -----------------------------------------------------------------------------
+# gnss:* — constellation scope
+# -----------------------------------------------------------------------------
+- name: "gnss:gps"
+  color: "fef2c0"
+  description: "Affects GPS"
+- name: "gnss:galileo"
+  color: "fef2c0"
+  description: "Affects Galileo"
+- name: "gnss:qzss"
+  color: "fef2c0"
+  description: "Affects QZSS"
+- name: "gnss:glonass"
+  color: "fef2c0"
+  description: "Affects GLONASS"
+- name: "gnss:beidou"
+  color: "fef2c0"
+  description: "Affects BeiDou"
+
+# -----------------------------------------------------------------------------
+# priority:* — maintainer triage signal
+# -----------------------------------------------------------------------------
+- name: "priority:high"
+  color: "d93f0b"
+  description: "Should be addressed soon"
+- name: "priority:medium"
+  color: "fbca04"
+  description: "Normal priority"
+- name: "priority:low"
+  color: "c2e0c6"
+  description: "Nice to have; no deadline"
+
+# -----------------------------------------------------------------------------
+# status:* — current state of the issue
+# -----------------------------------------------------------------------------
+- name: "status:needs-triage"
+  color: "ededed"
+  description: "Awaiting initial maintainer review"
+- name: "status:confirmed"
+  color: "ededed"
+  description: "Reproduced or accepted by a maintainer"
+- name: "status:blocked"
+  color: "ededed"
+  description: "Blocked on external input or another issue"
+- name: "status:waiting-for-info"
+  color: "ededed"
+  description: "Waiting for more information from the reporter"
+
+# -----------------------------------------------------------------------------
+# Community signals (GitHub defaults retained)
+# -----------------------------------------------------------------------------
+- name: "good first issue"
+  color: "7057ff"
+  description: "Good for newcomers"
+- name: "help wanted"
+  color: "008672"
+  description: "Extra attention is needed"
+- name: "duplicate"
+  color: "cfd3d7"
+  description: "This issue or pull request already exists"
+- name: "wontfix"
+  color: "ffffff"
+  description: "This will not be worked on"
+- name: "invalid"
+  color: "e4e669"
+  description: "This does not seem right"


### PR DESCRIPTION
## Summary

Promotes the intake-workflow groundwork from `develop` to `main` so that the new
issue and PR templates become active in the repository UI (templates only take
effect on the default branch).

Contents of this promotion (from #88):

- 5 Markdown issue templates under `.github/ISSUE_TEMPLATE/` (`bug_report`, `positioning_issue`, `feature_request`, `documentation`, `question`)
- `ISSUE_TEMPLATE/config.yml` disabling blank issues and linking to MkDocs docs + upstream RTKLIB
- `PULL_REQUEST_TEMPLATE.md` with summary / linked issues / `ctest` paste slot / positioning-regression check
- `.github/labels.yml` — hybrid label scheme (see below)
- Copilot-review fixes: absolute URL in docs template, default label for positioning issues `regression` → `bug`, HTML comments inside fenced code blocks replaced with `# ...` comments

## Label sync status

All 34 labels declared in `.github/labels.yml` have already been created on GitHub via `gh label create`, so the `labels:` front-matter in the templates will resolve correctly once this lands on `main`.

Verified with:

```
declared: 34  existing: 34
missing on GitHub: none
extra on GitHub (not in labels.yml): none
```

## Post-merge verification

- [ ] Visit https://github.com/h-shiono/MRTKLIB/issues/new/choose and confirm the 5 templates appear in the chooser
- [ ] Open each template and confirm the declared labels (`bug` / `regression` [intentionally swapped to `bug` after review] / `enhancement` / `documentation` / `question` + `status:needs-triage`) are auto-applied
- [ ] Open a throwaway PR against `develop` and confirm `PULL_REQUEST_TEMPLATE.md` is picked up

## Follow-ups (tracked separately)

- Wire up `EndBug/label-sync` (or equivalent) so `labels.yml` becomes the single source of truth going forward
- Retro-tag existing open issues with the new `module:` / `mode:` / `gnss:` axes
- Add `CONTRIBUTING.md` pointing to these templates
- When `cssr2rtcm3` is publicly released: add `module:cssr2rtcm3` label and consider a dedicated template

🤖 Generated with [Claude Code](https://claude.com/claude-code)