### PR TITLE
docs(guide): add IGS-RTS PPP quick-start guide

### DIFF
--- a/conf/igs/rtkrcv_igsrts.toml
+++ b/conf/igs/rtkrcv_igsrts.toml
@@ -1,0 +1,221 @@
+# MRTKLIB Configuration (TOML v1.0.0)
+# Real-time IGS-RTS float PPP (correction = "igs-rts") for `mrtk run`.
+#
+# Rover observations + correction (RTCM-SSR / IGS-SSR) arrive over NTRIP. CDDIS
+# serves NTRIP over TLS (port 443) — tunnel through stunnel and point the stream
+# paths at the local endpoint (127.0.0.1:2101). See docs/guide/quickstart-igs-rts.md
+# and docs/guide/ntrip.md. Replace USER:PW and the rover stream with your own.
+#
+#   stunnel ntrip-tls.conf            # 127.0.0.1:2101 -> caster.cddis...:443
+#   mrtk run -o conf/igs/rtkrcv_igsrts.toml -p 2401 -s
+
+[positioning]
+mode = "ppp-static"                 # ppp-kine for a moving rover
+frequency = "l1+2"
+solution_type = "forward"
+elevation_mask = 15.0
+dynamics = false
+satellite_ephemeris = "brdc+ssrapc" # SSRA = APC; use brdc+ssrcom for SSRC streams
+systems = ["GPS", "Galileo"]
+correction = "igs-rts"              # must be set explicitly (shares brdc+ssrapc with qzs-madoca)
+
+[positioning.snr_mask]
+rover_enabled = false
+base_enabled = false
+L1 = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+L2 = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+L5 = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+[positioning.corrections]
+satellite_antenna = false # SSR_APC orbits are antenna-phase-center based
+receiver_antenna = true
+phase_windup = "on"
+exclude_eclipse = false
+raim_fde = false
+iono_compensation = "off"
+tidal_correction = "on"
+
+[positioning.atmosphere]
+ionosphere = "dual-freq"
+troposphere = "est-ztdgrad"
+
+[ambiguity_resolution]
+mode = "off" # float PPP (RTS phase-bias product needed for AR)
+systems = 9
+
+[ambiguity_resolution.thresholds]
+ratio = 3.0
+ratio1 = 0.9999
+ratio2 = 0.25
+ratio3 = 0.1
+ratio4 = 0.05
+elevation_mask = 15.0
+hold_elevation = 0.0
+
+[ambiguity_resolution.counters]
+lock_count = 0
+min_fix = 10
+max_iterations = 99
+out_count = 5
+
+[rejection]
+innovation = 30.0
+gdop = 30.0
+
+[slip_detection]
+threshold = 0.05
+
+[kalman_filter]
+sync_solution = false
+iterations = 1
+
+[kalman_filter.measurement_error]
+code_phase_ratio_L1 = 100.0
+code_phase_ratio_L2 = 100.0
+phase = 0.003
+phase_elevation = 0.003
+phase_baseline = 0.0
+doppler = 1.0
+
+[kalman_filter.initial_std]
+bias = 30.0
+ionosphere = 0.03
+troposphere = 0.3
+
+[kalman_filter.process_noise]
+accel_h = 1.0
+accel_v = 0.1
+bias = 1.00e-04
+ionosphere = 0.001
+troposphere = 1.00e-04
+position = 0.0
+clock_stability = 5.00e-12
+
+[receiver]
+max_age = 30.0
+ignore_chi_error = false
+bds2_bias = false
+
+[antenna.rover]
+position_type = "single" # PPP seeds position from single-point; rover is estimated
+position_1 = 0.0
+position_2 = 0.0
+position_3 = 0.0
+type = "*"               # "*" = use rover-reported antenna; set the exact ANTEX name if absent
+delta_e = 0.0
+delta_n = 0.0
+delta_u = 0.0
+
+[antenna.base]
+position_type = "llh"
+position_1 = 0.0
+position_2 = 0.0
+position_3 = 0.0
+type = ""
+delta_e = 0.0
+delta_n = 0.0
+delta_u = 0.0
+max_average_epochs = 0
+init_reset = false
+
+[output]
+format = "llh"
+header = true
+options = true
+velocity = false
+time_system = "gpst"
+time_format = "hms"
+time_decimals = 3
+coordinate_format = "deg"
+field_separator = ""
+single_output = false
+max_solution_std = 0.0
+height_type = "ellipsoidal"
+geoid_model = "internal"
+static_solution = "all"
+nmea_interval_1 = 0.0
+nmea_interval_2 = 0.0
+solution_status = "off"
+
+[files]
+satellite_atx = ""
+receiver_atx = ""  # path to an ANTEX (igs20.atx) for receiver PCV
+station_pos = ""
+geoid = ""
+ionosphere = ""
+dcb = ""
+eop = ""
+ocean_loading = ""
+fcb = ""
+bias_sinex = ""
+temp_dir = ""
+geexe = ""
+solution_stat = ""
+trace = ""
+
+[server]
+time_interpolation = false
+sbas_satellite = "0"
+rinex_option_1 = ""
+rinex_option_2 = ""
+ppp_option = ""
+rtcm_option = ""
+cycle_ms = 10
+timeout_ms = 10000
+reconnect_ms = 10000
+nmea_cycle_ms = 5000
+buffer_size = 32768
+nav_msg_select = "all"
+proxy = ""
+swap_margin = 30
+
+[console]
+passwd = ""
+timetype = "gpst"
+soltype = "deg"
+solflag = "off"
+
+# --- Streams: rover obs + SSR correction over NTRIP (via the stunnel endpoint) ---
+# Replace the rover with your own receiver (serial://..., tcpcli://...) or an IGS
+# station mountpoint. The rover stream must also deliver broadcast ephemeris
+# (RTCM 1019/1020/1042/1044/1045/1046); if it does not, add a BCEP* stream in
+# [streams.input.base]. URL-encode special characters in the password (@ -> %40).
+[streams.input.rover]
+type = "ntripcli"
+path = "USER:PW@127.0.0.1:2101/AIRA00JPN?ver=2&host=caster.cddis.eosdis.nasa.gov"
+format = "rtcm3"
+
+[streams.input.base]
+type = "off"    # optional: BCEP00BKG0 here if the rover lacks ephemeris
+path = ""
+format = ""
+nmeareq = false
+nmealat = 0.0
+nmealon = 0.0
+
+[streams.input.correction]
+type = "ntripcli"
+path = "USER:PW@127.0.0.1:2101/SSRA02IGS0?ver=2&host=caster.cddis.eosdis.nasa.gov"
+format = "rtcm3"
+
+[streams.output.stream1]
+type = "file"
+path = "igsrts_realtime.pos"
+format = "llh"
+
+[streams.output.stream2]
+type = "off"
+path = ""
+format = "llh"
+
+[streams.log.stream1]
+type = "off"
+path = ""
+
+[streams.log.stream2]
+type = "off"
+path = ""
+
+[streams.log.stream3]
+type = "off"
+path = ""

--- a/docs/guide/quickstart-igs-rts.md
+++ b/docs/guide/quickstart-igs-rts.md
@@ -1,0 +1,205 @@
+# Quick Start: IGS-RTS PPP
+
+Conventional **float PPP** from the **IGS Real-Time Service (RTS)** — a global,
+open, real-time **RTCM-SSR / IGS-SSR (MT4076)** correction stream (orbit, clock,
+code bias). No base station and no regional augmentation are required; corrections
+arrive over the internet via NTRIP.
+
+Set `correction = "igs-rts"` and feed an RTCM-SSR stream alongside your rover
+observations and a broadcast navigation source. Typical accuracy is **~0.2 m
+horizontal (float)** after convergence — see [Expected accuracy](#expected-accuracy).
+
+!!! info "igs-rts vs igs"
+    `correction = "igs"` is *post-processing* with precise SP3/CLK **files**.
+    `correction = "igs-rts"` is *real-time* SSR over NTRIP. Both run the same
+    RTKLIB-style float-PPP measurement model; they differ only in the
+    orbit/clock source. See the
+    [Positioning Configuration Model](../design/configuration.md).
+
+---
+
+## Prerequisites
+
+1. **An NTRIP account for an RTS caster.** This guide uses NASA **CDDIS**, which
+   requires a free **Earthdata** login.
+    - Register: [https://urs.earthdata.nasa.gov/](https://urs.earthdata.nasa.gov/)
+    - CDDIS real-time / NTRIP overview:
+      [Earthdata — GNSS real-time data](https://www.earthdata.nasa.gov/data/space-geodesy-techniques/gnss/real-time-data)
+    - CDDIS caster stream table (mountpoints):
+      [CDDIS — Data caster streams](https://cddis.nasa.gov/Data_and_Derived_Products/Data_caster_streams.html)
+2. **stunnel** — CDDIS serves NTRIP over TLS (port 443). MRTKLIB has no built-in
+   TLS stack; tunnel through stunnel. See [NTRIP Streams → TLS](ntrip.md#tls-connections-ntrip-2s)
+   for the full setup. The minimal tunnel config is shown below.
+3. **A dual-frequency rover.** Geodetic receivers (GPS L1/L2, GAL E1/E5a) are
+   ideal. Other RTS casters (BKG `products.igs-ip.net`, etc.) work the same way.
+
+---
+
+## Streams and mountpoints
+
+An IGS-RTS PPP run needs three data sources. On CDDIS:
+
+| Role | What | Example mountpoint |
+|------|------|--------------------|
+| **SSR correction** | orbit/clock/code-bias (RTCM-SSR / IGS-SSR) | `SSRA02IGS0` (IGS combined, APC, ITRF) |
+| **Broadcast ephemeris** | RTCM-3 nav (1019/1020/1042/1044/1045/1046) | `BCEP00BKG0` |
+| **Rover observations** | your receiver, or an IGS station for testing | e.g. `AIRA00JPN` (Aira, Japan) |
+
+Notes:
+
+- **SSR provider variants.** `SSRAxxIGS0` is the IGS combined product in the
+  global **ITRF** frame; provider-specific streams exist too (`SSRA00CNE0` CNES,
+  `SSRA00WHU0` WHU, …). Prefer the **ITRF** variant — the `_SIRGAS2000` variants
+  are re-projected for South America and add a frame bias elsewhere. CNES streams
+  additionally carry **phase bias** (future PPP-AR); IGS combined is code-bias
+  only (float).
+- **`SSRA` = antenna-phase-center (APC)** referenced → use
+  `satellite_ephemeris = "brdc+ssrapc"`. `SSRC` = center-of-mass → `brdc+ssrcom`.
+- **Broadcast ephemeris is required** — SSR corrects the broadcast orbit/clock,
+  it does not replace it. Many receiver streams already embed RTCM nav (1019…);
+  if yours does not, add a `BCEP*` stream (or a RINEX nav file for `mrtk post`).
+- Pick mountpoints from the [CDDIS stream table](https://cddis.nasa.gov/Data_and_Derived_Products/Data_caster_streams.html).
+
+---
+
+## Connect (stunnel TLS tunnel)
+
+`ntrip-tls.conf`:
+
+```conf
+[ntrip-tls]
+client = yes
+accept = 127.0.0.1:2101
+connect = caster.cddis.eosdis.nasa.gov:443
+```
+
+```bash
+stunnel ntrip-tls.conf      # listens on 127.0.0.1:2101, forwards to CDDIS over TLS
+```
+
+Then connect MRTKLIB through the local endpoint with NTRIP v2 and the `&host=`
+header (required by most TLS casters). URL-encode special characters in the
+password (`@` → `%40`). Full details in [NTRIP Streams](ntrip.md).
+
+---
+
+## Configuration
+
+Sample: [`conf/igs/rnx2rtkp_igsrts.toml`](https://github.com/h-shiono/MRTKLIB/blob/main/conf/igs/rnx2rtkp_igsrts.toml).
+
+```toml
+[positioning]
+mode = "ppp-static"                  # or ppp-kine for a moving rover
+frequency = "l1+2"
+satellite_ephemeris = "brdc+ssrapc"  # SSRA = APC; use brdc+ssrcom for SSRC
+systems = ["GPS", "Galileo"]
+correction = "igs-rts"               # must be set explicitly (see note)
+
+[positioning.corrections]
+satellite_antenna = false            # SSR_APC orbits are antenna-phase-center based
+receiver_antenna = true
+
+[positioning.atmosphere]
+ionosphere = "dual-freq"             # iono-free combination
+troposphere = "est-ztdgrad"
+```
+
+!!! warning "`igs-rts` is never auto-inferred"
+    `igs-rts` shares `satellite_ephemeris = "brdc+ssrapc"` with `qzs-madoca`, so
+    omitting `correction` infers **`qzs-madoca`**, not `igs-rts`. You must set
+    `correction = "igs-rts"` explicitly. It requires `brdc+ssrapc` (or
+    `brdc+ssrcom`) and is rejected at load time otherwise.
+
+---
+
+## Running
+
+### Post-processing (`mrtk post`)
+
+Record the streams to RTCM-3 logs, then process. Capture with `mrtk relay`
+(stagger the starts a few seconds apart to avoid simultaneous-connect rejections
+on CDDIS):
+
+```bash
+Q='ver=2&host=caster.cddis.eosdis.nasa.gov'
+mrtk relay -in "ntrip://USER:PW@127.0.0.1:2101/SSRA02IGS0?$Q"  -out ssr.rtcm3  &
+mrtk relay -in "ntrip://USER:PW@127.0.0.1:2101/BCEP00BKG0?$Q"  -out brdc.rtcm3 &
+mrtk relay -in "ntrip://USER:PW@127.0.0.1:2101/AIRA00JPN?$Q"   -out rover.rtcm3 &
+```
+
+Convert obs/nav to RINEX, then run PPP (the SSR `.rtcm3` log is auto-detected by
+its extension):
+
+```bash
+mrtk convert -r rtcm3 -o rover.obs -tr 2026/05/22 14:00:00 rover.rtcm3
+mrtk convert -r rtcm3 -n brdc.nav  -tr 2026/05/22 14:00:00 brdc.rtcm3
+mrtk post -k conf/igs/rnx2rtkp_igsrts.toml rover.obs brdc.nav ssr.rtcm3 -o out.pos
+```
+
+!!! tip "`-tr` takes two tokens"
+    `mrtk convert -tr` expects the approximate log start as **two** arguments
+    (`Y/M/D` and `H:M:S`), e.g. `-tr 2026/05/22 14:00:00` — not one quoted string.
+
+### Real-time (`mrtk run`)
+
+Point the rover and correction input streams at the NTRIP mountpoints in your
+`mrtk run` config (`[streams.input.rover]` / `[streams.input.correction]`, type
+`ntripcli`), with the same `[positioning]` block as above, and start:
+
+```bash
+mrtk run -o conf/run-igsrts.toml -p 2401 -s
+```
+
+The correction-application pipeline (`decode_ssr*` → `satpos_ssr` → `corr_meas`)
+is identical to the post-processing path; both reach the same accuracy level.
+
+---
+
+## Expected accuracy
+
+Validated on a real CDDIS RTS stream — IGS station **AIRA00JPN** (GPS L1/L2 +
+GAL E1/E5a iono-free, TRM59800.00 SCIS), IGS combined RTCM-SSR (`SSRA02IGS0`) +
+broadcast ephemeris, against the IGS final SINEX coordinate:
+
+| Path | 3D 1σ | 3D 95% |
+|------|-------|--------|
+| Post-processing (`mrtk post`) | ~0.18 m | ~0.33 m |
+| Real-time (`mrtk run`, replay) | ~0.27 m | ~0.38 m |
+
+This is conventional **float** PPP (code-bias-only product). The result agrees
+with upstream RTKLIB 2.4.3 `rnx2rtkp` on identical inputs. Integer PPP-AR (a
+phase-bias product such as CNES `CLK9x`) is a future addition.
+
+!!! note "Verify against a SINEX, not a webpage coordinate"
+    When checking absolute accuracy, compare against an **IGS SINEX**
+    coordinate propagated to the observation epoch
+    (`scripts/tests/compare_pos_abs.py --sinex FILE --station CODE --epoch …`).
+    A station-page LLH is an ITRF reference-epoch value and can be off by tens of
+    centimetres of plate motion in tectonically active regions (e.g. Japan).
+
+---
+
+## Troubleshooting
+
+- **`correction source not implemented` / `invalid correction`** — set
+  `satellite_ephemeris = "brdc+ssrapc"` (or `"brdc+ssrcom"`); `igs-rts` requires
+  it.
+- **HTTP 401 / no data on capture** — check the Earthdata credentials and the
+  `&host=` header; when capturing several streams at once, start them a few
+  seconds apart (CDDIS rejects bursts of simultaneous connects).
+- **No solution (`Q=0`) / metre-level bias** — confirm the broadcast ephemeris
+  covers the obs window and that the SSR is the **ITRF** (not `_SIRGAS2000`)
+  variant. A real-time MSM RINEX often carries **no antenna name**; set
+  `[antenna.rover] type` explicitly so the receiver PCV is applied.
+- **`mrtk run`: `console open error dev=`** — pass a telnet port (`-p 2401`); the
+  follow-on `Error: vt is NULL` is harmless (no attached terminal).
+
+---
+
+## Next steps
+
+- [NTRIP Streams](ntrip.md) — NTRIP versions, TLS/stunnel, password escaping.
+- [Configuration (TOML)](configuration.md) and
+  [Config Options Reference](../reference/config-options.md).
+- [Positioning Configuration Model](../design/configuration.md) — the
+  `correction` axis and validity matrix.

--- a/docs/guide/quickstart-igs-rts.md
+++ b/docs/guide/quickstart-igs-rts.md
@@ -142,12 +142,15 @@ mrtk post -k conf/igs/rnx2rtkp_igsrts.toml rover.obs brdc.nav ssr.rtcm3 -o out.p
 
 ### Real-time (`mrtk run`)
 
-Point the rover and correction input streams at the NTRIP mountpoints in your
-`mrtk run` config (`[streams.input.rover]` / `[streams.input.correction]`, type
-`ntripcli`), with the same `[positioning]` block as above, and start:
+Use the real-time sample
+[`conf/igs/rtkrcv_igsrts.toml`](https://github.com/h-shiono/MRTKLIB/blob/main/conf/igs/rtkrcv_igsrts.toml):
+it points `[streams.input.rover]` and `[streams.input.correction]` at NTRIP
+mountpoints (type `ntripcli`) through the stunnel endpoint, with the same
+`[positioning]` block as above. Replace `USER:PW` and the rover stream with your
+own receiver, then start:
 
 ```bash
-mrtk run -o conf/run-igsrts.toml -p 2401 -s
+mrtk run -o conf/igs/rtkrcv_igsrts.toml -p 2401 -s
 ```
 
 The correction-application pipeline (`decode_ssr*` → `satpos_ssr` → `corr_meas`)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
     - Configuration (TOML): guide/configuration.md
     - "Quick Start: CLAS PPP-RTK": guide/quickstart-clas.md
     - "Quick Start: MADOCA-PPP": guide/quickstart-madoca-ppp.md
+    - "Quick Start: IGS-RTS PPP": guide/quickstart-igs-rts.md
     - NTRIP Streams: guide/ntrip.md
   - Hardware:
     - CLAS Positioning with mosaic-G5: hardware/cssr2rtcm3-mosaic-g5.md


### PR DESCRIPTION
## Summary

Adds a task-oriented **Quick Start: IGS-RTS PPP** guide
(`docs/guide/quickstart-igs-rts.md`) for `correction = "igs-rts"` (real-time
RTCM-SSR / IGS-SSR float PPP, shipped in v0.6.8 / #138).

The building blocks already existed but were scattered (NTRIP/stunnel in the
NTRIP guide, the `correction` key in the config reference, the conf sample).
This guide ties them into one end-to-end walkthrough.

## Contents

- **Streams & mountpoints** — CDDIS caster stream table + Earthdata real-time
  data links; choosing the SSR correction stream (`SSRA02IGS0`, ITRF/APC), the
  broadcast-ephemeris stream (`BCEP00BKG0`), and the rover. SSR variant notes
  (ITRF vs `_SIRGAS2000`, APC vs CoM, CNES phase-bias).
- **Connect** — stunnel TLS tunnel (cross-links the NTRIP Streams guide).
- **Configure** — the `igs-rts` sample; the "never auto-inferred" /
  `brdc+ssrapc` requirement.
- **Run** — both post-processing (`mrtk post`) and real-time (`mrtk run`).
- **Expected accuracy** — ~0.18 m (post) / ~0.27 m (real-time) 3D 1σ vs IGS
  SINEX; note on verifying against a SINEX rather than a station-page coord.
- **Troubleshooting** + next steps.

Adds the page to the mkdocs User Guide nav.

Docs-only. The CI docs build validates links/nav (mkdocs not available locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)