### PR TITLE
fix(vscode): drop machine-specific clangd.path, document override (#128)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,6 @@
     "--header-insertion=never",
     "--compile-commands-dir=${workspaceFolder}/build"
   ],
-  "clangd.path": "/opt/homebrew/opt/llvm/bin/clangd",
   "C_Cpp.intelliSenseEngine": "disabled",
   "[toml]": {
     "editor.defaultFormatter": "tamasfe.even-better-toml",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,31 @@ All 62 tests must pass before you open a PR. If your change makes a test
 fail intentionally, update the test in the same commit and explain why in
 the commit message.
 
+#### Editor setup (optional, VS Code)
+
+The repo ships a shared VS Code workspace config so the project formatters
+work out of the box:
+
+- `.vscode/extensions.json` recommends the extensions this project uses
+  (`clangd`, `ruff`, `even-better-toml`). VS Code prompts to install them
+  on first open.
+- `.vscode/settings.json` wires those extensions to the project standards
+  (clangd for C, `compile_commands.json` from `build/`, format-on-save).
+
+The committed settings deliberately contain **no machine-specific paths**.
+clangd is auto-detected from your `PATH`. If your `clangd` is not on `PATH`
+(for example macOS Homebrew installs `llvm` keg-only), set `clangd.path` in
+your personal **User** settings — not in the workspace file — so it stays
+out of version control:
+
+```jsonc
+// User settings.json
+"clangd.path": "/opt/homebrew/opt/llvm/bin/clangd"
+```
+
+User settings take effect because the workspace file leaves `clangd.path`
+unset (precedence: Workspace > User > Default).
+
 ### 4. Follow the coding standards
 
 Project-wide rules are in [CLAUDE.md §4](CLAUDE.md). The headline items:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,8 +135,10 @@ your personal **User** settings — not in the workspace file — so it stays
 out of version control:
 
 ```jsonc
-// User settings.json
-"clangd.path": "/opt/homebrew/opt/llvm/bin/clangd"
+// User settings.json — add this key to your existing settings object
+{
+  "clangd.path": "/opt/homebrew/opt/llvm/bin/clangd"
+}
 ```
 
 User settings take effect because the workspace file leaves `clangd.path`


### PR DESCRIPTION
## Summary

Fixes #128. The committed `.vscode/settings.json` hard-coded `clangd.path` to a macOS Homebrew LLVM **absolute path** (`/opt/homebrew/opt/llvm/bin/clangd`), which does not exist on other machines. Because VS Code workspace settings override User settings, contributors could not point clangd at their own binary — breaking clangd LSP diagnostics and clang-format in the editor.

## Changes

- **`.vscode/settings.json`**: remove the machine-specific `clangd.path` line only. clangd is now auto-detected from `PATH`. The remaining 6 settings (ruff / clangd / even-better-toml formatters, `clangd.arguments` via `${workspaceFolder}`, `intelliSenseEngine` disabled, `*.h`→c association) are all portable project-standard wiring and stay committed.
- **`CONTRIBUTING.md`**: add an "Editor setup (optional, VS Code)" note explaining recommended extensions, PATH auto-detection, and how to override `clangd.path` in personal **User** settings when clangd is not on `PATH` (e.g. Homebrew keg-only LLVM).

## Why not gitignore `.vscode/settings.json`?

6 of the 7 settings are portable project standards paired 1:1 with the extensions in `.vscode/extensions.json`. They make the mandated formatters (CLAUDE.md §5: clang-format / taplo / ruff) work out of the box on clone. Dropping the whole file to remove one bad line would discard that shared wiring. Best practice: commit portable shared settings, keep machine-specific values out → those belong in each user's global User settings (precedence: Workspace > User > Default).

## Maintainer follow-up

To keep using Homebrew clangd, add to your personal VS Code **User** `settings.json`:

```jsonc
"clangd.path": "/opt/homebrew/opt/llvm/bin/clangd"
```

## Test

Editor-config / docs only — no build or runtime impact. `.vscode/settings.json` validated as well-formed JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)