### PR TITLE
Release: label-sync workflow

### DIFF
--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -1,0 +1,39 @@
+name: Sync labels
+
+# Syncs the repository label set from .github/labels.yml using
+# https://github.com/EndBug/label-sync.
+#
+# Policy (2026-04-16):
+#   - Runs only on the default branch so that the YAML on main is the
+#     single source of truth. PR previews of label changes are explicitly
+#     not supported; label edits land by merging to main.
+#   - delete-other-labels is false, so labels that exist on GitHub but
+#     are missing from labels.yml are left alone. This protects ad-hoc
+#     labels from accidental removal while we gain confidence in the
+#     workflow. Flip to true in a follow-up once the first few runs
+#     look clean.
+#   - workflow_dispatch is enabled for manual re-runs (e.g. after a
+#     maintainer edits a label through the UI by mistake).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+      - .github/workflows/label-sync.yaml
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync labels from labels.yml
+        uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          delete-other-labels: false

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -24,6 +24,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:


### PR DESCRIPTION
## Summary

Promotes the label-sync workflow from `develop` to `main` so it starts running.
After this PR lands, `.github/labels.yml` becomes the single source of truth
for repository labels: subsequent label changes go through a PR that edits the
YAML.

Contents of this promotion (from #90):

- `.github/workflows/label-sync.yaml` — runs `EndBug/label-sync@v2` on pushes to `main` that touch `labels.yml` (plus manual `workflow_dispatch`)
- `delete-other-labels: false` — additive/update-only; ad-hoc labels are preserved
- Permissions: `contents: read` + `issues: write` (minimum needed after Copilot review fix)

## First-run expectations

`labels.yml` and the live label set are already byte-identical (34/34, verified after manual sync in #89 + retro-tag work). The workflow's first run on `main` should therefore be a no-op — no label additions, no updates.

## Post-merge verification

- [ ] Actions tab shows a `Sync labels` run triggered by this merge
- [ ] The run completes successfully (green check)
- [ ] Run log shows zero label changes (pure reconciliation)
- [ ] Manually edit a label description in a follow-up PR, merge to main, and confirm the change reflects on GitHub

## Follow-ups (tracked separately)

- After a few clean runs, flip `delete-other-labels` to `true` so the YAML is strictly authoritative
- Optional hardening: pin `EndBug/label-sync@v2` to a specific commit SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)