### PR TITLE
fix(build): guard against ILP64 BLAS/LAPACK provider (#108)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ if(UNIX AND NOT APPLE)
 endif()
 
 # ── System LAPACK/BLAS integration for fast matrix operations ────────────────
-# Force LP64 BLAS/LAPACK integer ABI; ILP64 silently breaks our int* wrappers (#108).
+# Request LP64 BLAS/LAPACK integer ABI; ILP64 silently breaks our int* wrappers (#108).
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.22")
     if(DEFINED BLA_SIZEOF_INTEGER AND NOT "${BLA_SIZEOF_INTEGER}" STREQUAL "4")
         message(FATAL_ERROR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,16 @@ if(UNIX AND NOT APPLE)
 endif()
 
 # ── System LAPACK/BLAS integration for fast matrix operations ────────────────
+# Force LP64 BLAS/LAPACK integer ABI; ILP64 silently breaks our int* wrappers (#108).
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.22")
+    if(DEFINED BLA_SIZEOF_INTEGER AND NOT "${BLA_SIZEOF_INTEGER}" STREQUAL "4")
+        message(FATAL_ERROR
+            "MRTKLIB requires LP64 BLAS/LAPACK (32-bit integer interface). "
+            "Set -DBLA_SIZEOF_INTEGER=4 or unset it.")
+    endif()
+    set(BLA_SIZEOF_INTEGER 4 CACHE STRING
+        "BLAS/LAPACK integer size (MRTKLIB requires 4)")
+endif()
 find_package(LAPACK)
 if(LAPACK_FOUND)
     target_compile_definitions(mrtklib PRIVATE LAPACK)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ streamed from an active `mrtk run` session.
 ### Prerequisites
 * CMake (>= 3.15)
 * C11 compatible compiler (GCC, Clang)
-* LAPACK/BLAS (Optional but recommended for fast matrix operations. e.g., `liblapack-dev` on Ubuntu, Accelerate framework on macOS)
+* LAPACK/BLAS (Optional but recommended for fast matrix operations. e.g., `liblapack-dev` on Ubuntu, Accelerate framework on macOS) — **requires LP64 (32-bit integer) ABI**; ILP64 providers are not supported. With CMake ≥ 3.22 this is enforced automatically; on older CMake, ensure your BLAS/LAPACK is built with `BLA_SIZEOF_INTEGER=4`.
 
 ### Build Instructions
 MRTKLIB uses standard CMake workflow. Out-of-source builds are strictly recommended.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ streamed from an active `mrtk run` session.
 ### Prerequisites
 * CMake (>= 3.15)
 * C11 compatible compiler (GCC, Clang)
-* LAPACK/BLAS (Optional but recommended for fast matrix operations. e.g., `liblapack-dev` on Ubuntu, Accelerate framework on macOS) — **requires LP64 (32-bit integer) ABI**; ILP64 providers are not supported. With CMake ≥ 3.22 this is enforced automatically; on older CMake, ensure your BLAS/LAPACK is built with `BLA_SIZEOF_INTEGER=4`.
+* LAPACK/BLAS (Optional but recommended for fast matrix operations. e.g., `liblapack-dev` on Ubuntu, Accelerate framework on macOS) — **requires the LP64 (32-bit integer) interface**; ILP64 providers are not supported (for example, avoid OpenBLAS built with `INTERFACE64=1`). On CMake ≥ 3.22 this is enforced automatically by `FindBLAS`/`FindLAPACK` via `BLA_SIZEOF_INTEGER=4` — note that this is a CMake selection hint, not a BLAS/LAPACK build-time option. On older CMake, install an LP64 build of your BLAS/LAPACK provider (the default for most distributions).
 
 ### Build Instructions
 MRTKLIB uses standard CMake workflow. Out-of-source builds are strictly recommended.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ streamed from an active `mrtk run` session.
 ### Prerequisites
 * CMake (>= 3.15)
 * C11 compatible compiler (GCC, Clang)
-* LAPACK/BLAS (Optional but recommended for fast matrix operations. e.g., `liblapack-dev` on Ubuntu, Accelerate framework on macOS) — **requires the LP64 (32-bit integer) interface**; ILP64 providers are not supported (for example, avoid OpenBLAS built with `INTERFACE64=1`). On CMake ≥ 3.22 this is enforced automatically by `FindBLAS`/`FindLAPACK` via `BLA_SIZEOF_INTEGER=4` — note that this is a CMake selection hint, not a BLAS/LAPACK build-time option. On older CMake, install an LP64 build of your BLAS/LAPACK provider (the default for most distributions).
+* LAPACK/BLAS (Optional but recommended for fast matrix operations. e.g., `liblapack-dev` on Ubuntu, Accelerate framework on macOS) — **requires the LP64 (32-bit integer) interface**; ILP64 providers are not supported (for example, avoid OpenBLAS built with `INTERFACE64=1`). On CMake ≥ 3.22, MRTKLIB requests a 32-bit integer BLAS/LAPACK interface by setting `BLA_SIZEOF_INTEGER=4`. This is a CMake selection hint, not a complete ABI verifier for all BLAS/LAPACK package layouts: if `FindBLAS`/`FindLAPACK` still resolves an ILP64 provider (e.g. an ILP64 OpenBLAS published as plain `libopenblas.so` with no `64`-suffixed name), make an LP64 BLAS/LAPACK provider visible to CMake explicitly. On older CMake, install an LP64 build of your BLAS/LAPACK provider (the default for most distributions).
 
 ### Build Instructions
 MRTKLIB uses standard CMake workflow. Out-of-source builds are strictly recommended.


### PR DESCRIPTION
## Summary

Fixes #108. MRTKLIB's BLAS/LAPACK wrappers declare Fortran routines with `int *` arguments, requiring the LP64 (32-bit integer) ABI. Until now `find_package(LAPACK)` ran without constraints, so on systems where CMake resolves it to an ILP64 OpenBLAS (e.g. NixOS 26.05), integer arguments were silently misinterpreted — producing `utest_t_matrix` SegFaults, `DGEMM` illegal-parameter errors, and corrupted matrix computations.

## Changes

- **`CMakeLists.txt`**: On CMake ≥ 3.22, default `BLA_SIZEOF_INTEGER` to `4` (LP64) and reject any explicit non-`4` override with a `FATAL_ERROR` that points the user at the remediation. Wrapped in a version guard so the existing `cmake_minimum_required(VERSION 3.15)` floor is preserved.
- **`README.md`**: Document the LP64 requirement in the Prerequisites section, with a hint for users on older CMake where the guard is silently inactive.

This does **not** add ILP64 support — that would require rewriting the wrapper signatures and is explicitly out of scope per the issue.

## Verification

- ✅ Default `cmake --preset default` succeeds; `LAPACK found and enabled` message unchanged.
- ✅ `cmake -DBLA_SIZEOF_INTEGER=8` now fails fast with the expected `FATAL_ERROR`.
- ✅ Full build succeeds (`mrtk` linked).
- ✅ `ctest --output-on-failure`: 61/63 pass. The 2 failing tests (`rtkrcv_rt`, `madocalib_pppar_ion_check`) are pre-existing baseline failures on this dev box, unrelated to LAPACK linkage (macOS Accelerate is already LP64).

## Notes

- Credit to @hal1278 for the precise, well-scoped bug report including the proposed fix.
- The guard only takes effect on CMake ≥ 3.22 because `BLA_SIZEOF_INTEGER` was introduced then. Older CMake users are notified through README documentation.

## Test plan

- [ ] CI green on default configuration (LAPACK present)
- [ ] Manual: `cmake -DBLA_SIZEOF_INTEGER=8` produces the FATAL_ERROR
- [ ] (Optional, requires ILP64 OpenBLAS) Repro environment from #108 no longer crashes — surfaces a clear configuration error instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)