### PR TITLE
Promote docs intake to main (CONTRIBUTING, SECURITY, CoC)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement via the private advisory channel described in [SECURITY.md](SECURITY.md). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,259 @@
+# Contributing to MRTKLIB
+
+Thanks for your interest in MRTKLIB. This document explains how to report
+issues, propose changes, and get a pull request merged.
+
+If you are just looking for how to *use* MRTKLIB, start with [README.md](README.md)
+and the [documentation site](https://h-shiono.github.io/MRTKLIB/).
+
+---
+
+## What contributions fit this project
+
+MRTKLIB is a GNSS positioning library focused on QZSS augmentation services
+(MADOCA-PPP, CLAS PPP-RTK, VRS-RTK) and the surrounding real-time and
+post-processing workflows. We welcome contributions that:
+
+- Fix bugs in positioning engines, decoders, streams, or build tooling
+- Improve the TOML configuration UX or CLI ergonomics
+- Add or strengthen test coverage, especially regression datasets
+- Improve documentation (Doxygen, MkDocs, examples, error messages)
+- Back-port well-understood algorithm improvements from upstream RTKLIB
+  forks (e.g. demo5, MALIB, MADOCALIB, CLASLIB)
+
+Contributions that materially change the mathematics of positioning
+algorithms are welcome but require regression evidence — see
+[Positioning-regression guard](#positioning-regression-guard) below.
+
+---
+
+## Reporting issues
+
+Open a new issue at
+<https://github.com/h-shiono/MRTKLIB/issues/new/choose>. Five templates are
+available; pick the one that matches your situation:
+
+| Template | Use when |
+|----------|----------|
+| **Bug report** | Build failure, crash, or incorrect behavior unrelated to positioning accuracy |
+| **Positioning accuracy / Fix-rate issue** | Solution is wrong or degraded (Fix rate, accuracy, convergence time) |
+| **Feature request** | New feature, enhancement, or refactor proposal |
+| **Documentation issue** | Errors, omissions, or confusing wording in the docs |
+| **Question / usage help** | How to use MRTKLIB or interpret results |
+
+### What makes a good positioning-issue report
+
+Positioning problems are hard to diagnose without concrete data. The
+template will ask for:
+
+- **Mode**: SPP / RTK / PPP / PPP-AR / PPP-RTK / VRS-RTK
+- **Correction source**: CLAS (L6D), MADOCA (L6E), MADOCA-PPP, or none
+- **Constellations enabled**: e.g. GPS + Galileo + QZSS
+- **Dataset**: observation/correction files, duration, date, location, and
+  whether the data can be shared
+- **Observed vs. expected**: Fix rate, horizontal/vertical accuracy,
+  time-to-first-fix, longest continuous Fix
+- **Baseline for regression**: if this is a regression, which commit or
+  version produced the expected result
+- **Exact command line** you ran
+
+Screenshots of ENU plots or scatter plots help a lot. Attach logs as files
+rather than pasting huge outputs inline.
+
+### Security vulnerabilities
+
+Please do **not** open public issues for security vulnerabilities. See
+[SECURITY.md](SECURITY.md) for the private disclosure channel.
+
+---
+
+## Before you open a pull request
+
+### 1. Discuss first for non-trivial changes
+
+If you plan to change positioning mathematics, rename public APIs, or
+restructure directories, please open an issue first and get rough alignment
+before writing code. For small bug fixes and documentation improvements,
+feel free to go straight to a PR.
+
+### 2. Fork and branch
+
+Fork the repository on GitHub, then create a topic branch off `develop`:
+
+```bash
+git checkout develop
+git pull origin develop
+git checkout -b feat/short-descriptive-name
+```
+
+Branch naming conventions used in this repo:
+
+| Prefix | Use for |
+|--------|---------|
+| `feat/` | New features or enhancements |
+| `fix/` | Bug fixes |
+| `refactor/` | Internal code changes with no behavior change |
+| `docs/` | Documentation-only changes |
+| `ci/` | CI / build / tooling changes |
+| `test/` | Test-only additions or fixes |
+
+### 3. Build and test locally
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
+cd build && ctest --output-on-failure
+```
+
+All 62 tests must pass before you open a PR. If your change makes a test
+fail intentionally, update the test in the same commit and explain why in
+the commit message.
+
+### 4. Follow the coding standards
+
+Project-wide rules are in [CLAUDE.md §4](CLAUDE.md). The headline items:
+
+- **No drive-by math changes.** Do not alter GNSS algorithms, matrix
+  operations, or physical constants as part of unrelated work. Isolate
+  algorithm changes to their own commits with regression evidence.
+- **Doxygen on public functions**:
+
+  ```c
+  /**
+   * @brief Short description of the function.
+   * @param[in]  param_name Description of input parameter.
+   * @param[out] param_name Description of output parameter.
+   * @return Return value description.
+   */
+  ```
+
+- **`clang-format`** is the source of truth for formatting. Run it on
+  your changes before committing.
+- **`extern "C"`** compatibility on headers that are still consumed by
+  legacy C files.
+- **`const`-correctness** on pointer parameters that are not written to.
+- Modern C++ idioms (`std::vector`, smart pointers) are welcome in new
+  code, but keep the public C API stable.
+
+### 5. Commit messages
+
+Use conventional-style prefixes matching the branch taxonomy:
+
+```
+feat(rtkrcv): add dual-stream L6D routing by PRN
+fix(clas): guard trop bank against stale entries past age threshold
+refactor(toml): extract signal-list parsing into helper
+docs(readme): document the cssr2rtcm3 release status
+ci(github): pin label-sync action to a commit SHA
+test(ppp-rtk): add regression for Galileo E1C/E5Q signal fallback
+```
+
+Keep the subject line under ~72 characters. Use the body to explain *why*
+the change is needed, especially for algorithm changes or subtle bug fixes.
+
+---
+
+## Pull request process
+
+### 1. Open the PR against `develop`
+
+`main` is the released branch; all feature work integrates via `develop`
+first. PRs against `main` are reserved for release promotions. The base
+branch for contributor PRs is **always `develop`** unless a maintainer
+directs otherwise.
+
+### 2. Fill in the PR template
+
+The [pull request template](.github/PULL_REQUEST_TEMPLATE.md) asks for a
+summary, linked issues, the type of change, and a slot for `ctest` output.
+Please fill it in — incomplete PR bodies slow down review.
+
+### 3. Positioning-regression guard
+
+If your change touches the positioning pipeline (any file under
+`src/pos/`, `src/clas/`, `src/madoca/`, `src/rtcm/`, `src/stream/`, or
+signal/observation handling) you must either:
+
+- Check the **"Not applicable"** box in the PR template and justify why, or
+- Run the relevant reference dataset and state the observed Fix rate and
+  accuracy in the PR body, comparing against `develop` before your change.
+
+The PPC benchmark command is documented in the project's backlog notes;
+the 62-test CTest suite exercises PPP / PPP-AR / PPP-RTK / VRS-RTK / SPP /
+RTK / CLAS / MADOCA paths on canonical inputs. A green CTest run is
+necessary but not always sufficient — be explicit about what you verified.
+
+### 4. Respond to review
+
+Reviews are primarily GitHub-based. Address review comments by adding
+**new commits** to the PR rather than force-pushing over the history;
+maintainers squash on merge so the branch's granular history is not
+preserved regardless. Force-push only when a maintainer asks you to rebase.
+
+### 5. Merge path
+
+Merge to `develop` happens once the PR has:
+
+- A green CI run (build + docs workflows; label-sync only runs on `main`)
+- Passing `ctest`
+- At least one maintainer approval
+- Positioning-regression evidence if applicable
+
+Promotion from `develop` to `main` is a separate PR created by a
+maintainer when a release is cut. See the
+[intake-workflow memory](.github/workflows/) for the two-stage model in
+detail.
+
+---
+
+## Labels
+
+Labels are managed declaratively in [`.github/labels.yml`](.github/labels.yml)
+and synced to GitHub by a workflow on push to `main`. Do **not** create or
+edit labels through the GitHub UI — the sync action is additive, so edits
+you make by hand get clobbered on the next run.
+
+The label scheme uses six orthogonal axes. Issues and PRs typically carry
+one label from each relevant axis.
+
+| Axis | Values | Prefix? |
+|------|--------|---------|
+| Type | `bug`, `enhancement`, `documentation`, `question`, `refactor`, `regression`, `performance` | no (retained GitHub defaults + gap-fillers) |
+| Module | `module:ppp`, `module:rtk`, `module:rtkrcv`, `module:rnx2rtkp`, `module:clas`, `module:madoca`, `module:toml-config`, `module:build` | `module:` |
+| Mode | `mode:realtime`, `mode:post-processing` | `mode:` |
+| GNSS | `gnss:gps`, `gnss:galileo`, `gnss:qzss`, `gnss:glonass`, `gnss:beidou` | `gnss:` |
+| Priority | `priority:high`, `priority:medium`, `priority:low` | `priority:` |
+| Status | `status:needs-triage`, `status:confirmed`, `status:blocked`, `status:waiting-for-info` | `status:` |
+
+To propose a new label, open a PR that edits `labels.yml` and explain the
+rationale in the PR body.
+
+---
+
+## Licensing of contributions
+
+MRTKLIB is distributed under the [BSD 2-Clause License](LICENSE). By
+submitting a pull request, you agree that your contribution may be
+distributed under the same license (the "inbound = outbound" convention).
+No separate Contributor License Agreement is required.
+
+If your change adds code derived from another project, please make sure
+that project's license is compatible with BSD 2-Clause, preserve the
+original copyright notice, and note the provenance in the commit message.
+
+---
+
+## Code of Conduct
+
+Please be civil and constructive in all project spaces. See
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for the full expectations and the
+reporting process.
+
+---
+
+## Getting help
+
+- General usage questions: open an issue with the "Question / usage help" template.
+- Bug reports and feature requests: use the other templates above.
+- Security issues: follow [SECURITY.md](SECURITY.md).
+- Documentation: <https://h-shiono.github.io/MRTKLIB/>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,11 +78,19 @@ feel free to go straight to a PR.
 
 ### 2. Fork and branch
 
-Fork the repository on GitHub, then create a topic branch off `develop`:
+Fork the repository on GitHub. On your first fork-based contribution, add
+this repository as an `upstream` remote so you can stay in sync with the
+canonical `develop` branch (rather than the copy on your fork):
 
 ```bash
-git checkout develop
-git pull origin develop
+git remote add upstream https://github.com/h-shiono/MRTKLIB.git
+```
+
+Then create a topic branch off the upstream `develop`:
+
+```bash
+git fetch upstream
+git checkout -B develop upstream/develop
 git checkout -b feat/short-descriptive-name
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,8 +13,9 @@ Report it privately using GitHub's **Private Vulnerability Reporting**:
    - Affected version or commit hash
    - Steps to reproduce, ideally with a minimal dataset or command line
    - The impact you observed or can demonstrate
-3. Submit the advisory. Only the maintainers and invited collaborators
-   will be able to see it.
+3. Submit the advisory. You (the reporter), the maintainers, and any
+   invited collaborators will be able to see it, and it remains private
+   from the public until disclosure.
 
 You will receive an acknowledgement within a reasonable time frame.
 Because MRTKLIB is maintained by a small team, please be patient if the
@@ -46,3 +47,17 @@ We follow a coordinated-disclosure model. After triage we will work with
 you on a fix timeline; public disclosure happens once a patch is
 available or after a mutually agreed deadline. You will be credited in
 the advisory unless you prefer to remain anonymous.
+
+## Code of Conduct reports
+
+Private reports of [Code of Conduct](CODE_OF_CONDUCT.md) violations are
+routed through the same GitHub Security Advisory channel described above.
+When filing, please state in the advisory title or summary that the
+report concerns conduct rather than a technical vulnerability, so it is
+triaged on the conduct path instead of the security path.
+
+Using the advisory channel for conduct reports is a pragmatic choice for
+a small project: it reuses an existing private, auditable intake without
+introducing a separate email address or form. We may introduce a
+dedicated conduct-report channel in the future if volume or scope
+warrants it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you believe you have found a security vulnerability in MRTKLIB, please
+**do not open a public GitHub issue**.
+
+Report it privately using GitHub's **Private Vulnerability Reporting**:
+
+1. Go to <https://github.com/h-shiono/MRTKLIB/security/advisories/new>
+2. Describe the issue, including:
+   - Affected component(s) (e.g. `mrtk run`, RTCM3 decoder, TOML parser)
+   - Affected version or commit hash
+   - Steps to reproduce, ideally with a minimal dataset or command line
+   - The impact you observed or can demonstrate
+3. Submit the advisory. Only the maintainers and invited collaborators
+   will be able to see it.
+
+You will receive an acknowledgement within a reasonable time frame.
+Because MRTKLIB is maintained by a small team, please be patient if the
+first response takes a few days.
+
+## What we consider in scope
+
+- Crashes, memory-safety issues (out-of-bounds reads/writes,
+  use-after-free), or undefined behavior triggered by crafted inputs:
+  RTCM3 streams, BINEX messages, UBX frames, SBF blocks, L6D/L6E
+  correction payloads, RINEX files, TOML configuration files
+- Path traversal or arbitrary-file-write issues in file-handling paths
+- Network-protocol weaknesses in the stream layer (NTRIP client/server,
+  TCP/UDP handlers) that could be exploited by a malicious peer
+- Authentication or credential-handling bugs in the stream layer
+
+## What we do not consider security issues
+
+- Incorrect positioning results or Fix-rate regressions — please use the
+  "Positioning accuracy / Fix-rate issue" template under
+  <https://github.com/h-shiono/MRTKLIB/issues/new/choose>
+- Bugs that require local root access to exploit
+- Denial of service through abnormally large input files, absent a
+  concrete exploitation path
+
+## Coordinated disclosure
+
+We follow a coordinated-disclosure model. After triage we will work with
+you on a fix timeline; public disclosure happens once a patch is
+available or after a mutually agreed deadline. You will be credited in
+the advisory unless you prefer to remain anonymous.


### PR DESCRIPTION
## Summary
Release-promotion PR: activates the three Community Profile documents on the default branch. All content was reviewed and merged via #92 on `develop`; this PR brings only those three files across to `main` so GitHub's UI (Community Profile, `Security` tab, Code of Conduct badge) picks them up.

Diff vs. `main`: **3 files, +414 / -0**, all additions.

- `CONTRIBUTING.md` (267 lines) — issue reporting, fork + upstream-remote workflow, branch/PR conventions targeting `develop`, coding standards, positioning-regression guard, label-axis cross-reference, BSD 2-clause inbound=outbound.
- `SECURITY.md` (63 lines) — Private Vulnerability Reporting flow, in-scope/out-of-scope enumeration, coordinated disclosure, and a "Code of Conduct reports" section routing CoC complaints through the same advisory channel.
- `CODE_OF_CONDUCT.md` (84 lines) — Contributor Covenant 2.1 verbatim, enforcement contact pointing at SECURITY.md's advisory channel.

### Commits included

- ff1dfb4 docs(github): add CONTRIBUTING, SECURITY, and Code of Conduct
- 3aef19a docs(github): address Copilot review on CONTRIBUTING/SECURITY
- 4faed04 Merge pull request #92 from h-shiono/feat/contributing-docs

### Positioning-regression guard
- [x] Not applicable — documentation-only, no source, test, or build changes.

## Pre-merge coordination

Before (or at) merge, enable **Settings → Security and analysis → Private vulnerability reporting**. Without it, the `/security/advisories/new` URL referenced from SECURITY.md (and indirectly from CODE_OF_CONDUCT.md's enforcement pointer) returns "not enabled" — the first-time reporter experience would be broken.

## Test plan
- [x] Enable Private Vulnerability Reporting (repo Settings → Security) before merge
- [x] Verify CI (build + docs) is green on `develop` before promoting
- [ ] Post-merge: open the repo's **Insights → Community** page and confirm CONTRIBUTING, SECURITY, and Code of Conduct each show a checkmark
- [ ] Post-merge: click the `Security` tab and confirm the "Report a vulnerability" button resolves to a working advisory form
- [ ] Post-merge: confirm the Code of Conduct badge appears on the repo landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)