### PR TITLE
release: ubx RAWX -TADJ invalid observation fix

### DIFF
--- a/src/data/rcv/mrtk_rcv_ublox.c
+++ b/src/data/rcv/mrtk_rcv_ublox.c
@@ -496,8 +496,12 @@ static int decode_rxmrawx(raw_t* raw) {
         }
         /* offset by time tag adjustment */
         if (toff != 0.0) {
-            P -= toff * CLIGHT;
-            L -= toff * code2freq(sys, code, frqid - 7);
+            if (P != 0.0) {
+                P -= toff * CLIGHT;
+            }
+            if (L != 0.0) {
+                L -= toff * code2freq(sys, code, frqid - 7);
+            }
         }
         /* half-cycle shift correction for BDS GEO */
         if (sys == SYS_CMP && (prn <= 5 || prn >= 59) && L != 0.0) {


### PR DESCRIPTION
## Summary

develop → main へのリリースマージ。PR #123 (fix(ubx): preserve invalid RAWX observations under -TADJ) の修正を本番ブランチへ取り込みます。

### 含まれる変更

- #123 — `decode_rxmrawx()` で `-TADJ` 有効時に invalid 観測値の番兵 (`P=0.0` / `L=0.0`) が `toff*CLIGHT` / `toff*freq` 減算で破壊されていた不具合を修正。番兵保持の `if (P != 0.0)` / `if (L != 0.0)` ガードを追加（demo5 RTKLIB が独自採用済みの修正と等価、本家 RTKLIB / MALIB / claslib upstream には未還元のバグ）

### 影響

- UBX-RXM-RAWX 受信機（u-blox 系）で `-TADJ` を使うユーザのみ影響
- 有効観測値の経路は完全に同一挙動。番兵保持のみが追加されるため回帰リスクは極小

## Test plan

- [x] develop ブランチで GitHub Actions の CI 緑を確認済み
- [ ] main マージ後に full ctest が緑であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)