### PR TITLE
feat(cssr2rtcm3): emit RTCM3 1033 (receiver descriptor)

### DIFF
--- a/apps/cssr2rtcm3/cssr2rtcm3.c
+++ b/apps/cssr2rtcm3/cssr2rtcm3.c
@@ -58,6 +58,7 @@
 #include "mrtklib/mrtk_stream.h"
 #include "mrtklib/mrtk_rcvraw.h"
 #include "mrtklib/mrtk_toml.h"
+#include "mrtklib/mrtk_version.h"
 
 /* constants and macros ------------------------------------------------------*/
 
@@ -1088,6 +1089,16 @@ static int encode_and_send_rtcm3(stream_t *strm_out, rtcm_t *rtcm,
     /* broadcast ephemeris for IODE synchronization with rover */
     total += send_ephemeris(strm_out, rtcm, obs, nav);
 
+    /* receiver / antenna descriptor (1033); sync=1 — 1006 follows.
+     * mosaic-CLAS emits 1033 every epoch alongside 1006, so we mirror that
+     * cadence rather than throttling. This identifies the (virtual) base
+     * receiver to the rover and avoids the rover applying a default-type
+     * receiver bias when the descriptor is silent (#122 Finding 2). */
+    if (gen_rtcm3(rtcm, 1033, 0, 1)) {
+        strwrite(strm_out, rtcm->buff, rtcm->nbyte);
+        total += rtcm->nbyte;
+    }
+
     /* station coordinates message (1006); sync=1 — MSM follows */
     if (gen_rtcm3(rtcm, 1006, 0, 1)) {
         strwrite(strm_out, rtcm->buff, rtcm->nbyte);
@@ -1409,6 +1420,20 @@ int mrtk_cssr2rtcm3(int argc, char **argv)
         fprintf(stderr, "RTCM init error.\n");
         goto cleanup;
     }
+
+    /* Issue #98 / #122 Finding 2: populate sta descriptors so we can emit
+     * RTCM3 1033 (receiver and antenna descriptor). The VRS has no real
+     * antenna, so antdes / antsno stay empty; receiver-side fields identify
+     * MRTKLIB cssr2rtcm3 so the rover (e.g. mosaic-G5) sees a valid base
+     * receiver record instead of inferring defaults from a silent stream. */
+    rtcm->sta.antdes[0] = '\0';
+    rtcm->sta.antsno[0] = '\0';
+    rtcm->sta.antsetup = 0;
+    strncpy(rtcm->sta.rectype, "MRTKLIB cssr2rtcm3", sizeof(rtcm->sta.rectype) - 1);
+    rtcm->sta.rectype[sizeof(rtcm->sta.rectype) - 1] = '\0';
+    snprintf(rtcm->sta.recver, sizeof(rtcm->sta.recver), "%s %s",
+             MRTKLIB_SOFTNAME, MRTKLIB_VERSION_STRING);
+    rtcm->sta.recsno[0] = '\0';
 
     /* read grid definition file */
     if (filopt.grid[0]) {


### PR DESCRIPTION
## Summary

#122 Phase 2 finding 2. mosaic-CLAS emits RTCM3 1033 (receiver and antenna descriptor) at every epoch alongside 1006; cssr2rtcm3 emits no 1033 at all. Without it the rover cannot identify the base receiver type and may fall back to a default receiver-bias model instead of one matched to the source. This PR adds 1033 emission at the same cadence mosaic-CLAS uses.

## Changes

- Populate \`rtcm->sta\` descriptor fields once at startup (after \`init_rtcm()\`):
  - \`antdes / antsno / antsetup\` — empty (VRS has no real antenna at the rover)
  - \`rectype = "MRTKLIB cssr2rtcm3"\`
  - \`recver  = "MRTKLIB <MRTKLIB_VERSION_STRING>"\`
  - \`recsno\` — empty
  Mirrors mosaic-CLAS's \`CRNSLIB / CRNSLIB_<version>_<hash>\` convention while making it obvious to anyone inspecting the stream that this is cssr2rtcm3.
- In \`send_observations()\`, call \`gen_rtcm3(rtcm, 1033, 0, 1)\` immediately before the 1006 message. Both carry \`sync=1\`; the trailing MSM7 messages keep their existing sync semantics. Cadence: 1033 every epoch, matching mosaic-CLAS.

## Verification

A 30-second cssr2rtcm3 run on \`G5P3136g.sbf\` produced:

| Type | Count |
|---|---:|
| 1006 | 939 |
| 1033 | **939** ← new |
| 1019 / 1044 / 1045 | 353 / 96 / 335 |
| 1077 / 1097 / 1117 | 939 / 939 / 939 |

The 1033 ASCII content decoded back to \`['MRTKLIB cssr2rtcm3', 'MRTKLIB 0.6.6']\`.

\`ctest -L claslib\`: **25/25 pass**.

## Test plan

- [x] ctest claslib (verified locally)
- [x] full ctest in CI
- [ ] mosaic-G5 RT run with this build to confirm the descriptor is consumed without breaking anything

## Related

- #122 Finding 2 (closed by this PR)
- #97 / #98 — same investigation track; impact on Fix rate to be measured in the next parallel 24h recording

## Note

Independent from PR #125 (snr_fixed posopt slot fix). Both are small structural cleanups from #122 Phase 2; they can land in either order.