### PR TITLE
fix(cssr2rtcm3): separate snr_fixed from GPS-freq posopt slot

### DIFF
--- a/apps/cssr2rtcm3/cssr2rtcm3.c
+++ b/apps/cssr2rtcm3/cssr2rtcm3.c
@@ -1347,8 +1347,12 @@ int mrtk_cssr2rtcm3(int argc, char **argv)
                 l6d_prn_fixed, l6d_prn_filter);
     }
 
-    /* SNR model: pass fixed value to OSR engine via posopt[10] */
-    prcopt.posopt[10] = (int)snr_fixed;
+    /* SNR model: pass fixed value to OSR engine via posopt[11] (reserved slot).
+     * Note: posopt[10] is GPS frequency option in clas_osr_selfreqpair, so
+     * routing snr_fixed through that slot caused a value collision (e.g.
+     * snr_fixed=50 was interpreted as an invalid freq option and silently
+     * fell back to L1+L2, breaking gps_frequency=l1+l5 etc.). */
+    prcopt.posopt[11] = (int)snr_fixed;
 
     /* set user position */
     if (has_fixed_pos) {

--- a/src/clas/mrtk_clas_osr.c
+++ b/src/clas/mrtk_clas_osr.c
@@ -1662,11 +1662,14 @@ int clas_ssr2osr(rtk_t* rtk, obsd_t* obs, int n, nav_t* nav, clas_osrd_t* osr, i
                 obs[ko].P[j] = osr[i].p[j];
                 obs[ko].L[j] = (lam_v[f] > 0.0) ? osr[i].c[j] / lam_v[f] : 0.0;
                 obs[ko].LLI[j] = (rtk->ssat[sati - 1].slip[j] & 1) ? 1 : 0;
-                /* SNR model: elevation-dependent or fixed (via posopt[10]) */
+                /* SNR model: elevation-dependent or fixed (via posopt[11]).
+                 * Note: posopt[11] is the reserved slot used by cssr2rtcm3
+                 * to carry snr_fixed without clashing with posopt[10] (GPS
+                 * frequency option in clas_osr_selfreqpair). */
                 {
                     double el = azel[i * 2 + 1]; /* elevation (rad), from zdres */
-                    double snr_db = (opt->posopt[10] > 0.0)
-                                        ? opt->posopt[10]
+                    double snr_db = (opt->posopt[11] > 0.0)
+                                        ? opt->posopt[11]
                                         : 25.0 + 20.0 * sin(el);
                     obs[ko].SNR[j] = (uint16_t)(snr_db / SNR_UNIT);
                 }

--- a/src/pos/mrtk_options.c
+++ b/src/pos/mrtk_options.c
@@ -107,7 +107,7 @@ opt_t sysopts[] = {
     {"pos1-posopt9", 3, (void*)&prcopt_.posopt[8], SWTOPT},    /* exclude QZS as refsat */
     {"pos1-posopt10", 3, (void*)&prcopt_.posopt[9], SWTOPT},   /* don't adjust phase bias */
     {"pos1-posopt11", 3, (void*)&prcopt_.posopt[10], FRQOPT2}, /* gps freq (l1+l2/l1+l5) */
-    {"pos1-posopt12", 3, (void*)&prcopt_.posopt[11], SWTOPT},  /* reserved */
+    {"pos1-posopt12", 3, (void*)&prcopt_.posopt[11], ""},      /* snr_fixed (dB-Hz, 0=elev model) */
     {"pos1-posopt13", 3, (void*)&prcopt_.posopt[12], FRQOPT2}, /* qzs freq (l1+l2/l1+l5) */
     {"pos1-gridsel", 0, (void*)&prcopt_.gridsel, "m"},
     {"pos1-rectype", 2, (void*)prcopt_.rectype[0], ""},

--- a/src/pos/mrtk_options.c
+++ b/src/pos/mrtk_options.c
@@ -107,7 +107,7 @@ opt_t sysopts[] = {
     {"pos1-posopt9", 3, (void*)&prcopt_.posopt[8], SWTOPT},    /* exclude QZS as refsat */
     {"pos1-posopt10", 3, (void*)&prcopt_.posopt[9], SWTOPT},   /* don't adjust phase bias */
     {"pos1-posopt11", 3, (void*)&prcopt_.posopt[10], FRQOPT2}, /* gps freq (l1+l2/l1+l5) */
-    {"pos1-posopt12", 3, (void*)&prcopt_.posopt[11], ""},      /* snr_fixed (dB-Hz, 0=elev model) */
+    {"pos1-posopt12", 0, (void*)&prcopt_.posopt[11], "dB-Hz"}, /* snr_fixed (dB-Hz, 0=elev model) */
     {"pos1-posopt13", 3, (void*)&prcopt_.posopt[12], FRQOPT2}, /* qzs freq (l1+l2/l1+l5) */
     {"pos1-gridsel", 0, (void*)&prcopt_.gridsel, "m"},
     {"pos1-rectype", 2, (void*)prcopt_.rectype[0], ""},


### PR DESCRIPTION
## Summary

#122 Finding 5 audit. cssr2rtcm3 used to route its \`snr_fixed\` value
(e.g. 50 dB-Hz) through \`prcopt.posopt[10]\`, the **same slot
\`clas_osr_selfreqpair()\` reads as the GPS frequency-pair option**
(POSL1L2=2, POSL1L5=3, POSL1L2L5=4, …). When the user set
\`snr_fixed = 50.0\`, the value 50 silently overwrote the GPS-frequency
selection: \`selfreqpair\` fell through to its default \`return 1\`
(L1+L2 bitmask), regardless of whatever \`gps_frequency\` was
configured.

The collision was latent in the default config (\`gps_frequency\`
unspecified ≡ "fall through to L1+L2 anyway"), so it didn't visibly
break anything in the current setups — but it would silently break
a user who set \`gps_frequency = "l1+l5"\` or \`"l1+l2+l5"\` together
with \`snr_fixed\`.

Move \`snr_fixed\` to \`posopt[11]\` (previously reserved). Update:

- \`apps/cssr2rtcm3/cssr2rtcm3.c\` — write snr_fixed into posopt[11]
- \`src/clas/mrtk_clas_osr.c\` — read SNR from posopt[11] in the VRS emit
- \`src/pos/mrtk_options.c\` — relabel \`pos1-posopt12\` to indicate it
  carries snr_fixed (dB-Hz, 0 = elevation model)

## Verification

- ctest claslib subset: **25/25 pass**.
- 60-s run on \`G5P3136g.sbf\` with \`snr_fixed = 50.0\`:
  - emitted RTCM3 MSM7 SNR is now flat \`50.000 dB-Hz\` for every sat
    (matches mosaic-CLAS, which is also flat 50 dB-Hz internally)
  - GPS frequency selection no longer corrupted by the snr_fixed value

## Test plan

- [x] ctest claslib subset green (run locally — already verified)
- [x] full ctest suite (CI)

## Related

- #122 Finding 5 (SNR audit) — closes that specific finding
- #97 / #98 — this is one of several small structural items identified
  in #122 Phase 2 analysis; no measurable Fix-rate impact expected on
  its own, but reduces future config-collision risk