### PR TITLE
docs(claude): promote AI guide refresh and public pitfalls catalog to main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,8 @@ mrtklib/
 
 ### Formatting
 
-`.clang-format` (Google base) is authoritative. Run before committing.
+- **C / C++:** `.clang-format` (Google base) is authoritative. Run before committing.
+- **TOML:** `taplo` is the formatter, configured by `taplo.toml` at the repo root. Run `taplo fmt` (or use the VS Code "Even Better TOML" extension) on any edit under `conf/`, root-level config files, or new TOML samples before committing.
 
 ### Style — what NOT to add
 
@@ -144,6 +145,22 @@ These hurt the codebase. Don't do them even if they seem helpful:
 | Coverage      | `cd build && ctest -T Coverage`                        |
 
 For long ctest runs (regression tests can take several minutes), prefer launching a `test-summarizer` subagent so the main context is not blocked. See §9.3.
+
+### Unified `mrtk` binary
+
+Since v0.6.0 the historical separate binaries (`rtkrcv`, `rnx2rtkp`, `convbin`, `str2str`, …) are consolidated into a single `mrtk` executable with subcommands. Use the unified form in new code, scripts, documentation, and configuration:
+
+| Subcommand   | Replaces / role                                          |
+|--------------|----------------------------------------------------------|
+| `mrtk run`   | `rtkrcv` — real-time positioning pipeline                |
+| `mrtk post`  | `rnx2rtkp` — post-processing positioning                 |
+| `mrtk relay` | `str2str` — relay and split data streams                 |
+| `mrtk convert` | `convbin` — raw → RINEX conversion                    |
+| `mrtk cssr2rtcm3` | Real-time CLAS CSSR → RTCM3 MSM converter (VRS)     |
+| `mrtk l6extract` | Extract L6 frames from SBF/UBX to per-PRN files       |
+| `mrtk ssr2obs` / `ssr2osr` / `bias` / `dump` / `sbf2l6` | utilities |
+
+Run `./build/mrtk --help` for the current full list and per-subcommand help via `./build/mrtk <sub> --help`. The legacy binaries are no longer built.
 
 ---
 
@@ -192,6 +209,19 @@ MRTKLIB requires an **LP64** BLAS/LAPACK provider (32-bit integer interface). On
 This is a *hint*, not enforcement: `FindBLAS.cmake` uses `BLA_SIZEOF_INTEGER` to pick between library-name candidates (e.g. `openblas` vs `openblas64`), but does not verify the resolved library's ABI. On platforms where the ILP64 build is shipped under the LP64 filename (NixOS being one), an ILP64 library can still be linked silently. Crashes in `utest_t_matrix` or any LAPACK call are the canonical symptom; the remediation is to pass an explicit LP64 provider via `CMAKE_PREFIX_PATH` or `BLAS_LIBRARIES`.
 
 Documentation and code comments should use *requests* / *hint* wording rather than *enforces* / *forces*.
+
+### 7.7 Antenna PCV array width: `NFREQPCV`, not `NFREQ`
+
+Two constants in `include/mrtklib/mrtk_foundation.h`:
+
+- `NFREQ = 3`     — number of carrier frequencies used by the positioning engines
+- `NFREQPCV = 12` — number of carrier frequencies stored in `pcv_t` (antenna phase-center parameters)
+
+`antmodel()` and `antmodel_s()` in `src/models/mrtk_antenna.c` loop `for (i = 0; i < NFREQPCV; i++)` and write **12 elements** into the output `double *dant` argument. The function signature gives no size hint, and the docstring only says "range offsets for each frequency".
+
+Callers that allocate `double dant[NFREQ]` (= 3 elements) and pass it to `antmodel()` will overflow the buffer by 9 doubles. The symptom is silent stack/heap corruption that only triggers when a non-zero PCV value is written into one of the upper slots.
+
+**Rule:** When calling `antmodel()` / `antmodel_s()`, the output buffer must be sized `NFREQPCV` (or `MAXFREQ`, whichever is in use locally). Audit any new caller for this. Do not change the loop bound to `NFREQ` without auditing every caller of `pcv_t`-aware code first.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ Since v0.6.0 the historical separate binaries (`rtkrcv`, `rnx2rtkp`, `convbin`, 
 | `mrtk convert` | `convbin` — raw → RINEX conversion                    |
 | `mrtk cssr2rtcm3` | Real-time CLAS CSSR → RTCM3 MSM converter (VRS)     |
 | `mrtk l6extract` | Extract L6 frames from SBF/UBX to per-PRN files       |
-| `mrtk ssr2obs` / `ssr2osr` / `bias` / `dump` / `sbf2l6` | utilities |
+| `mrtk ssr2obs` / `ssr2osr` / `bias` / `dump` | utilities                |
 
 Run `./build/mrtk --help` for the current full list and per-subcommand help via `./build/mrtk <sub> --help`. The legacy binaries are no longer built.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,17 +256,29 @@ For any task with 3+ steps or architectural impact:
 
 ### 9.3 Subagent strategy
 
-Use the `Agent` tool (subagents) when the work is independent, would consume the main context window, or benefits from a fresh perspective. One focused task per subagent — do not mix concerns.
+The `Agent` tool has real costs: the subagent has no context from the current conversation (cold-start briefing required), its findings are lossy-compressed into a single return message, spawn latency is fixed, and it cannot ask the user a clarifying question mid-task. Use it selectively, not by default.
 
-Typical subagent shapes:
+**Use a subagent when:**
 
-- **Algorithm safety review** — inspect a diff for matrix / filter / constants changes. Run before commit for any change under `src/pos/`, `src/clas/`, `src/madoca/`, `src/models/`.
-- **Test suite runner** — build and run the full ctest suite, return a compact summary. Use for long ctest runs so the main context is not blocked.
-- **Upstream diff classifier** — compare MRTKLIB against an upstream library and classify hunks by adoption category. Use for sync branches with many files changed.
-- **Codebase research** — open-ended "where is X handled / how does Y work" questions that span several files.
-- **Documentation generation** — Doxygen stubs for undocumented public functions in a single file.
+- The work is long-running (full ctest, large build, multi-file research) and would block the main response
+- The task is open-ended exploration that would consume significant context (e.g. "find every place X is referenced and classify each")
+- Multiple independent investigations can run in parallel — issue them in a **single message with multiple `Agent` tool uses** so they execute concurrently
+- The task matches a pre-configured specialised agent (algorithm safety review, test summarizer, upstream classifier)
 
-The maintainer-local Claude Code workspace provides pre-configured agents for several of the above (under `.claude/agents/`, gitignored). External contributors can configure their own.
+**Do NOT use a subagent when:**
+
+- The target file path or symbol is already known — use `Read` / `Grep` / `Glob` directly
+- The briefing cost (writing a self-contained prompt) exceeds the context the subagent would save
+- The task needs intermediate clarification back to the user
+- A direct edit / single-file change is what's actually required
+
+**Typical specialised shapes** (project conveniences live under `.claude/agents/`, gitignored; external contributors can configure their own):
+
+- Algorithm safety review for diffs under `src/pos/`, `src/clas/`, `src/madoca/`, `src/models/`
+- Test suite runner for long ctest invocations (the run takes minutes; main context stays free)
+- Upstream diff classifier for sync branches touching many files
+
+One focused task per subagent — do not mix concerns. When you delegate, do not duplicate the same search yourself.
 
 ### 9.4 Self-improvement loop
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,55 +1,43 @@
 # MRTKLIB — AI Development Guide
 
-## 0. Session Start Protocol (Read This First, Every Time)
+## 0. Session Start Protocol
 
-Before doing anything else, run these three steps:
+Before doing anything else, run these checks:
 
 ```bash
-cat tasks/todo.md       # What is in progress?
-cat tasks/lessons.md    # What mistakes have been made before?
-git status              # What is the current state of the working tree?
+git status                              # current working tree
+[ -f tasks/todo.md ] && cat tasks/todo.md           # active task (maintainer-local; absent in clones)
+[ -f tasks/lessons.md ] && cat tasks/lessons.md     # cumulative lessons (maintainer-local; absent in clones)
 ```
 
-Then state: "I have reviewed todo.md, lessons.md, and git status. Current focus: [active task from todo.md]."
-Do not proceed until this is done.
+Then state: "I have reviewed [files actually read]. Current focus: [active task, or 'no maintainer-local task state, will rely on git status and the user prompt']."
+
+`tasks/` is gitignored. In a fresh clone the AI proceeds without it; in the maintainer's environment those files are the canonical session-handoff state and must be read.
 
 ---
 
 ## 1. Project Overview
 
-**MRTKLIB** is a modernized, unified GNSS positioning library that integrates JAXA's MALIB, CLASLIB, and MADOCALIB into a single cohesive C/C++ package built on a modern CMake/vcpkg architecture.
+**MRTKLIB** is a modernized, unified GNSS positioning library that integrates JAXA's MALIB, CLASLIB, and MADOCALIB into a single cohesive C/C++ package on a CMake/vcpkg foundation.
 
 ### Current Phase: Algorithm Refinement & Real-Time Expansion
 
-All three upstream libraries (MALIB, MADOCALIB, CLASLIB) are fully integrated.
-Post-processing and real-time engines are operational for PPP, PPP-AR, PPP-RTK,
-and VRS-RTK modes. Current work focuses on algorithm improvements and real-time
-feature expansion.
+All three upstream libraries (MALIB, MADOCALIB, CLASLIB) are fully integrated. Post-processing and real-time engines are operational for PPP, PPP-AR, PPP-RTK, and VRS-RTK modes. Current work focuses on algorithm refinement and real-time feature expansion.
 
-### Version History
+### Recent Releases
 
-| Version | Engine | Improvements | Status |
-|---------|--------|-------------|--------|
-| **v0.4.1** | RTK | demo5 PAR, `detslp_dop`/`detslp_code`, full-constellation `varerr`, false-fix persistence fix | ✅ Released |
-| **v0.4.2** | PPP-RTK, PPP | demo5 `detslp_dop`/`detslp_code`, GLONASS clock guard in `ephpos()`, PAR variance gate + arfilter, full-constellation EFACT, adaptive outlier threshold | ✅ Released |
-| **v0.4.3** | PPP-RTK | Real-time CLAS PPP-RTK via `rtkrcv` (BINEX+L6, SBF+L6, RTCM3+UBX; 97.7% fix rate) | ✅ Released |
-| **v0.4.4** | PPP-RTK | Dual-channel CLAS real-time via `rtkrcv` | ✅ Released |
-| **v0.5.0** | All | TOML configuration (replaces legacy `.conf`) | ✅ Released |
-| **v0.5.1** | PPP-RTK | Bug fix: dual-channel CLAS RT fix rate degradation ([#35](https://github.com/h-shiono/MRTKLIB/issues/35)) | ✅ Released |
-| **v0.5.2** | All | Code quality: mandatory braces, nested ternary elimination (67 files) | ✅ Released |
-| **v0.5.3** | All | Code quality: full `clang-format` application (116 files, Google style) | ✅ Released |
-| **v0.5.4** | All | Signals update: frequency / physical band separation and structuring | ✅ Released |
-| **v0.5.5** | PPP-RTK | Bug fix: CLAS real-time via UBX ([#31](https://github.com/h-shiono/MRTKLIB/issues/31)) | ✅ Released |
-| **v0.5.6** | All | RINEX 4.00 CNAV/CNV2 NAV support (GPS, QZSS, BDS) | ✅ Released |
-| **v0.5.7** | — | Port `convbin` and `str2str` CLI applications | ✅ Released |
-| **v0.6.0** | All | Unified `mrtk` binary with subcommands; BSS reduced 3 GB → 34 MB | ✅ Released |
-| **v0.6.1** | All | Config UX: `systems` list, `excluded_sats`, `taplo` formatter | ✅ Released |
-| **v0.6.2** | — | MkDocs Material site + Doxygen API reference + GitHub Pages | ✅ Released |
-| **v0.6.3** | Stream | NTRIP v2 (HTTP/1.1) protocol support with auto-negotiation, chunked transfer encoding, URL percent-decoding | ✅ Released |
-| **v0.6.4** | rtkrcv / Repo | rtkrcv status-path stability fixes (data race + OOB + async-signal-safe SIGSEGV handler); GitHub Community Profile | ✅ Released |
-| **v0.6.5** | cssr2rtcm3 | First official release of `mrtk cssr2rtcm3` (real-time CSSR→RTCM3 MSM converter) and `mrtk l6extract`; mosaic-G5 P3 hardware guide; 24-hour static endurance test | ✅ Released |
-| **v0.6.6** | CLI | Unified `mrtk` subcommand help format and GNU-style long-option aliases (`--config`, `--output`, `--start`, `--end`, `--interval`, `--trace`, `--input`, `--nav`, `--device`, `--port`, `--freq`, `--help`); legacy binary headers removed | ✅ Released |
-| **v0.6.x** | All | Doxygen docstring coverage expansion | 💭 Backlog |
+See [`docs/releases/changelog.md`](docs/releases/changelog.md) for the full history. Recent highlights:
+
+| Version | Theme |
+|---------|-------|
+| v0.5.x | TOML configuration, code quality sweeps, signals restructuring, RINEX 4.00 CNAV, `convbin` / `str2str` ports |
+| v0.6.0 | Unified `mrtk` binary with subcommands (BSS reduced 3 GB → 34 MB) |
+| v0.6.1 | Config UX: `systems` list, `excluded_sats`, `taplo` formatter |
+| v0.6.2 | MkDocs Material site + Doxygen API reference + GitHub Pages |
+| v0.6.3 | NTRIP v2 (HTTP/1.1) protocol support |
+| v0.6.4 | rtkrcv status-path stability + GitHub Community Profile |
+| v0.6.5 | First official `mrtk cssr2rtcm3` release + 24-hour endurance test |
+| v0.6.6 | Unified subcommand help format + GNU-style long-option aliases |
 
 ### Test Status
 
@@ -59,26 +47,29 @@ Run `cd build && ctest --output-on-failure` to get current counts. Last known: 6
 
 ## 2. AI Role — Current Phase
 
-Focus areas in priority order:
+Focus areas, in priority order:
 
-1. **Algorithm Improvements:** Port and validate demo5/upstream algorithm refinements. All changes require before/after accuracy comparison.
-2. **Real-Time Feature Expansion:** New rtkrcv modes, stream handling, multi-constellation support.
-3. **Regression Guarding:** No change is complete without running the full test suite.
-4. **Code Quality:** Docstrings, const-correctness, C++ modernization — but only after tests pass.
-5. **Upstream Sync:** When MALIB/CLASLIB/MADOCALIB updates are detected, assess impact and cherry-pick selectively.
+1. **Algorithm improvements.** Port and validate demo5 / upstream algorithm refinements. All numerical changes require before/after accuracy comparison.
+2. **Real-time feature expansion.** New rtkrcv modes, stream handling, multi-constellation support.
+3. **Regression guarding.** No change is complete without running the full test suite.
+4. **Code quality.** Docstrings, const-correctness, modernization — but only after tests pass.
+5. **Upstream sync.** When MALIB / CLASLIB / MADOCALIB updates are detected, assess impact and cherry-pick selectively.
 
 ---
 
 ## 3. NEVER DO
 
-These are hard rules. No exceptions, no matter how reasonable it seems in context.
+Hard rules. No exceptions, no matter how reasonable an action seems in context.
 
-- **NEVER alter GNSS algorithms, matrix operations, or physical constants** during structural/refactoring work unless explicitly instructed.
-- **NEVER create `rtcm_t` on the stack or in static arrays** — it is ~103 MB. Always heap-allocate with `calloc`.
+- **NEVER alter GNSS algorithms, matrix operations, or physical constants** during structural / refactoring work unless explicitly instructed.
+- **NEVER create `rtcm_t` on the stack or in static arrays** — it is ~103 MB. Always heap-allocate with `calloc`. See §7.1 for the size table of other large structs.
 - **NEVER mark a task complete without running `ctest --output-on-failure`** and confirming all tests pass.
-- **NEVER assume upstream library behavior** — check the actual source when integrating.
-- **NEVER silently swallow a test tolerance change** — always flag it to the user with the numerical delta.
+- **NEVER assume upstream library behavior** — read the actual source when integrating.
+- **NEVER silently swallow a test tolerance change** — flag it to the user with the numerical delta.
 - **NEVER push to `main` directly** — all changes go through a feature branch.
+- **NEVER commit changes without an explicit user request.** "Looks good, ship it" or equivalent is required.
+- **NEVER skip pre-commit hooks** (`--no-verify`, `--no-gpg-sign`) or bypass signing. Hook failures must be root-caused, not bypassed.
+- **NEVER run destructive git operations without explicit confirmation:** `git push --force`, `git reset --hard`, `git branch -D`, `git filter-branch`, `git clean -fdx`, history rewrites. When in doubt, ask before acting.
 
 ---
 
@@ -89,28 +80,35 @@ mrtklib/
 ├── apps/                  # Executable entry points (CLI, GUI)
 ├── include/mrtklib/       # Public headers
 ├── src/                   # Core implementation (mrtk_*.c / .cpp)
-│   ├── pos/               # Positioning engines (ppp, ppp_ar, ppp_iono, spp, rtkpos, postpos)
-│   ├── madoca/            # MADOCA-PPP L6E/L6D decoders
-│   ├── models/            # Atmospheric, antenna, tides models
-│   ├── data/              # Ephemeris, observation, navigation data handlers
-│   ├── rtcm/              # RTCM3 encoder/decoder
-│   └── stream/            # Real-time data streams
+│   ├── pos/               #   Positioning engines (ppp, ppp_ar, ppp_iono, spp, rtkpos, postpos)
+│   ├── madoca/            #   MADOCA-PPP L6E/L6D decoders
+│   ├── models/            #   Atmospheric, antenna, tide models
+│   ├── data/              #   Ephemeris, observation, navigation data handlers
+│   ├── rtcm/              #   RTCM3 encoder/decoder
+│   └── stream/            #   Real-time data streams
 ├── tests/                 # CTest-based regression & unit tests
-├── conf/                  # Configuration files
-├── tasks/                 # todo.md, lessons.md (always kept current)
-└── vcpkg/                 # Dependency management
+├── conf/                  # Configuration files (TOML)
+├── docs/                  # User-facing docs (MkDocs); docs/dev/ for developer references
+├── vcpkg/                 # Dependency management
+├── tasks/                 # Maintainer-local task tracker & lessons (gitignored)
+└── .claude/               # Maintainer-local Claude Code config (gitignored)
 ```
+
+`tasks/` and `.claude/` are gitignored. A fresh clone of the repository will not contain them. Anything that needs to be visible to external contributors lives under `docs/`, `include/`, `src/`, `tests/`, `conf/`, or in the project README.
 
 ---
 
 ## 5. Coding Standards
 
-### Language Standards
-- **C++:** C++17 minimum. Use `<filesystem>`, structured bindings, `if constexpr` where appropriate.
-- **C:** C11 for legacy-compatible files. Maintain `extern "C"` in headers included by C files.
+### Language
 
-### Docstrings (mandatory for all public functions)
-```cpp
+- **C:** C11 for new code. The library target compiles with `-std=c11`; the global `-ansi` flag is overridden per-target (see [`docs/dev/pitfalls-public.md`](docs/dev/pitfalls-public.md) P-01).
+- **C++:** C++17 for new C++ files (currently a small fraction of the codebase). Use `<filesystem>`, structured bindings, `if constexpr` where they help readability.
+- **Headers consumed by C:** maintain `extern "C"` blocks.
+
+### Docstrings (mandatory for public API)
+
+```c
 /**
  * @brief Short description.
  * @param[in]  param_name  Description.
@@ -119,130 +117,195 @@ mrtklib/
  */
 ```
 
-### C++ Modernization Rules
-- Prefer `std::vector` over raw arrays for new code.
-- Use smart pointers (`std::unique_ptr`, `std::shared_ptr`) for new heap allocations.
-- Rigorous `const` correctness on all parameters.
-- Do not modernize legacy C code in the same commit as algorithm changes.
-
 ### Formatting
-`.clang-format` is authoritative. Run before committing.
+
+`.clang-format` (Google base) is authoritative. Run before committing.
+
+### Style — what NOT to add
+
+These hurt the codebase. Don't do them even if they seem helpful:
+
+- **Don't write comments that restate the code.** Comments are for the *why* when it's non-obvious — a hidden constraint, a subtle invariant, a workaround for a specific bug. If a comment would only say what the code already says, omit it.
+- **Don't add backwards-compatibility shims** (renamed-and-kept-old-name, deprecated aliases) unless the user explicitly asks. The codebase has no external API stability guarantee outside `include/mrtklib/`.
+- **Don't add error handling for cases that can't happen.** Trust internal code and framework guarantees. Validate at system boundaries (user input, file parsing, network), not between trusted internal modules.
+- **Don't introduce abstractions for hypothetical future requirements.** Three similar lines is preferable to a premature template / factory / strategy pattern. Only abstract when the third or fourth concrete case appears.
+- **Don't modernize legacy C in the same commit as an algorithm change.** Two separate commits, each independently reviewable.
 
 ---
 
 ## 6. Build & Test Commands
 
-| Action        | Command                                      |
-|---------------|----------------------------------------------|
-| Configure     | `cmake --preset default`                     |
-| Build         | `cmake --build build`                        |
-| Test (all)    | `cd build && ctest --output-on-failure`      |
-| Test (filter) | `cd build && ctest -R <pattern> --output-on-failure` |
-| Coverage      | `cd build && ctest -T Coverage`              |
+| Action        | Command                                                |
+|---------------|--------------------------------------------------------|
+| Configure     | `cmake --preset default`                               |
+| Build         | `cmake --build build`                                  |
+| Test (all)    | `cd build && ctest --output-on-failure`                |
+| Test (filter) | `cd build && ctest -R <pattern> --output-on-failure`   |
+| Coverage      | `cd build && ctest -T Coverage`                        |
+
+For long ctest runs (regression tests can take several minutes), prefer launching a `test-summarizer` subagent so the main context is not blocked. See §9.3.
 
 ---
 
 ## 7. Key Technical Notes (Accumulated)
 
-### 7.1 rtcm_t Struct Size
-`rtcm_t` ≈ 103 MB. Never stack-allocate. Use `calloc` + pointer arrays for multiple instances.
+### 7.1 Large struct sizes — always heap-allocate
 
-### 7.2 LAPACK vs Embedded LU Solver
-MRTKLIB uses system LAPACK; upstream madocalib uses an embedded LU solver. Expect ~1.5–3.8 cm numerical differences in PPP-AR solutions. Test tolerances are adjusted accordingly — never tighten without explicit sign-off.
+| Type | Approximate size |
+|------|-----------------|
+| `rtksvr_t` | ~972 MB |
+| `rtcm_t` | ~103 MB |
+| `osb_t` | ~700 KB |
+| `clas_corr_t` | ~352 KB |
 
-### 7.3 pppiono_t Design
-MRTKLIB: heap-allocated pointer `nav->pppiono = calloc(...)`. Upstream: embedded struct `nav.pppiono`. All access uses `->`, not `.`.
+Never stack-allocate or place these in static arrays. Use `calloc()` and pass by pointer. For multiple instances, use an array of pointers (not an array of structs).
 
-### 7.4 Multi-Channel Support
-- **CLAS L6D:** Post-processing and real-time both support dual-channel (`CLAS_CH_NUM=2`). In rtkrcv: stream 1 (base slot) = ch2, stream 2 = ch1.
+### 7.2 LAPACK vs embedded LU solver
+
+MRTKLIB links system LAPACK; upstream MADOCALIB uses an embedded LU solver. Expect ~1.5–3.8 cm numerical differences in PPP-AR solutions. Test tolerances are adjusted accordingly — **never tighten without explicit sign-off**.
+
+### 7.3 `pppiono_t` design
+
+MRTKLIB uses a heap-allocated pointer: `nav->pppiono = calloc(...)`. Upstream embeds the struct as `nav.pppiono`. All MRTKLIB access uses `->`, not `.`.
+
+### 7.4 Multi-channel support
+
+- **CLAS L6D:** Both post-processing and real-time support dual-channel (`CLAS_CH_NUM=2`). In rtkrcv, stream 1 (base slot) = ch2, stream 2 = ch1.
 - **MADOCA L6E:** Post-processing supports multi-L6E via `SSR_CH_NUM=2`. Real-time is single-stream.
 
-### 7.5 Known Bug Patterns (from lessons.md)
-- `initx()` placement: must be called before the state is used, not after. Misplacement causes silent filter divergence.
-- `filter()` skips zero-initialized states: always explicitly initialize state covariance to a nonzero value before first use.
+### 7.5 Known pitfalls
 
-> *More entries are in `tasks/lessons.md`. Section 7.5 is a summary of the highest-impact patterns only.*
+The repeatable pitfall patterns are catalogued in [`docs/dev/pitfalls-public.md`](docs/dev/pitfalls-public.md). Topics covered:
+
+- Build & toolchain (global `-ansi` flag, `BLA_SIZEOF_INTEGER` hint vs. guarantee, `trace()` no-op)
+- Memory & allocation (`MAXSAT` vs `MAXOBS`, `glorbit()` non-convergence)
+- GNSS algorithm pitfalls (frequency slot hardcoding, `nav->eph[]` direct indexing, GAL F/NAV slot, MSM signal-ID tables, MSM encoder semantics, CLAS `nf=2`)
+- Platform & runtime (macOS `cu.*` serial, diagnosing stuck daemons)
+- CSSR / IS-QZSS-L6 subtype reference
+
+Read that file when touching any of these areas, and consult it before commit when running `/review`. The maintainer keeps a longer internal investigation log; the public catalog distils the reusable rules.
+
+### 7.6 BLAS/LAPACK LP64 ABI
+
+MRTKLIB requires an **LP64** BLAS/LAPACK provider (32-bit integer interface). On CMake ≥ 3.22, `CMakeLists.txt` sets `BLA_SIZEOF_INTEGER=4` as a request to `FindBLAS.cmake` and rejects an explicit `=8` override with `FATAL_ERROR`.
+
+This is a *hint*, not enforcement: `FindBLAS.cmake` uses `BLA_SIZEOF_INTEGER` to pick between library-name candidates (e.g. `openblas` vs `openblas64`), but does not verify the resolved library's ABI. On platforms where the ILP64 build is shipped under the LP64 filename (NixOS being one), an ILP64 library can still be linked silently. Crashes in `utest_t_matrix` or any LAPACK call are the canonical symptom; the remediation is to pass an explicit LP64 provider via `CMAKE_PREFIX_PATH` or `BLAS_LIBRARIES`.
+
+Documentation and code comments should use *requests* / *hint* wording rather than *enforces* / *forces*.
 
 ---
 
 ## 8. Git Conventions
 
-### Branch Naming
+### Branch naming
+
 ```
 feat/<short-description>      # New feature
 fix/<short-description>       # Bug fix
 test/<short-description>      # Test additions/changes
 refactor/<short-description>  # Non-functional cleanup
 docs/<short-description>      # Documentation only
+sync/<library>-<date>         # Upstream sync
 ```
 
-### Commit Messages (Conventional Commits)
+### Commit messages (Conventional Commits)
+
 ```
 feat(ppp): add triple-frequency ambiguity resolution
 fix(clas): correct channel assignment in dual-stream mode
-test(madoca): add PPP-AR accuracy regression for 2024-01-15
+test(madoca): add PPP-AR accuracy regression for <data>
 refactor(rtcm): replace raw array with std::vector in msg buffer
 docs(api): add doxygen for mrtk_ppppos()
 ```
 
-### Upstream Sync Policy
-When MALIB/CLASLIB/MADOCALIB upstream updates are available:
+### Upstream sync policy
+
+When MALIB / CLASLIB / MADOCALIB upstream updates are available:
+
 1. Create branch `sync/<library>-<date>`.
 2. Run `git diff upstream/main -- <relevant files>` to identify changes.
-3. Classify each change: algorithm (needs sign-off) vs. bugfix (can cherry-pick) vs. formatting (ignore).
+3. Classify each hunk: algorithm (needs sign-off) / bugfix (can cherry-pick) / formatting (ignore).
 4. Cherry-pick only after explicit user approval for algorithm changes.
-5. Run full test suite. Document numerical deltas.
+5. Run the full test suite. Document numerical deltas.
 
 ---
 
 ## 9. Workflow Rules
 
-### 9.1 Bug Fix vs. Design Change
-- **Bug fix** (behavior clearly wrong, test is failing): Fix autonomously. Report what you found and what you changed.
-- **Design change** (new architecture, new algorithm, new API): Write plan to `tasks/todo.md` and check in with user before implementing.
+### 9.1 Bug fix vs. design change
+
+- **Bug fix** (behaviour clearly wrong, test failing): fix autonomously. Report what was found and what changed.
+- **Design change** (new architecture, new algorithm, new API surface): write a plan and check in before implementing.
 - When in doubt: it is a design change. Ask.
 
-### 9.2 Plan-First for Non-Trivial Work
+### 9.2 Planning artefacts
+
+Three different planning surfaces, each with its own role:
+
+| Surface | Role | Lifetime |
+|---------|------|----------|
+| **Plan mode** (`ExitPlanMode`) | Pre-implementation alignment with the user on the *approach* | This message |
+| **`TodoWrite`** | In-session progress tracking across multi-step work | This session |
+| **`tasks/todo.md`** (maintainer-local) | Cross-session task continuity, hand-off between sessions | Until the task ships |
+
 For any task with 3+ steps or architectural impact:
-1. Write a plan to `tasks/todo.md` with checkable items.
-2. Present the plan. Wait for approval.
-3. Implement. Mark items complete as you go.
-4. After completion, add a review note to `tasks/todo.md`.
 
-### 9.3 Subagent Strategy
-Use subagents (Task tool) liberally to keep the main context clean:
-- **Research agent:** "Investigate how upstream CLASLIB handles X — summarize findings."
-- **Test agent:** "Run the full test suite and report failures with context."
-- **Diff agent:** "Compare algorithm in mrtk_ppppos.c against madocalib reference — flag mathematical differences."
-- **Docs agent:** "Generate Doxygen docstrings for all undocumented public functions in src/pos/."
-- One focused task per subagent. Do not mix concerns.
+1. If the approach is non-obvious, present it through Plan mode and wait for approval.
+2. Use `TodoWrite` to track sub-steps during the session.
+3. The maintainer updates `tasks/todo.md` as the canonical record of "what is still open" between sessions.
 
-### 9.4 Self-Improvement Loop
+### 9.3 Subagent strategy
+
+Use the `Agent` tool (subagents) when the work is independent, would consume the main context window, or benefits from a fresh perspective. One focused task per subagent — do not mix concerns.
+
+Typical subagent shapes:
+
+- **Algorithm safety review** — inspect a diff for matrix / filter / constants changes. Run before commit for any change under `src/pos/`, `src/clas/`, `src/madoca/`, `src/models/`.
+- **Test suite runner** — build and run the full ctest suite, return a compact summary. Use for long ctest runs so the main context is not blocked.
+- **Upstream diff classifier** — compare MRTKLIB against an upstream library and classify hunks by adoption category. Use for sync branches with many files changed.
+- **Codebase research** — open-ended "where is X handled / how does Y work" questions that span several files.
+- **Documentation generation** — Doxygen stubs for undocumented public functions in a single file.
+
+The maintainer-local Claude Code workspace provides pre-configured agents for several of the above (under `.claude/agents/`, gitignored). External contributors can configure their own.
+
+### 9.4 Self-improvement loop
+
 After any user correction:
-1. Immediately update `tasks/lessons.md` with the pattern.
-2. Check if the same pattern appears anywhere in the current working files.
-3. If a high-impact pattern: promote to Section 7.5 of this file.
+
+1. Update the maintainer-local lessons log (`tasks/lessons.md`) immediately.
+2. Check whether the same pattern appears in the current working files.
+3. If the pattern is high-impact and generalisable, propose promotion to [`docs/dev/pitfalls-public.md`](docs/dev/pitfalls-public.md) per the local visibility policy. If it would belong in everyone's session, propose adding it to §7 of this file.
 
 ### 9.5 Definition of Done
+
 A task is done when:
+
 - [ ] All tests pass (`ctest --output-on-failure`)
 - [ ] No test tolerances were silently changed
-- [ ] Docstrings added for new/modified public functions
-- [ ] `tasks/todo.md` updated with completion note
-- [ ] Commit message follows convention
+- [ ] Doxygen docstrings exist for new / modified public functions
+- [ ] Maintainer task tracker reflects completion
+- [ ] Commit message follows Conventional Commits
+- [ ] No unrelated changes are bundled into the commit
 
 ---
 
-## 10. Custom Slash Commands
+## 10. Tooling
 
-These are defined in `.claude/commands/`. Use them to avoid repetitive setup:
+### Slash commands and skills
 
-| Command                  | What it does                                                    |
-|--------------------------|-----------------------------------------------------------------|
-| `/project:test`          | Build + run full ctest, summarize failures                      |
-| `/project:review`        | Review staged diff for GNSS algorithm safety (NEVER DO checks) |
-| `/project:lessons`       | Prompt to update lessons.md after a correction                  |
-| `/project:upstream-diff` | Show diff between MRTKLIB and upstream for a given library      |
-| `/project:docgen`        | Generate Doxygen stubs for undocumented functions in a file     |
+The maintainer's `.claude/` directory (gitignored) contains project-specific Claude Code commands and agents. They are conveniences for the maintainer's workflow, not a public API surface. External contributors using Claude Code can register equivalent commands in their own workspace.
 
-> *Command files live in `.claude/commands/<name>.md`. Add new ones as patterns emerge.*
+Examples of the patterns covered:
+
+| Pattern | What it does |
+|---------|--------------|
+| `/test` | Build + run full ctest, summarize failures |
+| `/review` | Review staged diff against §3 NEVER DO + [`docs/dev/pitfalls-public.md`](docs/dev/pitfalls-public.md) |
+| `/upstream-diff` | Compare MRTKLIB against upstream for a given library |
+| `/docgen` | Generate Doxygen stubs for undocumented functions in a file |
+
+### Tool discipline
+
+- Prefer dedicated tools over `Bash` when one fits: `Read` for files, `Edit` / `Write` for modifications, `Grep` / `Glob` for search.
+- Issue independent tool calls in parallel — sequence them only when the next call depends on the previous result.
+- Brief status updates at key moments (start of work, on finding, on direction change, on blocker). Keep the main response short; the diff and the test result speak for themselves.

--- a/docs/dev/pitfalls-public.md
+++ b/docs/dev/pitfalls-public.md
@@ -16,9 +16,12 @@ project-specific investigations; what appears here is the distilled rule set.
 ### P-01 — Global `-ansi` flag forces C90 on every new target
 
 `CMakeLists.txt` applies `add_compile_options(-ansi -pedantic)` repository-wide.
-Only the `mrtklib` library target and the unified `mrtk` binary explicitly
-override this with `-std=c11`. New executables, tests, or examples inherit
-`-ansi` (= C90) unless the override is added at the new target.
+Only a small number of explicitly-configured targets override this with
+`-std=c11` (currently the `mrtklib` library and the `t_ntrip` test). New
+executables, tests, or examples inherit `-ansi` (= C90) unless the override
+is added at the new target.
+
+`set_target_properties(... C_STANDARD 11)` and `target_compile_features(... c_std_11)` do **not** override `-ansi` once it has been pushed onto the command line by `add_compile_options()`; an explicit `target_compile_options(<target> PRIVATE -std=c11)` is required.
 
 A C99/C11 source file (mixed declarations, `for (int i = ...)`, designated
 initialisers, `// ...` comments, etc.) compiled under `-ansi` will fail on
@@ -126,9 +129,11 @@ slot 1 may be L5 (E5a) for GAL or QZS — the skip will exclude the wrong band.
 Look up the physical band dynamically:
 
 ```c
-int band = code2freq_num(sys, obs->code[f]);
-if (band == 2) continue;   /* skip L2 band, whatever slot it occupies */
+int band = code2freq_num(obs->code[f]);     /* returns 1, 2, 5, … (system-agnostic) */
+if (band == 2) continue;                    /* skip L2 band, whatever slot it occupies */
 ```
+
+The signature is `int code2freq_num(uint8_t code)` — a single code argument; no constellation needed.
 
 Under the default obsdef order for QZS, slot 0 is L1, **slot 1 is L5** (not L2),
 and slot 2 is L2. Do not rely on any specific slot mapping without a runtime

--- a/docs/dev/pitfalls-public.md
+++ b/docs/dev/pitfalls-public.md
@@ -1,0 +1,340 @@
+# MRTKLIB — Developer Pitfalls
+
+A curated reference of non-obvious behaviors that recur when developing on
+MRTKLIB. Each entry describes the trap, the rule, and a remediation pattern.
+These are derived from real maintenance experience and are useful both for
+new contributors and for AI coding assistants operating on the codebase.
+
+The entries are deliberately abstract — they teach a principle rather than
+narrating a specific incident. The maintainer keeps a richer internal log of
+project-specific investigations; what appears here is the distilled rule set.
+
+---
+
+## Build & Toolchain
+
+### P-01 — Global `-ansi` flag forces C90 on every new target
+
+`CMakeLists.txt` applies `add_compile_options(-ansi -pedantic)` repository-wide.
+Only the `mrtklib` library target and the unified `mrtk` binary explicitly
+override this with `-std=c11`. New executables, tests, or examples inherit
+`-ansi` (= C90) unless the override is added at the new target.
+
+A C99/C11 source file (mixed declarations, `for (int i = ...)`, designated
+initialisers, `// ...` comments, etc.) compiled under `-ansi` will fail on
+strict toolchains even if it builds on macOS by accident.
+
+```cmake
+# When adding a new target that uses C99+ syntax:
+target_compile_options(<target> PRIVATE -std=c11)
+```
+
+### P-02 — `BLA_SIZEOF_INTEGER` is a CMake hint, not an ABI guarantee
+
+CMake's `FindBLAS.cmake` uses `BLA_SIZEOF_INTEGER` only to choose between
+library-name candidates (e.g. `openblas` vs `openblas64` / `openblas_64`). It
+does **not** read symbol metadata from the resolved library. On platforms
+where an ILP64 build of BLAS is packaged under the same filename as the
+LP64 build, setting `BLA_SIZEOF_INTEGER=4` will still resolve to ILP64 silently
+and crash at first call.
+
+MRTKLIB sets `BLA_SIZEOF_INTEGER=4` (LP64) on CMake ≥ 3.22 and rejects an
+explicit `=8` override with `FATAL_ERROR`. Treat this as a *request* in
+documentation and code comments, not as enforcement. Wording like
+"requests LP64" is accurate; "enforces LP64" is misleading.
+
+If a user reports a crash with `BLA_SIZEOF_INTEGER=4` set, the remediation is
+to pass an explicit LP64 provider via `CMAKE_PREFIX_PATH` or `BLAS_LIBRARIES`.
+
+### P-03 — `trace()` is compiled out unless `-DTRACE` is defined
+
+The build does not define `TRACE`, so `trace(level, ...)` calls are no-op
+macros. Adding `trace(NULL, 2, "...")` for debugging will produce no output.
+
+Use `fprintf(stderr, ...)` for debug print. Always remove the lines before
+committing — leftover stderr prints are noisy in CI logs and may be flagged
+by review.
+
+---
+
+## Memory & Allocation
+
+### P-10 — Large structs must be heap-allocated
+
+Several core types are too large for the stack or for static arrays:
+
+| Type | Approximate size |
+|------|-----------------|
+| `rtksvr_t` | ~972 MB |
+| `rtcm_t` | ~103 MB |
+| `osb_t` | ~700 KB |
+| `clas_corr_t` | ~352 KB |
+
+Stack-allocating `rtcm_t var;` blows the default thread stack on Linux/macOS;
+embedding it in `static rtcm_t arr[N];` balloons the binary's BSS into the
+gigabyte range and can prevent the executable from loading.
+
+Always allocate via `calloc()` (or `new` in C++) and pass by pointer. When
+managing multiple instances, use an array of pointers, not an array of structs.
+
+### P-11 — `MAXSAT` and `MAXOBS` are different limits
+
+`MAXSAT` (~100+ when all constellations are enabled) and `MAXOBS` (96) are
+distinct constants. Iterating over satellites with `MAXSAT` while writing
+into a `MAXOBS`-sized buffer is a heap-overflow pattern that may surface only
+after hours of operation, once enough constellations have accumulated
+broadcast ephemeris to push the satellite count past 96.
+
+When the destination buffer is `obsd_t[MAXOBS]`, bound the write index
+against the buffer length, not the satellite count:
+
+```c
+for (sat = 1; sat <= MAXSAT && n < MAXOBS; sat++) {
+    /* ... append to obs[n] ... */
+}
+```
+
+### P-12 — `glorbit()` has no convergence timeout
+
+GLONASS satellite position from broadcast ephemeris is computed via a
+Runge-Kutta integrator (`glorbit()`). The integrator does not check for
+non-convergent input — given a corrupted GLONASS ephemeris with extreme
+values, it can spin indefinitely (process state `R`, ~30% CPU, no output,
+no crash).
+
+When iterating satellites for `satpos()` / `ephpos()` calls, gate the loop
+against the constellation allow-list you actually use. For example,
+CLAS-based code paths process only GPS / GAL / QZS; passing a stale or
+corrupted GLONASS satellite through `ephpos()` is unnecessary and risky.
+
+---
+
+## GNSS Algorithm Pitfalls
+
+### P-20 — Never hardcode frequency slot indices
+
+The obsdef array can be reordered. For example, `apply_pppsig()` reshuffles
+obsdef for MADOCA-style signal selection. Code such as:
+
+```c
+if (f == 1 && sys == SYS_GAL) continue;   /* WRONG */
+```
+
+makes a hidden assumption that slot 1 corresponds to L2. After reordering,
+slot 1 may be L5 (E5a) for GAL or QZS — the skip will exclude the wrong band.
+
+Look up the physical band dynamically:
+
+```c
+int band = code2freq_num(sys, obs->code[f]);
+if (band == 2) continue;   /* skip L2 band, whatever slot it occupies */
+```
+
+Under the default obsdef order for QZS, slot 0 is L1, **slot 1 is L5** (not L2),
+and slot 2 is L2. Do not rely on any specific slot mapping without a runtime
+lookup.
+
+### P-21 — `nav->eph[]` is time-sorted, not satellite-indexed
+
+`nav->eph[]` is a flat array indexed by insertion order, **not** by satellite
+ID. Direct indexing like:
+
+```c
+eph_t *eph = &nav->eph[sat - 1];   /* WRONG */
+```
+
+returns whatever ephemeris happens to occupy slot `sat-1`, almost never the
+correct one for satellite `sat`. The symptom is silent IODE mismatch, which
+typically manifests as DD ambiguity loss at every broadcast-ephemeris update
+boundary (~30 min for GPS, ~10 min for GAL).
+
+Always go through `seleph()`:
+
+```c
+eph_t *eph = seleph(time, sat, iode, nav);
+if (!eph) return 0;     /* design for NULL return */
+```
+
+Pass `iode = -1` to match any IODE; otherwise the call returns NULL when the
+requested IODE is not in the array. With SSR corrections, the requested IODE
+may legitimately be missing — the broadcast ephemeris stream and the SSR
+stream are not synchronised. Code that calls `seleph()` with a specific IODE
+must handle NULL gracefully (skip the satellite, fall back, or buffer a
+previous ephemeris generation).
+
+### P-22 — GAL F/NAV ephemeris is in `eph[sat-1+MAXSAT]`, not `eph[sat-1]`
+
+GAL has two ephemeris channels in RTCM3:
+
+| RTCM3 type | Channel | Slot in `nav->eph[]` |
+|-----------|---------|---------------------|
+| 1046 | I/NAV (E1/E5b) | `eph[sat-1]` |
+| 1045 | F/NAV (E5a) | `eph[sat-1+MAXSAT]` |
+
+`encode_type1045()` reads from the F/NAV slot. Copying GAL broadcast
+ephemeris into `eph[sat-1]` only is sufficient for the I/NAV-based encoder
+(1046) but produces empty 1045 payloads. To publish both, populate both
+slots.
+
+### P-23 — MSM signal-ID tables differ per constellation
+
+RTCM 3.3 defines different signal-ID-to-code mappings for each GNSS
+(table 3.5-91 for GPS, 3.5-99 for GAL, etc.). Signal ID 8 means `5I` in GPS
+but `6C` in GAL. ID 10 means `5X` in GPS but `6B` in GAL.
+
+Reusing a GPS lookup table for GAL produces MSM cells with valid headers but
+mis-coded signal identifiers. Receivers either drop the satellite or treat
+the signal as a different band, producing meter-level pseudorange errors.
+
+The correct per-constellation tables live in `src/rtcm/mrtk_rtcm3.c`
+(`msm_sig_gps[]`, `msm_sig_gal[]`, etc.).
+
+### P-24 — MSM encoder treats `code[j] != 0` as "satellite present"
+
+The MSM7 encoder (`encode_msm_head` / `gen_msm_index` in
+`src/rtcm/mrtk_rtcm3e.c`) builds the satellite/signal masks from
+`obs[i].code[j] != CODE_NONE`, not from the pseudorange value. An entry with
+`code[j]` set but `P[j] = 0.0` is encoded as a valid MSM cell, where the
+rough-range field overflows to its 255 sentinel. Some receivers attempt to
+use this as real data and produce kilometre-scale jumps in solution output.
+
+Drop the slot cleanly:
+
+```c
+/* either drop just this signal: */
+obs[ko].code[j] = CODE_NONE;
+obs[ko].P[j]    = 0.0;
+/* or drop the whole satellite: */
+obs[ko].sat = 0;
+```
+
+Half-populated cells (`code` set, `P` zero) must never reach the encoder.
+
+### P-25 — Forward declarations require tagged structs
+
+If a header originally defines a type via an anonymous struct:
+
+```c
+typedef struct { ... } nav_t;       /* anonymous struct */
+```
+
+then other headers cannot forward-declare `nav_t`, and pulling the full
+definition into every consumer creates an include cycle. Tag the struct:
+
+```c
+struct nav_s { ... };
+typedef struct nav_s nav_t;
+```
+
+Then a downstream header can forward-declare:
+
+```c
+struct nav_s;
+typedef struct nav_s nav_t;
+```
+
+This is the standard pattern when exposing previously-static helpers across
+translation-unit boundaries.
+
+### P-26 — CLAS configurations should use `nf=2`
+
+CLAS broadcasts ambiguity bias for L1+L5 only. Setting `nf=3` requests
+ambiguity resolution on a third band (E5b for GAL) where the bias
+correction is not provided, which silently degrades the fix rate. Use
+`nf=3` only after confirming that an E5b bias source is available (for
+example, from a third-party SSR provider running alongside CLAS).
+
+---
+
+## Platform & Runtime
+
+### P-30 — macOS serial: `cu.*` for outbound, not `tty.*`
+
+On macOS, `/dev/tty.*` device nodes block on the DCD (data carrier detect)
+line for outbound connections; the `/dev/cu.*` ("call-up") variants do not.
+Opening `/dev/tty.usbmodem*` for output to a GNSS receiver or USB serial
+bridge will hang at `open()` waiting for DCD, which most receivers never
+assert.
+
+For any programmatic outbound use on macOS, always use the `cu.*` form:
+
+```
+/dev/cu.usbmodem<NNN>     # good
+/dev/tty.usbmodem<NNN>    # blocks on DCD
+```
+
+### P-31 — Diagnose a stuck daemon before killing it
+
+When a long-running daemon stops emitting output, capture state before
+restarting. A `kill` discards the most useful evidence.
+
+| Observation | Interpretation |
+|-------------|---------------|
+| Process absent from `ps` | Truly dead. Check core file, `dmesg`, `journalctl` for SIGABRT / OOM |
+| `STAT=Z` (zombie) | Parent has not reaped. Child already exited |
+| `STAT=D` | Uninterruptible I/O wait — kernel driver or hardware issue |
+| **`STAT=R` with high CPU** | **User-space infinite loop. `gdb -p PID` will name it** |
+| `STAT=S` with low CPU | Sleeping on a syscall. Check `wchan` |
+
+Useful one-shot commands:
+
+```bash
+ps -o pid,etime,rss,vsz,pcpu,stat,cmd -p $(pgrep -f mrtk)
+sudo gdb -batch -ex "thread apply all bt" -p PID
+sudo cat /proc/PID/wchan
+sudo cat /proc/PID/stack
+sudo ls -la /proc/PID/fd/
+sudo strace -p PID -e trace=read,write,select,poll -c -t
+```
+
+A single `gdb -p` snapshot of a `STAT=R` process usually identifies the
+loop. Even non-reproducible hangs can often be root-caused from one good
+backtrace.
+
+---
+
+## CSSR / IS-QZSS-L6 Reference
+
+### P-40 — CSSR subtype quick reference
+
+| Subtype | Name | Contents |
+|---------|------|----------|
+| ST1 | Mask | Satellite / signal / cell masks per GNSS |
+| ST2 | Orbit | δ radial / along / cross + IODE |
+| ST3 | Clock | δ clock C0 |
+| ST4 | Code Bias | Per-signal code bias |
+| ST5 | Phase Bias | Per-signal phase bias + discontinuity |
+| **ST6** | Code + Phase Bias (combined) | Bias only — **no troposphere** |
+| ST7 | URA | Per-satellite URA |
+| ST8 | STEC | Per-satellite ionosphere polynomial (regional) |
+| ST9 | Gridded (legacy) | Per-grid trop + STEC residual, older format |
+| ST10 | Service Info | Grid definitions etc. |
+| ST11 | Combined Orbit/Clock | Optional network-scoped orbit+clock |
+| **ST12** | Atmospheric (STEC + Trop) | `trop_avail` / `stec_avail` flags in header |
+
+Current CLAS deployments carry troposphere corrections in **ST12** (not ST9).
+The `trop_avail` field (2 bits) governs whether the hydrostatic and wet
+parts are present; `trop_avail == 0` means the message is STEC-only for that
+network/epoch. Do not assume every ST12 message updates troposphere.
+
+Reference: IS-QZSS-L6-008 §4.1.2.2.
+
+---
+
+## How to extend this document
+
+Promote a finding from internal notes only when **all** of the following hold:
+
+- The rule generalises to any contributor working on a fresh clone
+- The rule is reproducible from the public source code alone
+- The wording is self-contained — no backreference to internal incident
+  history is needed for a reader to apply the rule
+- The phrasing is third-person principle, not a narrated investigation
+
+If a finding requires "we discovered through ... that ..." or names a
+specific commit / session / vendor to make sense, it belongs in the
+maintainer's local log, not here.
+
+When in doubt, leave it out. Missing one principle here costs an external
+contributor a question on the issue tracker; over-sharing internal context
+is irreversible.


### PR DESCRIPTION
## Summary

Promote the documentation-only changes merged into `develop` via #119 onto `main`. This brings the refreshed `CLAUDE.md` (Opus 4.7 conventions, tighter NEVER DO list, subagent Use/Do-NOT-use boundaries, unified `mrtk` binary table, `taplo` formatter, antenna PCV array width pitfall, LP64 ABI wording) and the new public-safe `docs/dev/pitfalls-public.md` to the default branch so they take effect for clones and external contributors.

No source code, build system, or test fixture changes are included.

### Commits being promoted

```
3063c7e Merge pull request #119 from h-shiono/docs/claude-md-refresh
3d9b4a1 docs(claude): address Copilot review on PR #119
a085cac docs(claude): add unified mrtk binary, taplo, and antenna PCV array width notes
2372172 docs(claude): tighten §9.3 subagent strategy with explicit do-not-use boundaries
52bfb4d docs(claude): refresh AI guide for Opus 4.7 and add public pitfalls catalog
```

## Related issues

- Promotes #119 from `develop` to `main`
- Carries forward the LP64 wording discipline from #108 / #110

## Type of change

- [x] Documentation only

## Testing

Documentation-only promotion; no source code modified. The same commits were already validated when merged into `develop` via #119. `ctest` was not re-run for this promotion.

- [x] Existing test suite still passes (no code changed since #119)
- [x] N/A — no new tests applicable for a docs-only change

## Positioning regression check

- [x] Not applicable (change does not affect the positioning pipeline)

## Breaking changes / migration notes

None.

## Checklist

- [x] I have read the coding standards in `CLAUDE.md`
- [x] Doxygen comments — N/A (no source changes)
- [x] `.clang-format` — N/A (no C/C++ changes)
- [x] No unrelated changes included in this PR (verified: `git diff origin/main..origin/develop --stat` shows only `CLAUDE.md` and `docs/dev/pitfalls-public.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)