### PR TITLE
docs(hardware): fix mosaic-G5 image paths and add purchase links

### DIFF
--- a/docs/hardware/cssr2rtcm3-mosaic-g5.md
+++ b/docs/hardware/cssr2rtcm3-mosaic-g5.md
@@ -96,15 +96,15 @@ Configure the mosaic-G5 using RxTools (the mosaic-G5 module does not have a Web 
 
     - Select `Serial Connection` > `Create New...`
 
-    <div style="text-align: center;"><img src="images/mosaic-g5/select_connection.png" style="max-width: 360px; width: 100%;"></div>
+    <div style="text-align: center;"><img src="../images/mosaic-g5/select_connection.png" style="max-width: 360px; width: 100%;"></div>
 
     - Choose the USB COM port, set a `Connection Name`, and click `Finish`.
 
-    <div style="text-align: center;"><img src="images/mosaic-g5/specify_the_serial_settings.png" style="max-width: 480px; width: 100%;"></div>
+    <div style="text-align: center;"><img src="../images/mosaic-g5/specify_the_serial_settings.png" style="max-width: 480px; width: 100%;"></div>
 
     - RxControl will launch after the connection is established.
 
-    <div style="text-align: center;"><img src="images/mosaic-g5/rx_control.png" style="max-width: 520px; width: 100%;"></div>
+    <div style="text-align: center;"><img src="../images/mosaic-g5/rx_control.png" style="max-width: 520px; width: 100%;"></div>
 
 4. **Set SBF output**: Go to `Communication` > `Output Settings` > `SBF Output` and configure `Stream 1` as follows:
     - Ports: `USB2`
@@ -114,7 +114,7 @@ Configure the mosaic-G5 using RxTools (the mosaic-G5 module does not have a Web 
 
     Click `Apply`, then `OK` to close.
 
-    <div style="text-align: center;"><img src="images/mosaic-g5/sbf_output.png" style="max-width: 640px; width: 100%;"></div>
+    <div style="text-align: center;"><img src="../images/mosaic-g5/sbf_output.png" style="max-width: 640px; width: 100%;"></div>
 
     <details>
     <summary>Required SBF blocks (reference)</summary>
@@ -150,7 +150,7 @@ Configure the mosaic-G5 using RxTools (the mosaic-G5 module does not have a Web 
         Without this step, the SBF stream will contain no `QZSRawL6D` blocks
         and `cssr2rtcm3` will receive no CLAS data.
 
-    <div style="text-align: center;"><img src="images/mosaic-g5/signal_tracking.png" style="max-width: 420px; width: 100%;"></div>
+    <div style="text-align: center;"><img src="../images/mosaic-g5/signal_tracking.png" style="max-width: 420px; width: 100%;"></div>
 
 6. **Set Positioning Mode**: Go to `Navigation` > `Positioning Mode`:
     - In the `PVT Mode` tab:

--- a/docs/hardware/cssr2rtcm3-mosaic-g5.md
+++ b/docs/hardware/cssr2rtcm3-mosaic-g5.md
@@ -83,6 +83,10 @@ flowchart LR
 | **GNSS antenna** | All-band antenna (L1/L2/L5/L6) |
 | **Host PC / SBC** | Linux or macOS machine with MRTKLIB built (PC, laptop, or SBC such as Raspberry Pi) |
 
+!!! tip "Where to buy the mosaic-go G5 P3 kit"
+    - **Global:** [Septentrio Online Shop](https://shop.septentrio.com/en)
+    - **Japan:** [CQ出版 オンラインショップ](https://shop.cqpub.co.jp/hanbai/books/I/I100557.html)
+
 ## Setting Up the Receiver
 
 [RxTools](https://www.septentrio.com/en/products/gps-gnss-receiver-software/rxtools) is a GNSS receiver control and analysis software suite by Septentrio.


### PR DESCRIPTION
## Summary

Docs-only update for the mosaic-G5 hardware guide. Promotes [#107](https://github.com/h-shiono/MRTKLIB/pull/107) from `develop` to `main` so the live GitHub Pages site reflects the fix.

- Fix five raw `<img src="images/...">` tags that 404'd on GitHub Pages — MkDocs does not rewrite raw HTML img paths under `use_directory_urls: true`, so they needed `../` to resolve to `/hardware/images/mosaic-g5/...`.
- Add a "Where to buy the mosaic-go G5 P3 kit" tip with links to the Septentrio online shop (global) and CQ出版 (Japan).

Affected page: https://h-shiono.github.io/MRTKLIB/hardware/cssr2rtcm3-mosaic-g5/

## Test plan

- [ ] After Pages rebuilds on main, confirm all five screenshots render on the live page
- [ ] Confirm the purchase-links tip appears below the Equipment table and both links open correctly
- [ ] Confirm the two markdown-syntax images (`long_term_24h*`) still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)