### PR TITLE
chore(labels): add module:cssr2rtcm3 for upcoming public release

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -45,7 +45,6 @@
 
 # -----------------------------------------------------------------------------
 # module:* — which part of the codebase is affected
-# (cssr2rtcm3 label deliberately omitted until that tool is publicly released)
 # -----------------------------------------------------------------------------
 - name: "module:ppp"
   color: "5319e7"
@@ -65,6 +64,9 @@
 - name: "module:madoca"
   color: "5319e7"
   description: "MADOCA L6E / MADOCA-PPP decoding and correction handling"
+- name: "module:cssr2rtcm3"
+  color: "5319e7"
+  description: "cssr2rtcm3 CSSR-to-RTCM3 converter (mrtk cssr2rtcm3)"
 - name: "module:toml-config"
   color: "5319e7"
   description: "TOML configuration loader and schema"


### PR DESCRIPTION
## Summary
- Add `module:cssr2rtcm3` label (already created on GitHub for #98).
- Drop the "deliberately omitted until publicly released" comment now
  that `cssr2rtcm3` is shipping publicly in v0.6.5.

The label was created directly on GitHub via `gh label create` so #98 could
be tagged immediately. This PR brings `.github/labels.yml` (the source of
truth consumed by the label-sync workflow) into agreement, so future runs
remain idempotent.

## Test plan
- [x] `gh label list` shows `module:cssr2rtcm3`
- [x] #98 is tagged with `module:cssr2rtcm3`
- [ ] After merge: label-sync workflow runs and reports no changes