### PR TITLE
v0.6.4 — rtkrcv stability + Community Profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to MRTKLIB are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.6.4] - 2026-04-16
+
+**Patch** — rtkrcv stability fixes and GitHub Community Profile completion.
+
+### Fixed
+
+- **rtkrcv status-poll SIGSEGV** (#74) — `prstatus()` `mode[]` array had 8 entries but `PMODE_PPP_RTK`/`PMODE_VRS_RTK` etc. index beyond that. Expanded to 13 entries with bounds checks on both `mode[]` and `freq[]`.
+- **rtkrcv status-path data race** (#74) — `prstatus()` shallow-copied `rtk_t` under lock, leaving `x`/`P`/`xa`/`Pa` aliased to heap buffers the processing thread keeps mutating via `rtkpos()`. Now extracts position + covariance diagonal into local variables under the lock and nulls the shared pointers after unlock.
+- **rtkrcv SIGSEGV handler safety** (#82, #85) — Crash handler is now async-signal-safe (`write(2)` instead of `fprintf()`) and re-raises the signal after restoring the default handler, so OS core-dump capture still fires.
+
+### Added
+
+- **GitHub issue and PR templates** (#88) — Five issue templates (`bug_report`, `positioning_issue`, `feature_request`, `documentation`, `question`) plus a PR template with `ctest` slot and positioning-regression check.
+- **Declarative label scheme** (#88, #90) — `.github/labels.yml` with 34 labels across six axes (type/module/mode/gnss/priority/status), synced to GitHub by `EndBug/label-sync@v2` on push to `main`.
+- **CONTRIBUTING.md** (#92) — Issue reporting, fork + upstream-remote workflow, branch/PR conventions targeting `develop`, coding standards, positioning-regression guard, label reference, BSD 2-clause inbound=outbound.
+- **SECURITY.md** (#92) — Private Vulnerability Reporting flow; scope explicitly also covers Code of Conduct reports via the same advisory channel.
+- **CODE_OF_CONDUCT.md** (#92) — Contributor Covenant 2.1 verbatim.
+- **Crash-diagnostic build flags** — `-rdynamic` on Linux for SIGSEGV backtrace symbolization.
+- **CLAS real-time Grafana dashboard link** in README for users monitoring `mrtk run`.
+
+### Test Results
+
+62/62 tests pass (no regressions).
+
 ## [v0.6.3] - 2026-03-31
 
 **Feature** — NTRIP v2 (HTTP/1.1) protocol support with auto-negotiation.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(MRTKLIB VERSION 0.6.3 LANGUAGES C)
+project(MRTKLIB VERSION 0.6.4 LANGUAGES C)
 
 # ── Version header generation ─────────────────────────────────────────────────
 set(MRTKLIB_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ incrementally back-ported to each engine:
 | **v0.6.1** | All | Config UX: `systems` string list, `excluded_sats` list, `taplo` formatter, section reorganization | ✅ Released |
 | **v0.6.2** | — | Documentation: MkDocs Material site + Doxygen API reference + GitHub Pages deployment | ✅ Released |
 | **v0.6.3** | Stream | NTRIP v2 (HTTP/1.1) protocol support with auto-negotiation, chunked transfer encoding, URL percent-decoding | ✅ Released |
+| **v0.6.4** | rtkrcv / Repo | rtkrcv status-path stability fixes (data race + OOB + async-signal-safe SIGSEGV handler); GitHub Community Profile (issue/PR templates, labels, CONTRIBUTING/SECURITY/CoC) | ✅ Released |
 | **v0.6.x** | All | Doxygen docstring coverage expansion | 💭 Backlog |
 
 > [!NOTE]

--- a/docs/releases/release-notes-v0.6.4.md
+++ b/docs/releases/release-notes-v0.6.4.md
@@ -1,0 +1,119 @@
+# Release Notes — v0.6.4
+
+## rtkrcv Stability Fixes + Community Profile
+
+**Release date:** 2026-04-16
+**Type:** Patch — rtkrcv crash fixes + GitHub Community Profile completion
+**Branch:** `release/v0.6.4`
+
+---
+
+### Overview
+
+v0.6.4 is a patch release dominated by rtkrcv stability fixes. It ships three
+independently root-caused crashes that affected the `mrtk run` (rtkrcv) status
+path, plus the repository-hygiene work that completes MRTKLIB's GitHub
+Community Profile (issue/PR templates, declarative labels, CONTRIBUTING,
+SECURITY, and Code of Conduct).
+
+No positioning-engine behavior changes. No new public APIs. The 62-test CTest
+suite passes unchanged.
+
+---
+
+### rtkrcv stability fixes (user-facing)
+
+#### Fix — status-poll SIGSEGV from out-of-bounds mode[] read (#74)
+
+`prstatus()` had an 8-entry `mode[]` array but newer positioning modes
+(`PMODE_PPP_RTK=9`, `PMODE_VRS_RTK=12`, …) had been added since, so the
+second status poll in any PPP-RTK / VRS-RTK session read past the array end
+and crashed on the invalid pointer. Mode table is now 13 entries covering
+`PPP-fixed`, `PPP-RTK`, `SSR2OSR`, `SSR2OSR-fixed`, and `VRS-RTK`, with
+bounds checks on both `mode[]` and `freq[]`.
+
+Commit: `5daa212`
+
+#### Fix — status-poll data race on shared state vectors (#74)
+
+`prstatus()` shallow-copied `rtk_t` under the server lock, leaving the
+`x / P / xa / Pa` pointers aliased to heap buffers that the processing
+thread kept mutating via `rtkpos()`. The race window was ~50–200 ms/epoch
+in PPP-RTK mode and surfaced as intermittent SIGSEGVs during long runs.
+
+Fix: extract the values the status path actually needs (position +
+covariance diagonal) into local variables while the lock is held, then null
+out the shared pointers after unlock so the status path cannot chase them.
+A SIGSEGV backtrace handler plus `-rdynamic` on Linux was added to make
+any future crashes easier to post-mortem.
+
+Commit: `1656081`
+
+#### Fix — async-signal-safe SIGSEGV handler that preserves core dumps (#82, #85)
+
+The new crash handler originally called `fprintf()` (not async-signal-safe)
+and `_exit()` (which suppresses core dumps). It now uses `write(2)` for
+diagnostics, reinstalls the default signal handler, and re-raises the
+signal so OS core-dump capture still fires. Review rounds on #85 tightened
+the handler further.
+
+Commits: `e352c24`, `4dd6b62`, `6e507d0`
+
+---
+
+### Repository hygiene — GitHub Community Profile
+
+v0.6.4 also lands the intake-surface work that activates MRTKLIB's GitHub
+Community Profile. These changes do not affect the compiled artifact.
+
+- **Issue and PR templates** (#88) — five issue templates
+  (`bug_report`, `positioning_issue`, `feature_request`, `documentation`,
+  `question`), a PR template with `ctest` slot and positioning-regression
+  check, and `.github/ISSUE_TEMPLATE/config.yml` pointing at the docs site.
+- **Declarative labels + sync workflow** (#90) — `.github/labels.yml` is now
+  the single source of truth for the 34-label scheme (type / module / mode /
+  gnss / priority / status). `EndBug/label-sync` runs on push to `main`
+  when `labels.yml` changes.
+- **Policy documents** (#92) — `CONTRIBUTING.md` (issue reporting, fork +
+  upstream workflow, coding standards, positioning-regression guard),
+  `SECURITY.md` (Private Vulnerability Reporting; scope also explicitly
+  covers Code of Conduct reports), and `CODE_OF_CONDUCT.md`
+  (Contributor Covenant 2.1 verbatim).
+
+Additional: README now links the CLAS real-time Grafana dashboard for users
+monitoring `mrtk run` telemetry.
+
+---
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/rtkrcv/rtkrcv.c` | Status-path data-race fix, bounds-checked mode table, async-signal-safe SIGSEGV handler |
+| `CMakeLists.txt` | Version 0.6.3 → 0.6.4; `-rdynamic` on Linux for crash backtraces |
+| `CONTRIBUTING.md` | New — contributor on-ramp |
+| `SECURITY.md` | New — vulnerability disclosure policy |
+| `CODE_OF_CONDUCT.md` | New — Contributor Covenant 2.1 |
+| `.github/ISSUE_TEMPLATE/*` | New — five issue templates + `config.yml` |
+| `.github/PULL_REQUEST_TEMPLATE.md` | New — PR template |
+| `.github/labels.yml` | New — declarative label source of truth |
+| `.github/workflows/label-sync.yaml` | New — label-sync automation |
+| `README.md` | CLAS real-time Grafana dashboard link; v0.6.4 roadmap entry |
+| `CHANGELOG.md` | v0.6.4 entry |
+| `mkdocs.yml` | v0.6.4 in Releases navigation |
+
+---
+
+### Upgrade notes
+
+- **rtkrcv users on v0.6.3 or earlier** — upgrading is recommended.
+  The mode-table out-of-bounds fix (#5daa212) affects anyone running
+  `mrtk run` in PPP-RTK or VRS-RTK mode and polling status.
+- **No configuration, TOML schema, or API changes.** Existing
+  `rtkrcv.toml` / `rnx2rtkp` invocations run unchanged.
+
+---
+
+### Test Results
+
+62/62 tests pass (no regressions).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
     - Test Methodology: reference/test-accuracy-methodology.md
   - Releases:
     - Changelog: releases/changelog.md
+    - v0.6.4: releases/release-notes-v0.6.4.md
     - v0.6.3: releases/release-notes-v0.6.3.md
     - v0.6.2: releases/release-notes-v0.6.2.md
     - v0.6.1: releases/release-notes-v0.6.1.md


### PR DESCRIPTION
## Summary

Release-promotion PR for **v0.6.4**. All content was reviewed and merged on `develop` via PRs #74, #82, #85, #88, #90, #92, and release-prep #94; this brings the version bump, release notes, and changelog entry across to `main` so the tag can be placed.

Diff vs. `main`: **5 files, +146 / -1** (version metadata and docs only).

### What ships in v0.6.4

**rtkrcv stability (user-facing):**
- #74 — `prstatus()` mode-table OOB fix + state-vector data-race fix
- #82, #85 — async-signal-safe SIGSEGV handler preserving core dumps

**Repository hygiene (no binary impact):**
- #88 — issue/PR templates + declarative labels
- #90 — `label-sync` workflow
- #92 — CONTRIBUTING.md, SECURITY.md, CODE_OF_CONDUCT.md

**Release prep (#94):**
- `CMakeLists.txt` version 0.6.3 → 0.6.4
- `CHANGELOG.md` v0.6.4 entry
- `docs/releases/release-notes-v0.6.4.md`
- `README.md` roadmap row
- `mkdocs.yml` nav entry

### Positioning-regression guard
- [x] Not applicable — no positioning-engine changes in v0.6.4.

## Post-merge actions
- [ ] `git tag -a v0.6.4 -m "rtkrcv Stability Fixes + Community Profile" <merge-commit>` + `git push origin v0.6.4`
- [ ] (Optional) Publish a GitHub Release using the release notes

## Test plan
- [x] Confirm CI green on this PR
- [ ] After merge + tag, verify `git describe` returns `v0.6.4`
- [ ] Verify MkDocs site picks up the v0.6.4 release notes page on next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)