### PR TITLE
fix(ubx): preserve invalid RAWX observations under -TADJ

### DIFF
--- a/src/data/rcv/mrtk_rcv_ublox.c
+++ b/src/data/rcv/mrtk_rcv_ublox.c
@@ -496,8 +496,12 @@ static int decode_rxmrawx(raw_t* raw) {
         }
         /* offset by time tag adjustment */
         if (toff != 0.0) {
-            P -= toff * CLIGHT;
-            L -= toff * code2freq(sys, code, frqid - 7);
+            if (P != 0.0) {
+                P -= toff * CLIGHT;
+            }
+            if (L != 0.0) {
+                L -= toff * code2freq(sys, code, frqid - 7);
+            }
         }
         /* half-cycle shift correction for BDS GEO */
         if (sys == SYS_CMP && (prn <= 5 || prn >= 59) && L != 0.0) {


### PR DESCRIPTION
## Summary

`decode_rxmrawx()` では、UBX-RXM-RAWXメッセージのデコードにおいて、疑似距離・搬送波位相を変数`P`, `L`に保存します。ただし、これらを不正な値と判定した場合、番兵として`0.0`に設定します:
https://github.com/h-shiono/MRTKLIB/blob/c696f073736e67336a5636dd7ca8a1ddd222587d/src/data/rcv/mrtk_rcv_ublox.c#L465-L470

その後、オプション`-TADJ`が有効である場合、メッセージに記録されたエポックと`-TADJ`により指定される周期のエポック間のオフセットに応じ、`P`, `L`がオフセットされます:
https://github.com/h-shiono/MRTKLIB/blob/c696f073736e67336a5636dd7ca8a1ddd222587d/src/data/rcv/mrtk_rcv_ublox.c#L497-L501

このとき、`P`, `L`の番兵を確認していないため、`P`, `L`が0でない値となり、有効な値として使用されてしまいます。
このPRはこの動作を修正するものです。

なお、番兵ではなくフラグで管理する方法もありますが、既存のコードでは疑似距離・搬送波位相観測値について同様に番兵を使用している箇所が多数あるため、このPRでは、最小変更として、番兵を使用しています。

## Type of change

- [x] Bug fix (non-breaking)

## Testing

- [x] Existing test suite still passes

## Checklist

- [x] I have read the coding standards in `CLAUDE.md`
- [ ] Doxygen comments added/updated for new or changed public functions
- [x] `.clang-format` applied (or diff is formatting-clean)
- [x] No unrelated changes included in this PR