### PR TITLE
Promote #110 (ILP64 BLAS/LAPACK guard) to main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ if(UNIX AND NOT APPLE)
 endif()
 
 # ── System LAPACK/BLAS integration for fast matrix operations ────────────────
-# Force LP64 BLAS/LAPACK integer ABI; ILP64 silently breaks our int* wrappers (#108).
+# Request LP64 BLAS/LAPACK integer ABI; ILP64 silently breaks our int* wrappers (#108).
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.22")
     if(DEFINED BLA_SIZEOF_INTEGER AND NOT "${BLA_SIZEOF_INTEGER}" STREQUAL "4")
         message(FATAL_ERROR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,16 @@ if(UNIX AND NOT APPLE)
 endif()
 
 # ── System LAPACK/BLAS integration for fast matrix operations ────────────────
+# Force LP64 BLAS/LAPACK integer ABI; ILP64 silently breaks our int* wrappers (#108).
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.22")
+    if(DEFINED BLA_SIZEOF_INTEGER AND NOT "${BLA_SIZEOF_INTEGER}" STREQUAL "4")
+        message(FATAL_ERROR
+            "MRTKLIB requires LP64 BLAS/LAPACK (32-bit integer interface). "
+            "Set -DBLA_SIZEOF_INTEGER=4 or unset it.")
+    endif()
+    set(BLA_SIZEOF_INTEGER 4 CACHE STRING
+        "BLAS/LAPACK integer size (MRTKLIB requires 4)")
+endif()
 find_package(LAPACK)
 if(LAPACK_FOUND)
     target_compile_definitions(mrtklib PRIVATE LAPACK)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ streamed from an active `mrtk run` session.
 ### Prerequisites
 * CMake (>= 3.15)
 * C11 compatible compiler (GCC, Clang)
-* LAPACK/BLAS (Optional but recommended for fast matrix operations. e.g., `liblapack-dev` on Ubuntu, Accelerate framework on macOS)
+* LAPACK/BLAS (Optional but recommended for fast matrix operations. e.g., `liblapack-dev` on Ubuntu, Accelerate framework on macOS) — **requires LP64 (32-bit integer) ABI**; ILP64 providers are not supported. With CMake ≥ 3.22 this is enforced automatically; on older CMake, ensure your BLAS/LAPACK is built with `BLA_SIZEOF_INTEGER=4`.
 
 ### Build Instructions
 MRTKLIB uses standard CMake workflow. Out-of-source builds are strictly recommended.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ streamed from an active `mrtk run` session.
 ### Prerequisites
 * CMake (>= 3.15)
 * C11 compatible compiler (GCC, Clang)
-* LAPACK/BLAS (Optional but recommended for fast matrix operations. e.g., `liblapack-dev` on Ubuntu, Accelerate framework on macOS) — **requires LP64 (32-bit integer) ABI**; ILP64 providers are not supported. With CMake ≥ 3.22 this is enforced automatically; on older CMake, ensure your BLAS/LAPACK is built with `BLA_SIZEOF_INTEGER=4`.
+* LAPACK/BLAS (Optional but recommended for fast matrix operations. e.g., `liblapack-dev` on Ubuntu, Accelerate framework on macOS) — **requires the LP64 (32-bit integer) interface**; ILP64 providers are not supported (for example, avoid OpenBLAS built with `INTERFACE64=1`). On CMake ≥ 3.22 this is enforced automatically by `FindBLAS`/`FindLAPACK` via `BLA_SIZEOF_INTEGER=4` — note that this is a CMake selection hint, not a BLAS/LAPACK build-time option. On older CMake, install an LP64 build of your BLAS/LAPACK provider (the default for most distributions).
 
 ### Build Instructions
 MRTKLIB uses standard CMake workflow. Out-of-source builds are strictly recommended.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ streamed from an active `mrtk run` session.
 ### Prerequisites
 * CMake (>= 3.15)
 * C11 compatible compiler (GCC, Clang)
-* LAPACK/BLAS (Optional but recommended for fast matrix operations. e.g., `liblapack-dev` on Ubuntu, Accelerate framework on macOS) — **requires the LP64 (32-bit integer) interface**; ILP64 providers are not supported (for example, avoid OpenBLAS built with `INTERFACE64=1`). On CMake ≥ 3.22 this is enforced automatically by `FindBLAS`/`FindLAPACK` via `BLA_SIZEOF_INTEGER=4` — note that this is a CMake selection hint, not a BLAS/LAPACK build-time option. On older CMake, install an LP64 build of your BLAS/LAPACK provider (the default for most distributions).
+* LAPACK/BLAS (Optional but recommended for fast matrix operations. e.g., `liblapack-dev` on Ubuntu, Accelerate framework on macOS) — **requires the LP64 (32-bit integer) interface**; ILP64 providers are not supported (for example, avoid OpenBLAS built with `INTERFACE64=1`). On CMake ≥ 3.22, MRTKLIB requests a 32-bit integer BLAS/LAPACK interface by setting `BLA_SIZEOF_INTEGER=4`. This is a CMake selection hint, not a complete ABI verifier for all BLAS/LAPACK package layouts: if `FindBLAS`/`FindLAPACK` still resolves an ILP64 provider (e.g. an ILP64 OpenBLAS published as plain `libopenblas.so` with no `64`-suffixed name), make an LP64 BLAS/LAPACK provider visible to CMake explicitly. On older CMake, install an LP64 build of your BLAS/LAPACK provider (the default for most distributions).
 
 ### Build Instructions
 MRTKLIB uses standard CMake workflow. Out-of-source builds are strictly recommended.


### PR DESCRIPTION
Catch-up merge of `develop` into `main`, carrying PR #110 only.

## What's included

- **#110 — fix(build): guard against ILP64 BLAS/LAPACK provider (#108)**
  - `CMakeLists.txt`: on CMake ≥ 3.22, request `BLA_SIZEOF_INTEGER=4` (LP64) and `FATAL_ERROR` on explicit non-4 override.
  - `README.md`: document the LP64 requirement honestly, calling out that `BLA_SIZEOF_INTEGER` is a CMake selection hint (not an ABI verifier) — per @hal1278's follow-up review.

Commits:

- `c25a187` fix(build): guard against ILP64 BLAS/LAPACK provider (#108)
- `5b1f43c` docs(readme): clarify BLA_SIZEOF_INTEGER is a CMake hint, not a BLAS build option
- `1a45668` docs(readme): soften LP64 enforcement claim per #108 follow-up
- `a7fc150` docs(cmake): align comment with README "request" wording per #108 follow-up

## No tag

Build-system + docs only; no positioning/algorithm behavior change. Riding along under `v0.6.6`, consistent with the prior docs catch-up pattern (`ba39015` is already 5 commits ahead of the `v0.6.6` tag). Next tag will accompany the upcoming SSR rate estimation work on `feat/cssr2rtcm3-ssr-rate-estimation`.

## Test plan

- [x] Local `ctest --output-on-failure` on `fix/lapack-lp64-guard` before merging to develop (61/63 pass; 2 pre-existing baseline failures unrelated to LAPACK ABI)
- [x] Default `cmake --preset default` succeeds
- [x] `cmake -DBLA_SIZEOF_INTEGER=8` fires the expected `FATAL_ERROR`
- [ ] CI green on `main` after merge

Fixes #108.