### PR TITLE
docs(hardware): fix broken image paths on mosaic-G5 GitHub Pages

### DIFF
--- a/docs/hardware/cssr2rtcm3-mosaic-g5.md
+++ b/docs/hardware/cssr2rtcm3-mosaic-g5.md
@@ -96,15 +96,15 @@ Configure the mosaic-G5 using RxTools (the mosaic-G5 module does not have a Web 
 
     - Select `Serial Connection` > `Create New...`
 
-    <div style="text-align: center;"><img src="images/mosaic-g5/select_connection.png" style="max-width: 360px; width: 100%;"></div>
+    <div style="text-align: center;"><img src="../images/mosaic-g5/select_connection.png" style="max-width: 360px; width: 100%;"></div>
 
     - Choose the USB COM port, set a `Connection Name`, and click `Finish`.
 
-    <div style="text-align: center;"><img src="images/mosaic-g5/specify_the_serial_settings.png" style="max-width: 480px; width: 100%;"></div>
+    <div style="text-align: center;"><img src="../images/mosaic-g5/specify_the_serial_settings.png" style="max-width: 480px; width: 100%;"></div>
 
     - RxControl will launch after the connection is established.
 
-    <div style="text-align: center;"><img src="images/mosaic-g5/rx_control.png" style="max-width: 520px; width: 100%;"></div>
+    <div style="text-align: center;"><img src="../images/mosaic-g5/rx_control.png" style="max-width: 520px; width: 100%;"></div>
 
 4. **Set SBF output**: Go to `Communication` > `Output Settings` > `SBF Output` and configure `Stream 1` as follows:
     - Ports: `USB2`
@@ -114,7 +114,7 @@ Configure the mosaic-G5 using RxTools (the mosaic-G5 module does not have a Web 
 
     Click `Apply`, then `OK` to close.
 
-    <div style="text-align: center;"><img src="images/mosaic-g5/sbf_output.png" style="max-width: 640px; width: 100%;"></div>
+    <div style="text-align: center;"><img src="../images/mosaic-g5/sbf_output.png" style="max-width: 640px; width: 100%;"></div>
 
     <details>
     <summary>Required SBF blocks (reference)</summary>
@@ -150,7 +150,7 @@ Configure the mosaic-G5 using RxTools (the mosaic-G5 module does not have a Web 
         Without this step, the SBF stream will contain no `QZSRawL6D` blocks
         and `cssr2rtcm3` will receive no CLAS data.
 
-    <div style="text-align: center;"><img src="images/mosaic-g5/signal_tracking.png" style="max-width: 420px; width: 100%;"></div>
+    <div style="text-align: center;"><img src="../images/mosaic-g5/signal_tracking.png" style="max-width: 420px; width: 100%;"></div>
 
 6. **Set Positioning Mode**: Go to `Navigation` > `Positioning Mode`:
     - In the `PVT Mode` tab:

--- a/docs/hardware/cssr2rtcm3-mosaic-g5.md
+++ b/docs/hardware/cssr2rtcm3-mosaic-g5.md
@@ -83,6 +83,10 @@ flowchart LR
 | **GNSS antenna** | All-band antenna (L1/L2/L5/L6) |
 | **Host PC / SBC** | Linux or macOS machine with MRTKLIB built (PC, laptop, or SBC such as Raspberry Pi) |
 
+!!! tip "Where to buy the mosaic-go G5 P3 kit"
+    - **Global:** [Septentrio Online Shop](https://shop.septentrio.com/en)
+    - **Japan:** [CQ出版 オンラインショップ](https://shop.cqpub.co.jp/hanbai/books/I/I100557.html)
+
 ## Setting Up the Receiver
 
 [RxTools](https://www.septentrio.com/en/products/gps-gnss-receiver-software/rxtools) is a GNSS receiver control and analysis software suite by Septentrio.


### PR DESCRIPTION
## Summary

- The five raw `<img src="images/mosaic-g5/...">` tags in the mosaic-G5 hardware guide were broken on the published GitHub Pages site.
- Root cause: MkDocs with the default `use_directory_urls: true` renders the page at `/hardware/cssr2rtcm3-mosaic-g5/`, adding an extra path segment. MkDocs rewrites markdown `![](...)` paths automatically (the two `long_term_24h*` images already worked), but it does **not** rewrite raw HTML `<img>` tags. The browser was resolving them to `/hardware/cssr2rtcm3-mosaic-g5/images/mosaic-g5/...` (404).
- Fix: prepend `../` so the browser resolves to `/hardware/images/mosaic-g5/...`, where the assets actually live.

Affected page: https://h-shiono.github.io/MRTKLIB/hardware/cssr2rtcm3-mosaic-g5/

## Test plan

- [ ] After Pages rebuild, confirm all five screenshots render on the live page (`select_connection`, `specify_the_serial_settings`, `rx_control`, `sbf_output`, `signal_tracking`)
- [ ] Run `mkdocs serve` locally and verify images render at `http://127.0.0.1:8000/hardware/cssr2rtcm3-mosaic-g5/`
- [ ] Confirm the two markdown-syntax images (`long_term_24h*`) still render (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)