### PR TITLE
feat(spp): SPP accuracy P0–P4 — C/N0 weighting, IGG-III robust, pre-robust gate, TDCP (#116)

### DIFF
--- a/conf/benchmark/single.toml
+++ b/conf/benchmark/single.toml
@@ -14,7 +14,7 @@ dynamics = false                               # snapshot SPP does not use dynam
 satellite_ephemeris = "brdc"
 excluded_sats = ""
 systems = ["GPS", "Galileo", "QZSS", "BeiDou"]
-robust = "off"                                 # #116 P2: "off" | "igg3" (IGG-III robust pseudorange re-weighting)
+robust = "igg3"                                # #116 P2: "off" | "igg3" (IGG-III robust pseudorange re-weighting)
 robust_k0 = 1.5                                # IGG-III lower threshold (full weight below)
 robust_k1 = 4.0                                # IGG-III upper threshold (reject above)
 
@@ -49,11 +49,12 @@ iterations = 1
 [kalman_filter.measurement_error]
 # #116 P1: C/N0 (Sigma-epsilon) pseudorange weighting. snr_error > 0 enables the
 # term; snr_max is the reference C/N0 above which no extra penalty is applied.
-# Default-off: on this geodetic-grade dataset C/N0 weighting alone improves the
-# bulk (rate/median) but slightly worsens the p95 tail via chi-square gate
-# loosening; the tail is addressed by P2 (robust re-weighting) / P3 (RAIM).
+# Enabled here together with robust="igg3": the P1+P2 weighting plus the P3
+# pre-robust acceptance gate is a clean win on this dataset (rate +16pp, median
+# -43%, p95 improved). See docs/design/spp-accuracy.md §4.4. The library default
+# (prcopt_default) keeps these off, so non-benchmark runs are unchanged.
 snr_max = 50.0  # dB-Hz
-snr_error = 0.0 # m (0 = disabled)
+snr_error = 0.5 # m (0 = disabled)
 
 [antenna.rover]
 position_type = "single"

--- a/conf/benchmark/single.toml
+++ b/conf/benchmark/single.toml
@@ -1,0 +1,104 @@
+# MRTKLIB Configuration (TOML v1.0.0)
+# Single-point positioning (SPP) baseline for the PPC-Dataset benchmark.
+# Classic single-frequency SPP: L1 + Klobuchar broadcast iono + Saastamoinen
+# tropo, broadcast ephemeris, elevation-only weighting, RAIM-FDE.
+# This is the "current SPP" baseline that issue #116 work is measured against;
+# see docs/design/spp-accuracy.md.
+
+[positioning]
+mode = "single"
+frequency = "l1"
+solution_type = "forward"
+elevation_mask = 15.0
+dynamics = false                               # snapshot SPP does not use dynamics
+satellite_ephemeris = "brdc"
+excluded_sats = ""
+systems = ["GPS", "Galileo", "QZSS", "BeiDou"]
+
+[positioning.snr_mask]
+rover_enabled = false
+base_enabled = false
+L1 = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+L2 = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+L5 = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+[positioning.corrections]
+satellite_antenna = false # broadcast ephemeris is already at the antenna phase center
+receiver_antenna = false  # SPP is metre-level; rover PCV (mm) is negligible
+phase_windup = "off"      # no carrier phase used in SPP
+raim_fde = true           # RAIM FDE outlier exclusion
+tidal_correction = "off"
+
+[positioning.atmosphere]
+ionosphere = "brdc"  # Klobuchar broadcast model (single-frequency)
+troposphere = "saas" # Saastamoinen + standard atmosphere
+
+[ambiguity_resolution]
+mode = "off"
+
+[rejection]
+innovation = 30.0
+gdop = 30.0
+
+[kalman_filter]
+iterations = 1
+
+[antenna.rover]
+position_type = "single"
+type = "*"
+delta_e = 0.0
+delta_n = 0.0
+delta_u = 0.0
+
+[antenna.base]
+position_type = "llh"
+position_1 = 90.0
+position_2 = 0.0
+position_3 = -6335367.6285
+type = ""
+delta_e = 0.0
+delta_n = 0.0
+delta_u = 0.0
+max_average_epochs = 0
+init_reset = false
+
+[output]
+format = "nmea"
+header = true
+options = true
+velocity = false
+time_system = "gpst"
+time_format = "tow"         # GPS TOW for time matching
+time_decimals = 3
+coordinate_format = "deg"
+field_separator = ""
+single_output = false
+max_solution_std = 0.0
+height_type = "ellipsoidal"
+geoid_model = "internal"
+static_solution = "all"
+nmea_interval_1 = 0.0
+nmea_interval_2 = 0.0
+solution_status = "off"
+
+[files]
+satellite_atx = ""
+receiver_atx = ""
+station_pos = ""
+geoid = ""
+ionosphere = ""
+dcb = ""
+eop = ""
+ocean_loading = ""
+temp_dir = ""
+geexe = ""
+solution_stat = ""
+trace = ""
+
+[server]
+time_interpolation = true
+sbas_satellite = "0"
+rinex_option_1 = ""
+rinex_option_2 = ""
+ppp_option = ""
+rtcm_option = ""

--- a/conf/benchmark/single.toml
+++ b/conf/benchmark/single.toml
@@ -17,6 +17,8 @@ systems = ["GPS", "Galileo", "QZSS", "BeiDou"]
 robust = "igg3"                                # #116 P2: "off" | "igg3" (IGG-III robust pseudorange re-weighting)
 robust_k0 = 1.5                                # IGG-III lower threshold (full weight below)
 robust_k1 = 4.0                                # IGG-III upper threshold (reject above)
+tdcp = true                                    # #116 P4: TDCP velocity + jump-rejection QC
+tdcp_jump = 5.0                                # reject epoch if code vs TDCP displacement differ by > this (m)
 
 [positioning.snr_mask]
 rover_enabled = false
@@ -42,6 +44,9 @@ mode = "off"
 [rejection]
 innovation = 30.0
 gdop = 30.0
+
+[slip_detection]
+doppler = 1.0 # #116 P4: Doppler-vs-phase cycle-slip threshold (cyc/s, 0=off)
 
 [kalman_filter]
 iterations = 1

--- a/conf/benchmark/single.toml
+++ b/conf/benchmark/single.toml
@@ -43,6 +43,15 @@ gdop = 30.0
 [kalman_filter]
 iterations = 1
 
+[kalman_filter.measurement_error]
+# #116 P1: C/N0 (Sigma-epsilon) pseudorange weighting. snr_error > 0 enables the
+# term; snr_max is the reference C/N0 above which no extra penalty is applied.
+# Default-off: on this geodetic-grade dataset C/N0 weighting alone improves the
+# bulk (rate/median) but slightly worsens the p95 tail via chi-square gate
+# loosening; the tail is addressed by P2 (robust re-weighting) / P3 (RAIM).
+snr_max = 50.0  # dB-Hz
+snr_error = 0.0 # m (0 = disabled)
+
 [antenna.rover]
 position_type = "single"
 type = "*"

--- a/conf/benchmark/single.toml
+++ b/conf/benchmark/single.toml
@@ -14,6 +14,9 @@ dynamics = false                               # snapshot SPP does not use dynam
 satellite_ephemeris = "brdc"
 excluded_sats = ""
 systems = ["GPS", "Galileo", "QZSS", "BeiDou"]
+robust = "off"                                 # #116 P2: "off" | "igg3" (IGG-III robust pseudorange re-weighting)
+robust_k0 = 1.5                                # IGG-III lower threshold (full weight below)
+robust_k1 = 4.0                                # IGG-III upper threshold (reject above)
 
 [positioning.snr_mask]
 rover_enabled = false

--- a/docs/design/spp-accuracy.md
+++ b/docs/design/spp-accuracy.md
@@ -326,13 +326,24 @@ Two findings, both negative on this dataset:
    100s of m). An innovation gate tames the worst of it but the residual spikes
    still leave RMS ~5× worse than P4, with no upside.
 
+**Caveat — this was not a tuned evaluation.** The first cut reused `udpos()`'s
+RTK-oriented process noise (white-noise on acceleration only) and a single
+innovation-gate threshold; the SINGLE-specific process noise, velocity weight,
+gate, and — most importantly — the slip handling that feeds the velocity were
+*not* swept. So this is "an untuned first cut on unfavourable data," not "the
+position EKF cannot work." Two things still make PPC the wrong place to tune it:
+(a) the post-P1–P4 WLS already dominates, so the smoothing upside is inherently
+small here; (b) the remaining tail is consistent NLOS bias, which no filter
+fixes (needs 3DMA / external aiding).
+
 The position EKF's value (track smoothing, coasting) shows up where there is
-real jitter to smooth — **static** receivers or **smartphone/low-cost** data —
-which the geodetic kinematic PPC set cannot exercise. It also fundamentally
-cannot fix the remaining tail, which is consistent NLOS bias (needs 3DMA /
-external aiding). **P6 was therefore reverted**; the SPP accuracy work ships at
-P1–P4. A future EKF would need a tightly-coupled formulation with rigorous slip
-handling, validated on smartphone/static data (e.g. the GSDC / SDC sets).
+real jitter to smooth — **static** receivers or **smartphone/low-cost** data,
+which the geodetic kinematic PPC set cannot exercise. **P6 was therefore reverted**
+from the P1–P4 ship and deferred: a proper, *tuned* re-attempt (ideally a
+tightly-coupled formulation with rigorous slip handling) belongs on a
+smartphone/static benchmark — the GSDC / SDC sets, where jitter is large and
+clock jumps actually occur (which also makes that the right venue for P5's
+clock-jump correction).
 
 ## 5. Design
 

--- a/docs/design/spp-accuracy.md
+++ b/docs/design/spp-accuracy.md
@@ -1,12 +1,15 @@
 # MRTKLIB — SPP Accuracy Enhancement (Doppler / TDCP EKF + Robust Weighting)
 
-> **Status:** Proposed (design) · **Tracking:** [#116](https://github.com/h-shiono/MRTKLIB/issues/116) · **Phase:** 0 (pre-implementation)
+> **Status:** P1–P4 implemented (PR #164, default-off) · P5/P6 deferred to the
+> smartphone benchmark ([#165](https://github.com/h-shiono/MRTKLIB/issues/165)) ·
+> **Tracking:** [#116](https://github.com/h-shiono/MRTKLIB/issues/116)
 >
-> This document is the design rationale for improving single-point positioning
-> (SPP, `PMODE_SINGLE`) accuracy to be competitive with commercial receivers.
-> No algorithm code is changed by this document. Per CLAUDE.md §3/§9.1 the
-> changes it describes are GNSS-algorithm / design changes that each require
-> explicit maintainer sign-off and an algorithm-safety review before landing.
+> This document is both the design rationale and the as-built record for
+> improving single-point positioning (SPP, `PMODE_SINGLE`) accuracy. P1–P4 ship
+> in PR #164 (all TOML-gated, `prcopt_default` off → existing behaviour
+> bit-identical); P5 (clock-jump) and P6 (position EKF) were investigated and
+> deferred (§4.6). GNSS-algorithm changes here each had maintainer sign-off and
+> an algorithm-safety review per CLAUDE.md §3/§9.1; per-step results are in §4.
 
 ---
 

--- a/docs/design/spp-accuracy.md
+++ b/docs/design/spp-accuracy.md
@@ -119,7 +119,7 @@ the maintainer explicitly wants improved and which TDCP/EKF cannot.
 | **P3** | Pre-robust all-satellite acceptance gate *(implemented)* — unblocks P1+P2 → clean win (§4.4) | WLS | **tail control; rate +16pp, median −43%** | medium |
 | **P4** | TDCP velocity + jump-rejection QC + slip detection *(implemented)* — §4.5 | WLS + light coupling | **tail/RMS −56% vs P0; rate +20pp** | medium |
 | **P5** | Common-mode clock-jump correction + logging / reset strategy | infra | low-cost-receiver continuity; EKF prerequisite | medium |
-| **P6** | SPP-EKF: coupled pos/vel/accel/clock + Doppler/TDCP, dynamics, reuse `rtk_t` | **EKF (new)** | kinematic smoothing / precision | medium |
+| **P6** | SPP position EKF (loosely-coupled) — *investigated, reverted* (§4.6) | EKF | no gain on PPC; diverges | — |
 
 Each step ships as an independent, reviewable commit, must pass the full
 `ctest --output-on-failure`, and records numerical deltas (CLAUDE.md §7.2 —
@@ -301,9 +301,47 @@ mis-reject and hurt) — but a direct velocity check against the reference
 All four (P1–P4) are enabled in [`single.toml`](../../conf/benchmark/single.toml);
 `prcopt_default` keeps them off (`tdcp=0`), so existing behaviour is bit-identical.
 
+### 4.6 P6 investigated and reverted — the position EKF does not pay off here (2026-05-24)
+
+The loosely-coupled position EKF ([§5.1](#51-architecture-decision--reuse-rtk_t-for-pmode_single)) was
+implemented (`spp_posfilt()`: `udpos()` CV/CA time update + `filter()` with the
+WLS position and TDCP velocity as measurements) and measured against P4:
+
+| Metric (mean) | P4 | P6 loosely-coupled |
+|---------------|---:|-------------------:|
+| <2 m rate | 61.2% | 61.1% (same) |
+| p68 | 2.83 m | 2.83 m (**no smoothing gain**) |
+| p95 | 12.42 m | 12.49 m (slightly worse) |
+| RMS 2D | 7.54 m | 37.1 m (**diverges**) |
+
+Two findings, both negative on this dataset:
+
+1. **No smoothing gain.** After P1–P4 the per-epoch WLS position is already good,
+   so it dominates the filter (R ≈ a few m² ≪ the predicted covariance) and the
+   output ≈ WLS — the median is unchanged. There is little epoch-to-epoch jitter
+   left to smooth on geodetic-grade kinematic data.
+2. **Divergence risk.** The only way to gain smoothing is to trust the
+   velocity-driven prediction, but the TDCP velocity is occasionally
+   slip-corrupted; integrated into the filter state it diverges (RMS spikes to
+   100s of m). An innovation gate tames the worst of it but the residual spikes
+   still leave RMS ~5× worse than P4, with no upside.
+
+The position EKF's value (track smoothing, coasting) shows up where there is
+real jitter to smooth — **static** receivers or **smartphone/low-cost** data —
+which the geodetic kinematic PPC set cannot exercise. It also fundamentally
+cannot fix the remaining tail, which is consistent NLOS bias (needs 3DMA /
+external aiding). **P6 was therefore reverted**; the SPP accuracy work ships at
+P1–P4. A future EKF would need a tightly-coupled formulation with rigorous slip
+handling, validated on smartphone/static data (e.g. the GSDC / SDC sets).
+
 ## 5. Design
 
 ### 5.1 Architecture decision — reuse `rtk_t` for `PMODE_SINGLE`
+
+> **Status: investigated and reverted ([§4.6](#46-p6-investigated-and-reverted--the-position-ekf-does-not-pay-off-here-2026-05-24)).**
+> The loosely-coupled variant below was built and measured; it gave no gain and
+> diverged on the geodetic kinematic benchmark. Retained as design rationale for
+> a future tightly-coupled attempt on static/smartphone data.
 
 The decisive finding is that the EKF infrastructure SPP needs already exists and
 is already wired into the SPP code path:

--- a/docs/design/spp-accuracy.md
+++ b/docs/design/spp-accuracy.md
@@ -53,22 +53,35 @@ weighting. This is why the delivery order below leads with weighting, not EKF.
 
 **In scope**
 
+A **robust WLS front-end** that stays inside the existing snapshot estimator
+(no architecture change):
+
 - C-N0 (Sigma-ε) measurement weighting added to `varerr()`.
-- An optional, gated SPP extended Kalman filter (EKF) for `PMODE_SINGLE` that
-  carries position / velocity / acceleration / clock / clock-drift /
-  inter-system bias states across epochs.
-- Doppler and TDCP measurement updates fused into that EKF.
-- Common-mode (all-satellite) receiver clock-jump correction.
-- A `single` mode added to the PPC-Dataset benchmark for before/after metrics.
+- IGG-III equivalent-weight robust re-weighting in the `estpos()` iteration.
+- RAIM-FDE improvement (multi-fault, better exclusion thresholds).
+- Doppler-based quality control (predicted-vs-measured consistency gating).
 
-**Out of scope** (separate issues / later)
+Then an **auxiliary TDCP relative-displacement constraint** (still
+snapshot-coupled), and only after that an **optional, gated SPP-EKF**:
 
-- IGG-III full robust estimator beyond the C-N0 weighting first step (the EKF
-  measurement-update residual hook is designed so it can be added later — see
-  [§5.6](#56-robust-estimation-hook)).
-- ML/NLOS classification (issue #116 priority 4).
-- Factor-graph optimization (priority 3) — architecturally a batch/sliding-window
-  optimizer, which does not fit the streaming rtkrcv loop (see [§7](#7-real-time-considerations)).
+- TDCP used to tighten the velocity solve and to gate between-epoch jumps.
+- Common-mode (all-satellite) receiver clock-jump correction + a logging /
+  reset strategy (the prerequisite for a stable filter).
+- An EKF for `PMODE_SINGLE` carrying position / velocity / acceleration /
+  clock / clock-drift / inter-system bias states, with Doppler and TDCP fused.
+
+Tooling:
+
+- A `single` mode added to the PPC-Dataset benchmark for before/after metrics
+  (P0, shipped).
+
+**Out of scope** — external / post-processing / optional extensions, not the
+SPP core:
+
+- ML / NLOS classification (issue #116 priority 4).
+- Factor-graph optimization (priority 3) — a batch / sliding-window optimizer
+  that does not fit the streaming rtkrcv loop (see [§7](#7-real-time-considerations)).
+- 3D-mapping-aided (3DMA) GNSS — requires an external building model.
 
 ## 4. Delivery order and rationale
 
@@ -76,27 +89,37 @@ A literature survey of SPP accuracy techniques (maintainer-local research
 report; its findings are distilled in §2–4 and the references in §9, and the
 work is tracked under [#116](https://github.com/h-shiono/MRTKLIB/issues/116))
 ranks **TDCP-EKF first** for *kinematic impact* and *RTKLIB affinity*. That is
-correct as the single highest-ceiling lever and is the architecturally correct
-choice for a real-time library. But the **best risk-adjusted first step** is the
-lightweight half of priority 2, for three reasons:
+the single highest-ceiling lever and the architecturally correct estimator for a
+real-time library — but it is not the right *first* step.
 
-1. C-N0 weighting is the only cheap lever that moves **bias**, including for the
-   static case the maintainer explicitly wants improved.
-2. It is ~tens of lines confined to `varerr()`, lowest regression risk.
-3. The TDCP-EKF alone does **not** improve static bias; shipping it first would
-   under-deliver against the "competitive with commercial receivers" goal.
+Two pieces of evidence reorder the work toward a **robust WLS front-end first,
+EKF last**:
 
-So the order is **weighting first, then EKF**:
+1. **The P0 baseline is outlier-dominated** ([§4.1](#41-p0-baseline-measured-2026-05-24)):
+   in several runs `RMS 2D > p95`, so a handful of blunders dominate the error.
+   The direct fix for that is robust weighting + fault exclusion, not a filter.
+2. An independent design review (Codex) reached the same conclusion: land the
+   improvements that drop into the existing WLS without breaking it
+   (**SNR/C-N0 weighting, robust WLS, RAIM-FDE improvement, Doppler quality
+   control**) first; introduce **TDCP as an auxiliary relative-displacement
+   constraint** next; and only **EKF-ify after sufficient logging and a reset
+   strategy exist**. FGO / ML / 3DMA are external/optional, not the core.
 
-| Step | Content | Primary gain | Risk |
-|------|---------|--------------|------|
-| **P0** | Add `single` mode to PPC benchmark; baseline vs F9P / mosaic-X5 | measurement harness | none |
-| **P1** | C-N0 (Sigma-ε) weighting in `varerr()`, TOML-gated | **bias** (static + kinematic) | low |
-| **P2** | SPP-EKF skeleton (position + clock; pseudorange + Doppler), gated | precision; kills snapshot jumps | low (gated) |
-| **P3** | Add velocity/accel dynamics states (`dynamics` 1/2) | kinematic track smoothing | low |
-| **P4** | Common-mode clock-jump correction | low-cost receiver continuity | medium (prereq for P5) |
-| **P5** | TDCP measurement + cycle-slip gating | **mm/s velocity constraint** | medium |
-| **P6** | (optional) IGG-III robust hook in EKF update | outlier robustness / bias | low |
+This also keeps risk monotonic: P1–P3 are confined to the snapshot WLS (no
+state carried across epochs, so RTK/PPP seeding is unaffected in structure), and
+the architecture change (the EKF) is deferred until the front-end is robust.
+C-N0 weighting is additionally the cheap lever that moves **static bias**, which
+the maintainer explicitly wants improved and which TDCP/EKF cannot.
+
+| Step | Content | Architecture | Primary gain | Risk |
+|------|---------|--------------|--------------|------|
+| **P0** | `single` mode in PPC benchmark + baseline *(shipped)* | tooling | measurement harness | none |
+| **P1** | C-N0 (Sigma-ε) weighting in `varerr()`, TOML-gated | WLS | **bias** (static + kinematic) | low |
+| **P2** | IGG-III equivalent-weight robust re-weighting in `estpos()` | WLS | **outlier suppression** (dominant error) | low |
+| **P3** | RAIM-FDE improvement + Doppler-based quality control | WLS | gross-blunder exclusion | low |
+| **P4** | TDCP auxiliary constraint: velocity tightening + between-epoch consistency / slip gating | WLS + light coupling | precision; jump rejection | medium |
+| **P5** | Common-mode clock-jump correction + logging / reset strategy | infra | low-cost-receiver continuity; EKF prerequisite | medium |
+| **P6** | SPP-EKF: coupled pos/vel/accel/clock + Doppler/TDCP, dynamics, reuse `rtk_t` | **EKF (new)** | kinematic smoothing / precision | medium |
 
 Each step ships as an independent, reviewable commit, must pass the full
 `ctest --output-on-failure`, and records numerical deltas (CLAUDE.md §7.2 —
@@ -133,8 +156,9 @@ python3 scripts/benchmark/run_benchmark.py \
 - **RMS is outlier-dominated.** In several runs `RMS 2D > p95` (run1: 27.9 m vs
   17.8 m; tokyo_run3: 36.0 m vs 14.7 m) — a handful of large blunders beyond the
   95th percentile dominate the RMS. This is exactly the snapshot-WLS
-  position-jump vulnerability that temporal continuity (EKF, P2+) and robust
-  down-weighting (P1/P6) target. Expect the biggest headline improvement here.
+  position-jump vulnerability that robust down-weighting + fault exclusion
+  (P2/P3) and temporal continuity (EKF, P6) target. Expect the biggest headline
+  improvement from the robust WLS front-end.
 - **Median accuracy is 3–12 m (p68).** Typical urban-canyon single-frequency
   SPP. Tightening this is the precision job of the EKF + TDCP.
 - **~18–27 satellites tracked.** Ample redundancy for robust estimators and
@@ -206,7 +230,7 @@ rows:
 - **Doppler** rows constrain velocity / clock-drift, lifted from
   [`resdop()`](../../src/pos/mrtk_spp.c) (existing, validated logic).
 
-### 5.4 TDCP measurement update (P5)
+### 5.4 TDCP measurement update (P4 auxiliary, fused in the EKF at P6)
 
 For each satellite continuously locked across `t-1 → t`, form
 `Δφ = φ(t) − φ(t-1)`, predict the geometric increment from satellite motion and
@@ -216,7 +240,7 @@ which the SPP path must begin to populate (today only RTK/PPP do). TDCP delivers
 the mm/s-class velocity constraint (van Graas & Soloviev 2004; Freda et al.
 2015 — [§9](#9-references)).
 
-### 5.5 Common-mode clock-jump correction (P4)
+### 5.5 Common-mode clock-jump correction (P5)
 
 Low-cost receivers steer their clock, producing simultaneous millisecond jumps
 on every satellite's carrier phase. `rescode()` already processes all visible
@@ -227,14 +251,18 @@ differencing — preventing the jump from being mistaken for per-satellite cycle
 slips (Everett et al. 2022 / demo5 — [§9](#9-references)). It is a prerequisite
 for stable TDCP on low-cost hardware.
 
-### 5.6 Robust-estimation hook
+### 5.6 Robust estimation (P2, carried into the EKF at P6)
 
-The EKF measurement-update step exposes a residual-evaluation point so that an
-IGG-III equivalent-weight (Yang et al. 2001) down-weighting pass can be added in
-P6 without re-architecting — the same hybrid TDCP-EKF + robust-regression
+An IGG-III equivalent-weight (Yang et al. 2001) re-weighting pass is added to the
+`estpos()` WLS iteration first (P2): each measurement's weight is scaled by a
+three-segment function of its standardized residual, smoothly down-weighting
+medium outliers and rejecting gross ones — directly attacking the
+outlier-dominated baseline ([§4.1](#41-p0-baseline-measured-2026-05-24)) without
+any architecture change. The same residual-evaluation point is then exposed in
+the EKF measurement update (P6), giving the hybrid robust-WLS + TDCP-EKF
 structure validated in Remote Sensing 12(16):2550 (2020).
 
-### 5.7 Cycle-slip gating (P5)
+### 5.7 Cycle-slip gating (P4 for TDCP auxiliary, reused at P6)
 
 TDCP breaks on a single undetected slip, so detection is layered:
 
@@ -247,7 +275,7 @@ TDCP breaks on a single undetected slip, so detection is layered:
 A satellite flagged as slipped drops only its TDCP row for that epoch; its
 pseudorange row is still used. The existing `detslp_*` helpers are `rtk_t`-bound
 file statics in [`mrtk_ppp.c`](../../src/pos/mrtk_ppp.c); sharing them with SPP
-needs a small refactor to a common helper, designed at P5.
+needs a small refactor to a common helper, designed at P4.
 
 ## 6. The Doppler-absence invariant
 
@@ -331,7 +359,7 @@ primary, ○ corroborating / applied.
   12(16):2550 (2020).
   DOI [10.3390/rs12162550](https://doi.org/10.3390/rs12162550).
   State-augmented EKF combining **TDCP + robust regression** — the template for
-  the P5+P6 hybrid in this design.
+  the robust-WLS (P2) + TDCP-EKF (P6) hybrid in this design.
 - ○ "A Doppler enhanced TDCP algorithm based on terrain adaptive and robust
   Kalman filter using a stand-alone receiver." *The Journal of Navigation*
   (Cambridge University Press).
@@ -351,7 +379,7 @@ primary, ○ corroborating / applied.
   *Proc. 3rd Int. Geodetic Symp. on Satellite Doppler Positioning*, vol. 2,
   pp. 1213–1231.
 
-**Robust estimation (IGG-III; the lever for static bias — priority 2 / P6)**
+**Robust estimation (IGG-III; the lever for static bias — priority 2 / P2)**
 
 - ◎ Yang, Y.; He, H.; Xu, G. (2001). "Adaptively robust filtering for kinematic
   geodetic positioning." *Journal of Geodesy* 75:109–116.
@@ -366,6 +394,8 @@ primary, ○ corroborating / applied.
   (P1) needs a known static coordinate validated against an IGS SINEX
   (epoch-propagated, not a station webpage coordinate).
 - **`detslp_*` sharing.** Exact refactor to expose cycle-slip detection to SPP
-  without disturbing PPP/RTK — settled at P5.
+  without disturbing PPP/RTK — settled at P4.
 - **demo5 clock-jump parity.** Read the demo5 `pntpos.c` implementation before
-  P4 rather than assuming behaviour (CLAUDE.md §3).
+  P5 rather than assuming behaviour (CLAUDE.md §3).
+- **IGG-III thresholds.** The `k0`/`k1` segment thresholds need tuning against
+  the P0 baseline; start from the literature range and validate per [§4.1](#41-p0-baseline-measured-2026-05-24).

--- a/docs/design/spp-accuracy.md
+++ b/docs/design/spp-accuracy.md
@@ -166,6 +166,34 @@ python3 scripts/benchmark/run_benchmark.py \
 
 These six rows are the fixed before/after reference for P1–P6.
 
+### 4.2 P1 result (C/N0 weighting, measured 2026-05-24)
+
+P1 ([§5.8](#58-cn0-sigma-epsilon-weighting-p1)) was measured against the P0
+baseline across a small `(snr_max, snr_error)` sweep (mean over the six runs):
+
+| Setting | <2 m rate | RMS 2D | p68 | p95 |
+|---------|----------:|-------:|----:|----:|
+| P0 (off) | 41.2% | 17.07 m | 5.61 m | 17.71 m |
+| (50, 0.5) | 44.1% | 17.05 m | 5.35 m | 18.44 m |
+| (50, 0.3) | 42.8% | 17.00 m | 5.46 m | 18.29 m |
+| (45, 0.3) | 42.1% | 17.06 m | 5.52 m | 17.99 m |
+| (48, 0.4) | 42.9% | 16.97 m | 5.45 m | 18.38 m |
+
+The pattern is consistent across every setting: C/N0 weighting **improves the
+bulk** (fix rate +1–3 pp, median p68 slightly) **but worsens the p95 tail**
+(+0.3–0.7 m). The mechanism is gate loosening — the additive SNR variance
+inflates the per-epoch covariance, so the chi-square test in `valsol()` admits
+more epochs (epoch count rises), and the newly-admitted marginal epochs land in
+the tail. Per-run it is not uniform: a clear win on tokyo_run2 (<2 m
+44.3 → 53.2%, p95 10.67 → 9.09 m) but a tail regression on nagoya_run1.
+
+This is exactly the designed division of labour: **C/N0 weighting moves the bulk,
+not the outlier tail** — the tail (the dominant P0 error) is the job of P2
+(robust residual re-weighting) and P3 (RAIM). C/N0 weighting is therefore
+**shipped but left default-off** (`snr_error = 0`) in [`single.toml`](../../conf/benchmark/single.toml);
+the enable decision is deferred until P2/P3, after which P1+P2 are evaluated
+together (the hybrid validated in Remote Sensing 12(16):2550).
+
 ## 5. Design
 
 ### 5.1 Architecture decision — reuse `rtk_t` for `PMODE_SINGLE`
@@ -276,6 +304,25 @@ A satellite flagged as slipped drops only its TDCP row for that epoch; its
 pseudorange row is still used. The existing `detslp_*` helpers are `rtk_t`-bound
 file statics in [`mrtk_ppp.c`](../../src/pos/mrtk_ppp.c); sharing them with SPP
 needs a small refactor to a common helper, designed at P4.
+
+### 5.8 C/N0 (Sigma-epsilon) weighting (P1, implemented)
+
+[`varerr()`](../../src/pos/mrtk_spp.c) gains an optional C/N0 term, identical in
+form to the RTK `varerr()` ([`mrtk_rtkpos.c`](../../src/pos/mrtk_rtkpos.c)):
+
+```
+sigma^2 += (fact * err[6])^2 * 10^(0.1 * max(0, err[5] - CN0))
+           err[5] = snr_max (dB-Hz),  err[6] = snr_error (m)
+```
+
+`err[5]`/`err[6]` were previously zero-initialised and unreachable from any
+config; P1 exposes them as legacy options `stats-snrmax` / `stats-errsnr` and
+TOML keys `[kalman_filter.measurement_error] snr_max` / `snr_error`, which also
+makes the RTK engine's long-dormant SNR term configurable. The term is gated by
+`err[6] > 0` (default 0 → off → bit-identical) and skipped when `CN0 == 0` so a
+receiver that reports no C/N0 keeps the elevation-only model. The base
+elevation/constant variance is untouched. See [§4.2](#42-p1-result-cn0-weighting-measured-2026-05-24)
+for the measured effect and why it is shipped default-off.
 
 ## 6. The Doppler-absence invariant
 

--- a/docs/design/spp-accuracy.md
+++ b/docs/design/spp-accuracy.md
@@ -117,7 +117,7 @@ the maintainer explicitly wants improved and which TDCP/EKF cannot.
 | **P1** | C-N0 (Sigma-ε) weighting in `varerr()`, TOML-gated *(implemented)* | WLS | bulk (rate/median); defeats gate → §4.2 | low |
 | **P2** | IGG-III robust re-weighting in `estpos()` (MAD scale) *(implemented)* | WLS | bulk (rate +11pp, median); defeats gate → §4.3 | low |
 | **P3** | Pre-robust all-satellite acceptance gate *(implemented)* — unblocks P1+P2 → clean win (§4.4) | WLS | **tail control; rate +16pp, median −43%** | medium |
-| **P4** | TDCP auxiliary constraint: velocity tightening + between-epoch consistency / slip gating | WLS + light coupling | precision; jump rejection | medium |
+| **P4** | TDCP velocity + jump-rejection QC + slip detection *(implemented)* — §4.5 | WLS + light coupling | **tail/RMS −56% vs P0; rate +20pp** | medium |
 | **P5** | Common-mode clock-jump correction + logging / reset strategy | infra | low-cost-receiver continuity; EKF prerequisite | medium |
 | **P6** | SPP-EKF: coupled pos/vel/accel/clock + Doppler/TDCP, dynamics, reuse `rtk_t` | **EKF (new)** | kinematic smoothing / precision | medium |
 
@@ -271,6 +271,36 @@ P1+P2+P3 is therefore enabled together in [`single.toml`](../../conf/benchmark/s
 the library default (`prcopt_default`) keeps all three off, so non-benchmark and
 existing-test behaviour is bit-identical.
 
+### 4.5 P4 result — TDCP velocity + jump rejection (measured 2026-05-24)
+
+P4 adds time-differenced carrier phase: a per-satellite TDCP velocity solve
+(replacing the Doppler measurement when the phase is locked and slip-free) and a
+between-epoch jump-rejection QC that drops epochs whose code position change
+disagrees with the TDCP-derived displacement (`velocity × dt`) by more than
+`tdcp_jump` (5 m). Mean over the six runs, P1+P2+P3 → P1+P2+P3+P4:
+
+| Metric | P0 | P1+P2+P3 | **+P4** | total vs P0 |
+|--------|---:|---------:|--------:|------------:|
+| <2 m rate | 41.2% | 57.5% | **61.2%** | **+20.0 pp** |
+| p68 (median) | 5.61 m | 3.19 m | **2.83 m** | **−50%** |
+| p95 (tail) | 17.71 m | 15.73 m | **12.42 m** | **−30%** |
+| RMS 2D | 17.07 m | 16.55 m | **7.54 m** | **−56%** |
+
+The jump-rejection QC collapses the **extreme tail** that P3 could not reach —
+the consistent/jumpy worst-case epochs whose code position spikes contradict the
+precise TDCP displacement. The clearest cases: tokyo_run3 RMS 36.85 → 4.84 m,
+nagoya_run1 RMS 29.26 → 15.10 m. Rate and p95 improve on every run; the epoch
+count drops only ~4%, so the QC removes wrong-position spikes, not good epochs.
+
+The benchmark measures position, so this is the QC (position) effect. The TDCP
+*velocity* (mm/s vs Doppler cm/s) is exercised by the same machinery — the QC
+works precisely because the TDCP velocity is accurate (a noisy velocity would
+mis-reject and hurt) — but a direct velocity check against the reference
+`East/North/Up Velocity` columns is deferred tooling.
+
+All four (P1–P4) are enabled in [`single.toml`](../../conf/benchmark/single.toml);
+`prcopt_default` keeps them off (`tdcp=0`), so existing behaviour is bit-identical.
+
 ## 5. Design
 
 ### 5.1 Architecture decision — reuse `rtk_t` for `PMODE_SINGLE`
@@ -335,15 +365,31 @@ rows:
 - **Doppler** rows constrain velocity / clock-drift, lifted from
   [`resdop()`](../../src/pos/mrtk_spp.c) (existing, validated logic).
 
-### 5.4 TDCP measurement update (P4 auxiliary, fused in the EKF at P6)
+### 5.4 TDCP velocity + jump rejection (P4, implemented)
 
-For each satellite continuously locked across `t-1 → t`, form
-`Δφ = φ(t) − φ(t-1)`, predict the geometric increment from satellite motion and
-the state, and add a residual row constraining velocity and the position
-increment. Previous-epoch phase/time come from `ssat.ph[0][f]` / `ssat.pt[0][f]`,
-which the SPP path must begin to populate (today only RTK/PPP do). TDCP delivers
-the mm/s-class velocity constraint (van Graas & Soloviev 2004; Freda et al.
-2015 — [§9](#9-references)).
+The auxiliary TDCP, kept within the snapshot architecture (the full EKF fusion is
+P6). Two pieces, plus the enabling infrastructure:
+
+- **Phase history**: `pntpos()` stores `ssat.ph[0][f]` / `ssat.pt[0][f]` at the
+  end of each epoch (the SPP path previously did not; only RTK/PPP did). Reached
+  via `rtk->ssat` in the post `PMODE_SINGLE` path.
+- **Slip detection** (`spp_detslp()`): LLI plus the demo5 Doppler-vs-phase-rate
+  consistency test (the `detslp_dop()` logic, kept SPP-local), gated by
+  `thresdop`. Slipped sats fall back to Doppler.
+- **TDCP velocity** (`resdop()`): per satellite, when locked and slip-free, the
+  measured range rate is the TDCP phase rate `(φ(t)−φ(t-1))/Δt` (mm/s-class;
+  van Graas & Soloviev 2004, Freda et al. 2015) instead of the Doppler;
+  otherwise Doppler (preserving the Doppler-absence invariant). The geometric
+  model and design matrix are unchanged. *Approximation:* the TDCP average rate
+  over [t-1,t] is paired with the instantaneous geometric rate at t — an
+  O(accel·Δt) error, negligible at 1 Hz next to the noise reduction.
+- **Jump rejection** (P4b): compare the code position change to the TDCP
+  displacement (`velocity·Δt`); if they differ by more than `tdcp_jump` the epoch
+  is rejected (`SOLQ_NONE`). Phase history is still recorded for rejected epochs
+  so TDCP continuity survives.
+
+Gated by `[positioning] tdcp` (default off → bit-identical). Measured effect:
+[§4.5](#45-p4-result--tdcp-velocity--jump-rejection-measured-2026-05-24).
 
 ### 5.5 Common-mode clock-jump correction (P5)
 

--- a/docs/design/spp-accuracy.md
+++ b/docs/design/spp-accuracy.md
@@ -1,0 +1,371 @@
+# MRTKLIB — SPP Accuracy Enhancement (Doppler / TDCP EKF + Robust Weighting)
+
+> **Status:** Proposed (design) · **Tracking:** [#116](https://github.com/h-shiono/MRTKLIB/issues/116) · **Phase:** 0 (pre-implementation)
+>
+> This document is the design rationale for improving single-point positioning
+> (SPP, `PMODE_SINGLE`) accuracy to be competitive with commercial receivers.
+> No algorithm code is changed by this document. Per CLAUDE.md §3/§9.1 the
+> changes it describes are GNSS-algorithm / design changes that each require
+> explicit maintainer sign-off and an algorithm-safety review before landing.
+
+---
+
+## 1. Background
+
+MRTKLIB's SPP is a faithful port of RTKLIB 2.4.3 `pntpos.c`, living in
+[`src/pos/mrtk_spp.c`](../../src/pos/mrtk_spp.c). It is a **per-epoch
+weighted-least-squares (WLS) snapshot estimator** with these characteristics:
+
+- `estpos()` — pseudorange WLS, state `x[NX]` = position(3) + 7 inter-system
+  clock terms. **No state is carried across epochs**; the previous solution is
+  only an iteration seed, not a covariance-weighted prior.
+- `estvel()` / `resdop()` — **Doppler is already used** for a *separate*
+  snapshot velocity solve (`x[4]` = velocity(3) + clock drift). It is not fused
+  with position and does not smooth the position track.
+- `varerr()` — **elevation-only** measurement weighting. SNR/C-N0 is used only
+  for *masking* (`snrmask()`), never for weighting.
+- `raim_fde()` — single-satellite fault detection/exclusion.
+- No carrier-phase usage, no time-differenced carrier phase (TDCP), no
+  carrier smoothing, no robust estimator, no clock-jump handling.
+
+The consequence: a static SPP user gets the full per-epoch scatter (no
+time-averaging at all), and a kinematic user gets a track that jumps whenever a
+single pseudorange outlier slips through RAIM.
+
+## 2. What "accuracy" means here (precision vs. bias)
+
+The two halves of "accuracy" respond to *different* techniques. Conflating them
+is the most common way to over-promise on this work.
+
+| Aspect | Definition | What moves it |
+|--------|-----------|---------------|
+| **Precision** | epoch-to-epoch scatter / repeatability (RMS noise) | time-averaging (EKF), TDCP (position-domain carrier smoothing), Doppler velocity constraint |
+| **Bias / accuracy** | offset of the *mean* position from truth | robust down-weighting of multipath/NLOS, C-N0 weighting, better atmosphere/ephemeris models |
+
+**TDCP is a time difference**, so quasi-static systematic errors (fixed
+multipath bias, ionosphere/troposphere residual, broadcast orbit/clock error,
+code biases) cancel in the difference and carry *no* information to correct the
+bias. TDCP therefore tightens the cloud but does not move its centre. Moving
+the centre (especially for a static receiver) is the job of robust + C-N0
+weighting. This is why the delivery order below leads with weighting, not EKF.
+
+## 3. Scope
+
+**In scope**
+
+- C-N0 (Sigma-ε) measurement weighting added to `varerr()`.
+- An optional, gated SPP extended Kalman filter (EKF) for `PMODE_SINGLE` that
+  carries position / velocity / acceleration / clock / clock-drift /
+  inter-system bias states across epochs.
+- Doppler and TDCP measurement updates fused into that EKF.
+- Common-mode (all-satellite) receiver clock-jump correction.
+- A `single` mode added to the PPC-Dataset benchmark for before/after metrics.
+
+**Out of scope** (separate issues / later)
+
+- IGG-III full robust estimator beyond the C-N0 weighting first step (the EKF
+  measurement-update residual hook is designed so it can be added later — see
+  [§5.6](#56-robust-estimation-hook)).
+- ML/NLOS classification (issue #116 priority 4).
+- Factor-graph optimization (priority 3) — architecturally a batch/sliding-window
+  optimizer, which does not fit the streaming rtkrcv loop (see [§7](#7-real-time-considerations)).
+
+## 4. Delivery order and rationale
+
+A literature survey of SPP accuracy techniques (maintainer-local research
+report; its findings are distilled in §2–4 and the references in §9, and the
+work is tracked under [#116](https://github.com/h-shiono/MRTKLIB/issues/116))
+ranks **TDCP-EKF first** for *kinematic impact* and *RTKLIB affinity*. That is
+correct as the single highest-ceiling lever and is the architecturally correct
+choice for a real-time library. But the **best risk-adjusted first step** is the
+lightweight half of priority 2, for three reasons:
+
+1. C-N0 weighting is the only cheap lever that moves **bias**, including for the
+   static case the maintainer explicitly wants improved.
+2. It is ~tens of lines confined to `varerr()`, lowest regression risk.
+3. The TDCP-EKF alone does **not** improve static bias; shipping it first would
+   under-deliver against the "competitive with commercial receivers" goal.
+
+So the order is **weighting first, then EKF**:
+
+| Step | Content | Primary gain | Risk |
+|------|---------|--------------|------|
+| **P0** | Add `single` mode to PPC benchmark; baseline vs F9P / mosaic-X5 | measurement harness | none |
+| **P1** | C-N0 (Sigma-ε) weighting in `varerr()`, TOML-gated | **bias** (static + kinematic) | low |
+| **P2** | SPP-EKF skeleton (position + clock; pseudorange + Doppler), gated | precision; kills snapshot jumps | low (gated) |
+| **P3** | Add velocity/accel dynamics states (`dynamics` 1/2) | kinematic track smoothing | low |
+| **P4** | Common-mode clock-jump correction | low-cost receiver continuity | medium (prereq for P5) |
+| **P5** | TDCP measurement + cycle-slip gating | **mm/s velocity constraint** | medium |
+| **P6** | (optional) IGG-III robust hook in EKF update | outlier robustness / bias | low |
+
+Each step ships as an independent, reviewable commit, must pass the full
+`ctest --output-on-failure`, and records numerical deltas (CLAUDE.md §7.2 —
+tolerances are never silently changed).
+
+### 4.1 P0 baseline (measured 2026-05-24)
+
+The current SPP code path, measured on all six PPC-Dataset urban-driving runs
+via the new `single` benchmark mode (config: [`conf/benchmark/single.toml`](../../conf/benchmark/single.toml)
+— single-frequency L1, Klobuchar iono, Saastamoinen tropo, broadcast ephemeris,
+elevation-only weighting, RAIM-FDE; first 60 epochs skipped for convergence):
+
+| Case | N | mean nSV | <2 m | RMS 2D | 1σ (p68) | p95 |
+|------|---|---------:|-----:|-------:|---------:|----:|
+| nagoya_run1 | 5832 | 19.8 | 57.1% | 27.92 m | 3.31 m | 17.82 m |
+| nagoya_run2 | 6101 | 20.5 | 56.9% | 11.12 m | 3.41 m | 20.30 m |
+| nagoya_run3 | 4238 | 18.3 | 25.7% | 10.59 m | 12.15 m | 18.36 m |
+| tokyo_run1  | 9435 | 20.7 | 33.0% | 11.59 m | 6.90 m | 24.41 m |
+| tokyo_run2  | 8327 | 25.8 | 44.3% |  5.19 m | 3.91 m | 10.67 m |
+| tokyo_run3  | 14265 | 27.0 | 30.1% | 36.02 m | 3.91 m | 14.69 m |
+
+Reproduce:
+
+```
+python3 scripts/benchmark/run_benchmark.py \
+  --dataset-dir <PPC-Dataset> --mode single --skip-download --skip-epochs 60
+```
+
+(The PPC-Dataset is downloaded manually — see
+[`docs/reference/benchmark.md`](../reference/benchmark.md).)
+
+**What the numbers say, and how it shapes the work:**
+
+- **RMS is outlier-dominated.** In several runs `RMS 2D > p95` (run1: 27.9 m vs
+  17.8 m; tokyo_run3: 36.0 m vs 14.7 m) — a handful of large blunders beyond the
+  95th percentile dominate the RMS. This is exactly the snapshot-WLS
+  position-jump vulnerability that temporal continuity (EKF, P2+) and robust
+  down-weighting (P1/P6) target. Expect the biggest headline improvement here.
+- **Median accuracy is 3–12 m (p68).** Typical urban-canyon single-frequency
+  SPP. Tightening this is the precision job of the EKF + TDCP.
+- **~18–27 satellites tracked.** Ample redundancy for robust estimators and
+  RAIM-style exclusion — the geometry is not the limiter; outlier handling is.
+
+These six rows are the fixed before/after reference for P1–P6.
+
+## 5. Design
+
+### 5.1 Architecture decision — reuse `rtk_t` for `PMODE_SINGLE`
+
+The decisive finding is that the EKF infrastructure SPP needs already exists and
+is already wired into the SPP code path:
+
+- [`rtkpos()`](../../src/pos/mrtk_rtkpos.c) owns a **persistent `rtk_t`**
+  (`rtk->x`, `rtk->P`, `rtk->ssat`, `rtk->tt`) across epochs.
+- For `PMODE_SINGLE`, `rtkpos()` already calls `pntpos()` **with `rtk->ssat`**,
+  so the per-satellite phase-history slots (`ssat.ph[]`, `ssat.pt[]`) used by
+  TDCP are already reachable.
+- The inter-epoch time delta `rtk->tt` is already computed.
+- A constant-velocity / constant-acceleration position EKF (the kinematic
+  dynamics model) already exists in [`udpos()`](../../src/pos/mrtk_rtkpos.c)
+  (`NP(opt) = 9` when `dynamics != 0`), with its state-transition matrix.
+- The Kalman primitives [`filter()`](../../src/core/mrtk_mat.c) and
+  `smoother()` are battle-tested across PPP/RTK/VRS.
+
+**Decision:** add an EKF path for `PMODE_SINGLE` inside `rtkpos()` that stores
+state in the existing persistent `rtk_t`, reusing the `udpos()`-style time
+update, `ssat` phase history, and `rtk->tt`. The snapshot `pntpos()` is **left
+unchanged** because it is still the initial-position seed for RTK/PPP/PPP-RTK/VRS
+([`mrtk_rtkpos.c` rover seed](../../src/pos/mrtk_rtkpos.c) and base seed). The
+EKF is a parallel, gated path. The alternative — threading a new persistent SPP
+state struct through `pntpos()`, `postpos`, and `rtksvr` — duplicates what
+`rtk_t` already provides and was rejected.
+
+> Note: the realtime helper SPP call in
+> [`src/stream/mrtk_rtksvr.c`](../../src/stream/mrtk_rtksvr.c) passes
+> `ssat = NULL`; it computes a throwaway base position, not the user solution,
+> and stays on the snapshot path. Only the `rtkpos()` `PMODE_SINGLE` user
+> solution is EKF-enabled.
+
+### 5.2 State vector
+
+SPP needs the receiver clock as a state (RTK differences it away), so the RTK
+state layout is *not* reused verbatim — a dedicated SPP layout is defined:
+
+```
+x = [ rx ry rz | vx vy vz | ax ay az | cdt cddt | isb_glo isb_gal isb_bds3 ... ]
+      position(3)  velocity(3)  accel(3)   clock+drift(2)   inter-system bias(NT-1)
+                 (dynamics>=1) (dynamics==2)
+```
+
+- Velocity states exist only when `dynamics >= 1`; acceleration only when
+  `dynamics == 2`. `dynamics == 0` ⇒ no kinematic states (degenerates toward
+  snapshot, see [§6](#6-the-doppler-absence-invariant)).
+- Inter-system biases reuse the seven-clock decomposition already in `estpos()`,
+  modelled as random walks.
+- Time update reuses the `udpos()` transition pattern (`F[i+(i+3)*nx]=tt`,
+  optional accel coupling), with `cdt += cddt*tt`.
+
+### 5.3 Pseudorange + Doppler measurement update
+
+A single [`filter()`](../../src/core/mrtk_mat.c) update stacks all measurement
+rows:
+
+- **Pseudorange** rows constrain position / clock / ISB. The Jacobian and
+  correction terms are lifted directly from
+  [`rescode()`](../../src/pos/mrtk_spp.c).
+- **Doppler** rows constrain velocity / clock-drift, lifted from
+  [`resdop()`](../../src/pos/mrtk_spp.c) (existing, validated logic).
+
+### 5.4 TDCP measurement update (P5)
+
+For each satellite continuously locked across `t-1 → t`, form
+`Δφ = φ(t) − φ(t-1)`, predict the geometric increment from satellite motion and
+the state, and add a residual row constraining velocity and the position
+increment. Previous-epoch phase/time come from `ssat.ph[0][f]` / `ssat.pt[0][f]`,
+which the SPP path must begin to populate (today only RTK/PPP do). TDCP delivers
+the mm/s-class velocity constraint (van Graas & Soloviev 2004; Freda et al.
+2015 — [§9](#9-references)).
+
+### 5.5 Common-mode clock-jump correction (P4)
+
+Low-cost receivers steer their clock, producing simultaneous millisecond jumps
+on every satellite's carrier phase. `rescode()` already processes all visible
+satellites in one pass, so the structural prerequisite is met. The added logic
+estimates a single common ms step (median of per-satellite `Δφ`, in integer
+multiples of `c × 1 ms`) and removes it from all satellites **before**
+differencing — preventing the jump from being mistaken for per-satellite cycle
+slips (Everett et al. 2022 / demo5 — [§9](#9-references)). It is a prerequisite
+for stable TDCP on low-cost hardware.
+
+### 5.6 Robust-estimation hook
+
+The EKF measurement-update step exposes a residual-evaluation point so that an
+IGG-III equivalent-weight (Yang et al. 2001) down-weighting pass can be added in
+P6 without re-architecting — the same hybrid TDCP-EKF + robust-regression
+structure validated in Remote Sensing 12(16):2550 (2020).
+
+### 5.7 Cycle-slip gating (P5)
+
+TDCP breaks on a single undetected slip, so detection is layered:
+
+- `obs.LLI[]` loss-of-lock bits.
+- Doppler-predicted vs. measured phase consistency (port/share
+  [`detslp_dop()`](../../src/pos/mrtk_ppp.c) logic).
+- Geometry-free phase jump (dual-frequency,
+  [`detslp_gf()`](../../src/pos/mrtk_ppp.c) equivalent).
+
+A satellite flagged as slipped drops only its TDCP row for that epoch; its
+pseudorange row is still used. The existing `detslp_*` helpers are `rtk_t`-bound
+file statics in [`mrtk_ppp.c`](../../src/pos/mrtk_ppp.c); sharing them with SPP
+needs a small refactor to a common helper, designed at P5.
+
+## 6. The Doppler-absence invariant
+
+**Hard design invariant** (testable acceptance criterion):
+
+> When Doppler/TDCP are absent, the SPP solution is equivalent to the current
+> WLS: bit-identical with the EKF gate off, and accuracy-equivalent with the
+> gate on via the no-Doppler fallback.
+
+This holds because Doppler and TDCP are **additive measurement rows, never
+replacements** for the pseudorange path:
+
+- Per-satellite absence is already handled — `resdop()` skips `D[0]==0.0`; the
+  pseudorange row is unaffected.
+- Whole-epoch absence ⇒ velocity states lose observability. Two safeguards:
+  1. position process noise is set so an unobserved velocity prior cannot
+     over-constrain position (the update degenerates to pseudorange-only ≈ WLS);
+  2. a **safety valve**: if an epoch has zero Doppler *and* zero TDCP rows, that
+     epoch falls back to the snapshot WLS solution (mirroring the
+     `var > VAR_POS` reset already in [`udpos()`](../../src/pos/mrtk_rtkpos.c)).
+
+**Verification:** the P0 benchmark is rerun on Doppler-stripped observations and
+must reproduce the baseline metrics; this becomes a CI assertion.
+
+## 7. Real-time considerations
+
+No real-time concern:
+
+- State dimension ≈ 17 (pos 3 + vel 3 + accel 3 + clock 2 + ISB 6).
+  `filter()` is O(n³) but n=17 is negligible; ~30 measurement rows likewise.
+- TDCP needs only the previous epoch (already in `ssat`), so it is naturally
+  streaming; no batch buffering.
+- rtkrcv already runs the far larger RTK/PPP EKFs in real time; the SPP EKF is a
+  fraction of that cost.
+
+This is also the positive argument for EKF over factor-graph optimization
+(priority 3): FGO is a sliding-window batch optimizer that does not fit the
+streaming `rtkrcv` loop, whereas the EKF is natively sequential. For a
+real-time-capable library the EKF is the correct estimator.
+
+## 8. Configuration (TOML gating)
+
+Default behaviour is unchanged — every step is opt-in, so all existing tests
+stay bit-identical:
+
+- `[positioning] spp_filter = "wls" | "ekf"` (default `"wls"`).
+- Reuse existing `pos1-dynamics` (0 none / 1 velocity / 2 accel) for the
+  kinematic state selection.
+- Sub-keys `spp_cn0_weight`, `spp_tdcp`, `spp_clkjump` to enable each step
+  independently for staged rollout and ablation.
+
+## 9. References
+
+Verified against publisher records (May 2026). Confidence: ◎ established /
+primary, ○ corroborating / applied.
+
+**TDCP velocity estimation (mm/s; ambiguity cancels in the time difference)**
+
+- ◎ Van Graas, F.; Soloviev, A. (2004). "Precise Velocity Estimation Using a
+  Stand-Alone GPS Receiver." *NAVIGATION* 51(4):283–292.
+  DOI [10.1002/j.2161-4296.2004.tb00359.x](https://doi.org/10.1002/j.2161-4296.2004.tb00359.x).
+  Reports 2–4 mm/s (1σ) horizontal, 9.7 mm/s (1σ) vertical.
+- ◎ Serrano, L.; Kim, D.; Langley, R.B.; Itani, K.; Ueno, M. (2004). "A GPS
+  Velocity Sensor: How Accurate Can It Be? — A First Look." *Proc. ION NTM 2004*,
+  San Diego, pp. 875–885.
+  [PDF](http://gauss.gge.unb.ca/papers.pdf/ionntm2004.serrano.pdf).
+- ◎ Freda, P.; Angrisano, A.; Gaglione, S.; Troisi, S. (2015).
+  "Time-differenced carrier phases technique for precise GNSS velocity
+  estimation." *GPS Solutions* 19(2):335–341.
+  DOI [10.1007/s10291-014-0425-1](https://doi.org/10.1007/s10291-014-0425-1).
+
+**Doppler / TDCP fused in an EKF (state-augmented), real-time, stand-alone**
+
+- ◎ "Doppler measurement integration for kinematic real-time GPS positioning."
+  *Applied Geomatics* 2(4):155–162 (2010).
+  DOI [10.1007/s12518-010-0031-z](https://doi.org/10.1007/s12518-010-0031-z).
+  Single-frequency, urban, loosely-coupled EKF — direct precedent for
+  Doppler-in-EKF in real time.
+- ◎ "The Design a TDCP-Smoothed GNSS/Odometer Integration Scheme with
+  Vehicular-Motion Constraint and Robust Regression." *Remote Sensing*
+  12(16):2550 (2020).
+  DOI [10.3390/rs12162550](https://doi.org/10.3390/rs12162550).
+  State-augmented EKF combining **TDCP + robust regression** — the template for
+  the P5+P6 hybrid in this design.
+- ○ "A Doppler enhanced TDCP algorithm based on terrain adaptive and robust
+  Kalman filter using a stand-alone receiver." *The Journal of Navigation*
+  (Cambridge University Press).
+  [Article page](https://www.cambridge.org/core/journals/journal-of-navigation/article/abs/doppler-enhanced-tdcp-algorithm-based-on-terrain-adaptive-and-robust-kalman-filter-using-a-standalone-receiver/6A77A5FAE63FB107348D85F16FB1E908).
+  (volume/year to confirm on cite.)
+
+**Common-mode clock-jump correction (demo5 lineage)**
+
+- ◎ Everett, T.; Taylor, T.; Lee, D.-K.; Akos, D.M. (2022). "Optimizing the Use
+  of RTKLIB for Smartphone-Based GNSS Measurements." *Sensors* 22(10):3825.
+  DOI [10.3390/s22103825](https://doi.org/10.3390/s22103825).
+- demo5 / rtklibexplorer — implementation primary source (gray literature).
+
+**Carrier smoothing (origin of the position-domain smoothing TDCP generalises)**
+
+- ◎ Hatch, R. (1982). "The Synergism of GPS Code and Carrier Measurements."
+  *Proc. 3rd Int. Geodetic Symp. on Satellite Doppler Positioning*, vol. 2,
+  pp. 1213–1231.
+
+**Robust estimation (IGG-III; the lever for static bias — priority 2 / P6)**
+
+- ◎ Yang, Y.; He, H.; Xu, G. (2001). "Adaptively robust filtering for kinematic
+  geodetic positioning." *Journal of Geodesy* 75:109–116.
+  DOI [10.1007/s001900000157](https://doi.org/10.1007/s001900000157).
+- ○ "Mitigating Integrity Risk in SBAS Positioning Using Enhanced IGG III Robust
+  Estimation." *Remote Sensing* 17(17):3067 (2025).
+  DOI [10.3390/rs17173067](https://doi.org/10.3390/rs17173067).
+
+## 10. Open questions
+
+- **Static accuracy truth.** PPC-Dataset is kinematic. Static bias improvement
+  (P1) needs a known static coordinate validated against an IGS SINEX
+  (epoch-propagated, not a station webpage coordinate).
+- **`detslp_*` sharing.** Exact refactor to expose cycle-slip detection to SPP
+  without disturbing PPP/RTK — settled at P5.
+- **demo5 clock-jump parity.** Read the demo5 `pntpos.c` implementation before
+  P4 rather than assuming behaviour (CLAUDE.md §3).

--- a/docs/design/spp-accuracy.md
+++ b/docs/design/spp-accuracy.md
@@ -114,9 +114,9 @@ the maintainer explicitly wants improved and which TDCP/EKF cannot.
 | Step | Content | Architecture | Primary gain | Risk |
 |------|---------|--------------|--------------|------|
 | **P0** | `single` mode in PPC benchmark + baseline *(shipped)* | tooling | measurement harness | none |
-| **P1** | C-N0 (Sigma-ε) weighting in `varerr()`, TOML-gated | WLS | **bias** (static + kinematic) | low |
-| **P2** | IGG-III equivalent-weight robust re-weighting in `estpos()` | WLS | **outlier suppression** (dominant error) | low |
-| **P3** | RAIM-FDE improvement + Doppler-based quality control | WLS | gross-blunder exclusion | low |
+| **P1** | C-N0 (Sigma-ε) weighting in `varerr()`, TOML-gated *(implemented)* | WLS | bulk (rate/median); defeats gate → §4.2 | low |
+| **P2** | IGG-III robust re-weighting in `estpos()` (MAD scale) *(implemented)* | WLS | bulk (rate +11pp, median); defeats gate → §4.3 | low |
+| **P3** | **Weighting-proof acceptance gate** (a-priori chi-square / covariance / RAIM integrity) — unblocks P1+P2's tail | WLS | **tail (p95/RMS), the dominant error** | medium |
 | **P4** | TDCP auxiliary constraint: velocity tightening + between-epoch consistency / slip gating | WLS + light coupling | precision; jump rejection | medium |
 | **P5** | Common-mode clock-jump correction + logging / reset strategy | infra | low-cost-receiver continuity; EKF prerequisite | medium |
 | **P6** | SPP-EKF: coupled pos/vel/accel/clock + Doppler/TDCP, dynamics, reuse `rtk_t` | **EKF (new)** | kinematic smoothing / precision | medium |
@@ -193,6 +193,44 @@ not the outlier tail** — the tail (the dominant P0 error) is the job of P2
 **shipped but left default-off** (`snr_error = 0`) in [`single.toml`](../../conf/benchmark/single.toml);
 the enable decision is deferred until P2/P3, after which P1+P2 are evaluated
 together (the hybrid validated in Remote Sensing 12(16):2550).
+
+### 4.3 P2 result and the gate-defeat finding (measured 2026-05-24)
+
+P2 ([§5.6](#56-robust-estimation-p2-implemented-and-the-gate-defeat-finding))
+adds IGG-III robust re-weighting. Mean over the six runs:
+
+| Config | <2 m rate | RMS 2D | p68 | p95 |
+|--------|----------:|-------:|----:|----:|
+| P0 baseline | 41.2% | 17.07 m | 5.61 m | 17.71 m |
+| P2 alone (k0=1.5,k1=4.0) | 47.6% | 21.35 m | 4.83 m | 30.82 m |
+| **P1+P2 (1.5,4.0)+snr** | **52.5%** | 19.11 m | **4.30 m** | 27.30 m |
+
+Robust + C/N0 weighting is a **large bulk win** (fix rate 41 → 52 %, median p68
+5.61 → 4.30 m) but **blows up the p95 tail** (17.7 → 27 m). The per-run detail
+identifies the mechanism precisely:
+
+| Run | epochs N (P0 → P1+P2) | p68 | p95 |
+|-----|----------------------:|-----|-----|
+| tokyo_run2 | 8327 → 8505 (stable) | 3.91 → 2.19 m | 10.67 → **8.08 m** ✓ |
+| tokyo_run3 | 14265 → 13933 (−) | 3.91 → 2.45 m | 14.69 → **14.15 m** ✓ |
+| nagoya_run2 | 6101 → 8573 (**+40 %**) | 3.41 → 6.20 m | 20.30 → **56.13 m** ✗ |
+
+**Where the epoch count N stays stable, P1+P2 is a clean win on every metric**
+(tokyo_run2/run3: better rate, median, *and* tail). **Where N explodes, the tail
+explodes with it** (nagoya_run2 +40 % epochs → p95 triples). The median improves
+almost everywhere — the estimator genuinely produces better solutions.
+
+The problem is therefore **not the estimator but the output gate**: the C/N0
+variance inflation and robust down-weighting shrink the residuals that
+`valsol()`'s chi-square test consumes, so the test stops rejecting the bad
+epochs it used to catch (N rises) and those epochs land in the tail. The
+weighting defeats the gate.
+
+This precisely scopes **P3**: restore an acceptance gate that the weighting
+cannot defeat (e.g. chi-square on a-priori variances, a formal-covariance /
+post-exclusion-DOP integrity check, or proper RAIM protection levels). With the
+gate restored, the tokyo_run2 result shows P1+P2+P3 should be a clean win across
+the board. Until then P1 and P2 stay default-off.
 
 ## 5. Design
 
@@ -279,16 +317,28 @@ differencing — preventing the jump from being mistaken for per-satellite cycle
 slips (Everett et al. 2022 / demo5 — [§9](#9-references)). It is a prerequisite
 for stable TDCP on low-cost hardware.
 
-### 5.6 Robust estimation (P2, carried into the EKF at P6)
+### 5.6 Robust estimation (P2, implemented) and the gate-defeat finding
 
 An IGG-III equivalent-weight (Yang et al. 2001) re-weighting pass is added to the
-`estpos()` WLS iteration first (P2): each measurement's weight is scaled by a
-three-segment function of its standardized residual, smoothly down-weighting
-medium outliers and rejecting gross ones — directly attacking the
-outlier-dominated baseline ([§4.1](#41-p0-baseline-measured-2026-05-24)) without
-any architecture change. The same residual-evaluation point is then exposed in
-the EKF measurement update (P6), giving the hybrid robust-WLS + TDCP-EKF
-structure validated in Remote Sensing 12(16):2550 (2020).
+`estpos()` WLS Gauss-Newton iteration: each pseudorange row's weight is scaled by
+a three-segment function `igg3_weight()` of its standardized residual, smoothly
+down-weighting medium outliers (`k0<|r̃|≤k1`) and rejecting gross ones
+(`|r̃|>k1`). The residual is standardized by a **MAD robust scale**
+(`σ̂ = max(1, 1.4826·median|r̃|)`; Rousseeuw & Croux 1993, Huber 1981), so a
+uniform mis-scaling of the a-priori variances does not trigger mass rejection.
+It is applied from the 2nd iteration (`i≥1`), after the clock is estimated, and
+only to the satellite rows (the rank constraints are left intact). Gated by
+`[positioning] robust = "igg3"` with `robust_k0`/`robust_k1` (defaults 1.5/4.0);
+`robust = "off"` (default) is bit-identical.
+
+The benchmark ([§4.3](#43-p2-result-and-the-gate-defeat-finding-measured-2026-05-24))
+shows this is a large bulk win that **defeats the chi-square gate** and inflates
+the tail. That is the central finding: weighting (P1) and robust re-weighting
+(P2) improve the solution but make `valsol()`'s residual-based test pass for
+epochs it should reject. The fix is P3 (a weighting-proof acceptance gate), not
+more estimator work. The same robust pass is later exposed in the EKF
+measurement update (P6), giving the robust-WLS + TDCP-EKF hybrid validated in
+Remote Sensing 12(16):2550 (2020).
 
 ### 5.7 Cycle-slip gating (P4 for TDCP auxiliary, reused at P6)
 
@@ -434,6 +484,19 @@ primary, ○ corroborating / applied.
 - ○ "Mitigating Integrity Risk in SBAS Positioning Using Enhanced IGG III Robust
   Estimation." *Remote Sensing* 17(17):3067 (2025).
   DOI [10.3390/rs17173067](https://doi.org/10.3390/rs17173067).
+
+**Robust scale (MAD) for the standardized residual (P2)**
+
+- ◎ Rousseeuw, P.J.; Croux, C. (1993). "Alternatives to the Median Absolute
+  Deviation." *JASA* 88(424):1273–1283.
+  DOI [10.1080/01621459.1993.10476408](https://doi.org/10.1080/01621459.1993.10476408).
+  Establishes `MADn = 1.4826·med{|xᵢ − med xⱼ|}` as a 50%-breakdown,
+  bounded-influence robust scale (1.4826 = Gaussian-consistency factor).
+- ◎ Huber, P.J. (1981). *Robust Statistics*. Wiley. MAD as the "single most
+  useful ancillary estimate of scale"; foundation for robust scale + IRLS.
+- ○ Blewitt, G. et al. (2016). "MIDAS robust trend estimator for accurate GPS
+  station velocities without step detection." *JGR Solid Earth* 121 — MAD-scaled
+  robust estimation in operational GNSS.
 
 ## 10. Open questions
 

--- a/docs/design/spp-accuracy.md
+++ b/docs/design/spp-accuracy.md
@@ -116,7 +116,7 @@ the maintainer explicitly wants improved and which TDCP/EKF cannot.
 | **P0** | `single` mode in PPC benchmark + baseline *(shipped)* | tooling | measurement harness | none |
 | **P1** | C-N0 (Sigma-ε) weighting in `varerr()`, TOML-gated *(implemented)* | WLS | bulk (rate/median); defeats gate → §4.2 | low |
 | **P2** | IGG-III robust re-weighting in `estpos()` (MAD scale) *(implemented)* | WLS | bulk (rate +11pp, median); defeats gate → §4.3 | low |
-| **P3** | **Weighting-proof acceptance gate** (a-priori chi-square / covariance / RAIM integrity) — unblocks P1+P2's tail | WLS | **tail (p95/RMS), the dominant error** | medium |
+| **P3** | Pre-robust all-satellite acceptance gate *(implemented)* — unblocks P1+P2 → clean win (§4.4) | WLS | **tail control; rate +16pp, median −43%** | medium |
 | **P4** | TDCP auxiliary constraint: velocity tightening + between-epoch consistency / slip gating | WLS + light coupling | precision; jump rejection | medium |
 | **P5** | Common-mode clock-jump correction + logging / reset strategy | infra | low-cost-receiver continuity; EKF prerequisite | medium |
 | **P6** | SPP-EKF: coupled pos/vel/accel/clock + Doppler/TDCP, dynamics, reuse `rtk_t` | **EKF (new)** | kinematic smoothing / precision | medium |
@@ -227,10 +227,49 @@ epochs it used to catch (N rises) and those epochs land in the tail. The
 weighting defeats the gate.
 
 This precisely scopes **P3**: restore an acceptance gate that the weighting
-cannot defeat (e.g. chi-square on a-priori variances, a formal-covariance /
-post-exclusion-DOP integrity check, or proper RAIM protection levels). With the
-gate restored, the tokyo_run2 result shows P1+P2+P3 should be a clean win across
-the board. Until then P1 and P2 stay default-off.
+cannot defeat. With the gate restored, the tokyo_run2 result predicts P1+P2+P3
+should be a clean win across the board.
+
+### 4.4 P3 result — the gate is the fix (measured 2026-05-24)
+
+A baseline diagnostic with the gate disabled (`raim_fde = false`) settles the
+mechanism: the number of *converged* epochs (e.g. nagoya_run1 7477, nagoya_run2
+9364) **exceeds** the P1+P2 epoch count (6846 / 8573), which in turn exceeds P0
+(5832 / 6101). So the bad epochs **already converge in the baseline** — robust
+does not rescue non-converging epochs (it is *not* a convergence problem). P0's
+`valsol()` correctly rejects them (gate-off p95 ≈ 62 m); weighting merely defeats
+that gate. **It is a gate problem.**
+
+The first P3 attempt — chi-square over the robust *inliers* (excluding the
+down-weighted sats) — did **not** work (tail unchanged), because the
+consistent-bias inliers are mutually consistent and pass. The fix is the
+opposite: gate on the **pre-robust residuals over *all* satellites** (including
+the ones the robust pass is about to suppress), evaluated at the robust solution,
+and output the robust solution for accepted epochs. An epoch is accepted only if
+the robust solution fits *every* satellite at nominal noise — so the suppressed
+outliers' large residuals re-trigger rejection of the consistent-bias epochs,
+while the genuinely clean epochs pass and keep their improved solution.
+
+Result (P1+P2+P3, `robust="igg3"` k0=1.5/k1=4.0 + C/N0 snr_error=0.5), mean over
+the six runs:
+
+| Metric | P0 baseline | **P1+P2+P3** | change |
+|--------|------------:|-------------:|-------:|
+| <2 m fix rate | 41.2% | **57.5%** | **+16.3 pp** |
+| p68 (median) | 5.61 m | **3.19 m** | **−43%** |
+| p95 (tail) | 17.71 m | **15.73 m** | **−11%** (improved) |
+| RMS 2D | 17.07 m | 16.55 m | slightly better |
+
+A **clean win on every aggregate metric**: rate and median improve sharply and
+the p95 tail *improves* (5 of 6 runs) rather than regressing. The epoch count
+returns to ≈P0 (the gate again rejects the bad epochs), yet the absolute number
+of <2 m epochs rises by ~900. The residual extreme tail (a few worst urban
+epochs, visible in nagoya_run1's RMS) is the consistent-bias class that snapshot
+methods cannot catch — that is the remit of the temporal work (P4 TDCP / P6 EKF).
+
+P1+P2+P3 is therefore enabled together in [`single.toml`](../../conf/benchmark/single.toml);
+the library default (`prcopt_default`) keeps all three off, so non-benchmark and
+existing-test behaviour is bit-identical.
 
 ## 5. Design
 
@@ -335,8 +374,8 @@ The benchmark ([§4.3](#43-p2-result-and-the-gate-defeat-finding-measured-2026-0
 shows this is a large bulk win that **defeats the chi-square gate** and inflates
 the tail. That is the central finding: weighting (P1) and robust re-weighting
 (P2) improve the solution but make `valsol()`'s residual-based test pass for
-epochs it should reject. The fix is P3 (a weighting-proof acceptance gate), not
-more estimator work. The same robust pass is later exposed in the EKF
+epochs it should reject. The fix is the P3 gate ([§5.8](#58-pre-robust-acceptance-gate-p3-implemented)),
+not more estimator work. The same robust pass is later exposed in the EKF
 measurement update (P6), giving the robust-WLS + TDCP-EKF hybrid validated in
 Remote Sensing 12(16):2550 (2020).
 
@@ -354,6 +393,21 @@ A satellite flagged as slipped drops only its TDCP row for that epoch; its
 pseudorange row is still used. The existing `detslp_*` helpers are `rtk_t`-bound
 file statics in [`mrtk_ppp.c`](../../src/pos/mrtk_ppp.c); sharing them with SPP
 needs a small refactor to a common helper, designed at P4.
+
+### 5.8 Pre-robust acceptance gate (P3, implemented)
+
+When the robust pass runs, `estpos()` snapshots the standardized residuals over
+**all** satellites *before* the IGG-III re-weighting (`vpre`) and feeds those to
+`valsol()` instead of the down-weighted residuals. The accept/reject chi-square
+therefore tests whether the (robust) solution is consistent with *every*
+satellite at nominal noise, so the outliers the robust pass suppresses still
+re-trigger rejection — the weighting can no longer defeat the gate. The robust
+solution is what gets written to `sol`; only the gate statistic uses `vpre`.
+
+The discarded first attempt gated over the robust *inliers* (excluding the
+suppressed sats); §4.4 shows that fails, because consistent-bias urban epochs
+have mutually-consistent inliers. Including all sats is the whole point. The gate
+is active only when `robust != "off"`, so the default path is unchanged.
 
 ### 5.8 C/N0 (Sigma-epsilon) weighting (P1, implemented)
 

--- a/include/mrtklib/mrtk_opt.h
+++ b/include/mrtklib/mrtk_opt.h
@@ -298,6 +298,11 @@ typedef struct prcopt_t {         /* processing options type */
     /* #116 P2: SPP robust estimation (appended for ABI stability) */
     int robust;        /* SPP robust mode (0:off, 1:igg3 IGG-III equivalent weight) */
     double robustk[2]; /* IGG-III thresholds {k0,k1} on standardized residual (<=0: code default) */
+
+    /* #116 P4: SPP TDCP auxiliary constraint (appended for ABI stability) */
+    int tdcp;         /* SPP TDCP mode (0:off, 1:on time-differenced carrier phase) */
+    double tdcpjump;  /* TDCP jump-rejection threshold (m); reject epoch if the code position
+                       * change disagrees with the TDCP displacement by more than this (<=0: code default) */
 } prcopt_t;
 
 /*============================================================================

--- a/include/mrtklib/mrtk_opt.h
+++ b/include/mrtklib/mrtk_opt.h
@@ -294,6 +294,10 @@ typedef struct prcopt_t {         /* processing options type */
     int sigcfg_set;                   /* 1: sigcfg explicitly configured (overrides nf/pppsig) */
 
     int correction; /* correction source (CORR_???; CORR_AUTO=infer from mode+sateph) */
+
+    /* #116 P2: SPP robust estimation (appended for ABI stability) */
+    int robust;        /* SPP robust mode (0:off, 1:igg3 IGG-III equivalent weight) */
+    double robustk[2]; /* IGG-III thresholds {k0,k1} on standardized residual (<=0: code default) */
 } prcopt_t;
 
 /*============================================================================

--- a/scripts/benchmark/run_benchmark.py
+++ b/scripts/benchmark/run_benchmark.py
@@ -22,7 +22,8 @@ Usage
     --dataset-dir DIR           PPC-Dataset root (default: data/benchmark)
     --l6-dir DIR                L6 file cache (default: data/benchmark/l6)
     --out-dir DIR               Results directory (default: data/benchmark/results)
-    --mode clas|madoca|rtk|both|all  (both=clas+madoca, all=clas+madoca+rtk, default: all)
+    --mode single|clas|madoca|rtk|both|all  (both=clas+madoca, all=clas+madoca+rtk, default: all)
+                                single = SPP baseline (rover.obs + base.nav only)
     --case ID[,ID...]           Run subset (default: all 6 runs)
     --rnx2rtkp PATH             rnx2rtkp binary path (default: auto-detect)
     --skip-download             Skip L6 download step
@@ -44,31 +45,45 @@ from compare_ppc import _match_epochs, compute_metrics, parse_nmea, parse_refere
 from download_l6 import ensure_case_l6
 
 # ---------------------------------------------------------------------------
-# Auto-detect rnx2rtkp
+# Auto-detect the positioning binary.
+# Since v0.6.0 post-processing lives in the unified `mrtk` binary as
+# `mrtk post`; the legacy standalone `rnx2rtkp` is kept as a fallback.
 # ---------------------------------------------------------------------------
 _CANDIDATE_BINS = [
+    "build/mrtk",
+    "build/Release/mrtk",
+    "build/Debug/mrtk",
     "build/rnx2rtkp",
     "build/Release/rnx2rtkp",
     "build/Debug/rnx2rtkp",
 ]
 
 
+def _post_argv(binary: str) -> list[str]:
+    """Build the argv prefix for a post-processing run.
+
+    The unified `mrtk` binary needs the `post` subcommand; the legacy
+    standalone `rnx2rtkp` is invoked directly.
+    """
+    return [binary, "post"] if os.path.basename(binary).startswith("mrtk") else [binary]
+
+
 def _find_rnx2rtkp(hint: str = "") -> str:
-    """Locate the rnx2rtkp binary.
+    """Locate the positioning binary (`mrtk` preferred, `rnx2rtkp` fallback).
 
     Args:
         hint: Explicit path supplied via --rnx2rtkp.  If non-empty, return
               as-is after verifying the file exists.
 
     Returns:
-        Path to rnx2rtkp binary.
+        Path to the positioning binary.
 
     Raises:
         SystemExit: If no binary can be found.
     """
     if hint:
         if not os.path.isfile(hint):
-            sys.exit(f"FAIL: rnx2rtkp not found at {hint!r}")
+            sys.exit(f"FAIL: binary not found at {hint!r}")
         return hint
     # Search relative to MRTKLIB root (parent of scripts/)
     root = Path(__file__).resolve().parent.parent.parent
@@ -79,11 +94,12 @@ def _find_rnx2rtkp(hint: str = "") -> str:
     # Fall back to PATH
     import shutil
 
-    p = shutil.which("rnx2rtkp")
-    if p:
-        return p
+    for name in ("mrtk", "rnx2rtkp"):
+        p = shutil.which(name)
+        if p:
+            return p
     sys.exit(
-        "FAIL: rnx2rtkp binary not found. "
+        "FAIL: positioning binary not found. "
         "Build first with 'cmake --build build', or pass --rnx2rtkp PATH."
     )
 
@@ -130,8 +146,7 @@ def _run_rnx2rtkp(
     nav = nav.resolve()
     l6_files = [f.resolve() for f in l6_files]
     output.parent.mkdir(parents=True, exist_ok=True)
-    cmd = [
-        rnx2rtkp,
+    cmd = _post_argv(rnx2rtkp) + [
         "-k", conf,
         "-k", city_conf,
         "-ts", str(week), f"{tow_start:.3f}",
@@ -236,10 +251,12 @@ def print_summary(rows: list[dict]) -> None:
         use_threshold = not math.isnan(m.get("threshold_2d", float("nan")))
 
         if use_threshold:
-            # PPP mode (MADOCA): single row; no integer fix, all output is PPP float
+            # Threshold modes: single row; no integer fix.
+            #   MADOCA → PPP float; SINGLE → SPP (Q=1). Metrics span every epoch.
+            tier_label = "SPP" if r["mode"] == "single" else "PPP"
             ppp_rate = f"{m['thr_rate']:.1f}%"
             ppp_ttff = _fmt_s(m["conv_thr_s"])
-            print(_row(r["case_id"], r["mode"], "PPP",
+            print(_row(r["case_id"], r["mode"], tier_label,
                        m["n_matched"], _fmt_sv(m["mean_sv_all"]), ppp_rate,
                        _fmt_m(m["rms_2d_all"]), _fmt_m(m["p68_2d_all"]),
                        _fmt_m(m["p95_2d_all"]), ppp_ttff,
@@ -268,6 +285,7 @@ def print_summary(rows: list[dict]) -> None:
     print(_SEP)
     print("  CLAS/RTK tiers: FIX=Q=4 | FF=Q=4+5 (excl SPP) | ALL=every epoch")
     print("  MADOCA tier:    PPP=all valid PPP-float epochs (Q=3); Rate%=<30cm fraction")
+    print("  SINGLE tier:    SPP=all valid SPP epochs (Q=1); Rate%=<2m fraction")
 
 
 # ---------------------------------------------------------------------------
@@ -335,6 +353,8 @@ def run_benchmark(args: argparse.Namespace) -> int:
 
     # PPP modes use a 2D error threshold instead of Q=4 for fix/convergence
     _PPP_THRESHOLD = 0.30  # metres
+    # SPP has no integer fix; report the fraction of epochs within this 2D bound
+    _SPP_THRESHOLD = 2.0  # metres
 
     results = []
 
@@ -380,13 +400,16 @@ def run_benchmark(args: argparse.Namespace) -> int:
             elif mode == "madoca":
                 extra_files = l6_paths.get("madoca", [])
                 threshold = _PPP_THRESHOLD  # PPP: use <30cm threshold
+            elif mode == "single":
+                extra_files = []  # SPP: rover.obs + base.nav (broadcast eph) only
+                threshold = _SPP_THRESHOLD
             else:  # clas
                 extra_files = l6_paths.get("clas", [])
                 threshold = math.nan  # PPP-RTK uses Q=4
 
             print(f"\n[{case['id']}  /  {mode.upper()}]")
 
-            if not extra_files:
+            if not extra_files and mode != "single":
                 print(f"  WARNING: no input files found for {mode}; skipping.")
                 results.append({"case_id": case["id"], "mode": mode,
                                  "metrics": None, "status": "skip"})
@@ -394,11 +417,9 @@ def run_benchmark(args: argparse.Namespace) -> int:
 
             # Skip if output is newer than all inputs
             if out.exists() and not args.force:
-                newest_in = max(
-                    obs.stat().st_mtime,
-                    nav.stat().st_mtime,
-                    max(f.stat().st_mtime for f in extra_files),
-                )
+                in_mtimes = [obs.stat().st_mtime, nav.stat().st_mtime]
+                in_mtimes += [f.stat().st_mtime for f in extra_files]
+                newest_in = max(in_mtimes)
                 if out.stat().st_mtime > newest_in:
                     print(f"  [cached]  {out.name}")
                     skip_run = True
@@ -446,7 +467,8 @@ def run_benchmark(args: argparse.Namespace) -> int:
 
             # Progress line
             if not math.isnan(threshold):
-                rate_str = f"<{threshold*100:.0f}cm={m['thr_rate']:.1f}%"
+                thr_label = f"<{threshold:.1f}m" if threshold >= 1.0 else f"<{threshold*100:.0f}cm"
+                rate_str = f"{thr_label}={m['thr_rate']:.1f}%"
                 conv_str = _fmt_s(m["conv_thr_s"])
             else:
                 rate_str = f"Fix={m['fix_rate']:.1f}%  FF={m['ff_rate']:.1f}%"
@@ -483,9 +505,10 @@ def main() -> int:
                    help="L6 file cache directory (default: data/benchmark/l6)")
     p.add_argument("--out-dir", default="data/benchmark/results",
                    help="Output directory for NMEA results (default: data/benchmark/results)")
-    p.add_argument("--mode", choices=["clas", "madoca", "rtk", "both", "all"],
+    p.add_argument("--mode", choices=["single", "clas", "madoca", "rtk", "both", "all"],
                    default="all",
-                   help="Positioning mode (default: all = clas+madoca+rtk)")
+                   help="Positioning mode (default: all = clas+madoca+rtk; "
+                        "single = SPP baseline, rover.obs + base.nav only)")
     p.add_argument("--case", default="",
                    help="Comma-separated case IDs (default: all)")
     p.add_argument("--rnx2rtkp", default="",

--- a/src/core/mrtk_toml.c
+++ b/src/core/mrtk_toml.c
@@ -138,6 +138,8 @@ static const toml_map_t toml_mapping[] = {
     {"kalman_filter.measurement_error", "phase_elevation", "stats-errphaseel"},
     {"kalman_filter.measurement_error", "phase_baseline", "stats-errphasebl"},
     {"kalman_filter.measurement_error", "doppler", "stats-errdoppler"},
+    {"kalman_filter.measurement_error", "snr_max", "stats-snrmax"},
+    {"kalman_filter.measurement_error", "snr_error", "stats-errsnr"},
     {"kalman_filter.measurement_error", "ura_ratio", "stats-uraratio"},
 
     /* ── kalman_filter.initial_std ─────────────────────────────────────────── */

--- a/src/core/mrtk_toml.c
+++ b/src/core/mrtk_toml.c
@@ -38,6 +38,9 @@ static const toml_map_t toml_mapping[] = {
     {"positioning", "constellations", "pos1-navsys"},
     {"positioning", "excluded_sats", "pos1-exclsats"},
     {"positioning", "signals", "pos1-signals"},
+    {"positioning", "robust", "pos1-robust"},
+    {"positioning", "robust_k0", "pos1-robustk0"},
+    {"positioning", "robust_k1", "pos1-robustk1"},
 
     /* ── positioning.clas ──────────────────────────────────────────────────── */
     {"positioning.clas", "grid_selection_radius", "pos1-gridsel"},

--- a/src/core/mrtk_toml.c
+++ b/src/core/mrtk_toml.c
@@ -41,6 +41,8 @@ static const toml_map_t toml_mapping[] = {
     {"positioning", "robust", "pos1-robust"},
     {"positioning", "robust_k0", "pos1-robustk0"},
     {"positioning", "robust_k1", "pos1-robustk1"},
+    {"positioning", "tdcp", "pos1-tdcp"},
+    {"positioning", "tdcp_jump", "pos1-tdcpjump"},
 
     /* ── positioning.clas ──────────────────────────────────────────────────── */
     {"positioning.clas", "grid_selection_radius", "pos1-gridsel"},

--- a/src/pos/mrtk_options.c
+++ b/src/pos/mrtk_options.c
@@ -209,6 +209,8 @@ opt_t sysopts[] = {
     {"stats-errphaseel", 1, (void*)&prcopt_.err[2], "m"},
     {"stats-errphasebl", 1, (void*)&prcopt_.err[3], "m/10km"},
     {"stats-errdoppler", 1, (void*)&prcopt_.err[4], "Hz"},
+    {"stats-snrmax", 1, (void*)&prcopt_.err[5], "dBHz"},
+    {"stats-errsnr", 1, (void*)&prcopt_.err[6], "m"},
     {"stats-stdbias", 1, (void*)&prcopt_.std[0], "m"},
     {"stats-stdiono", 1, (void*)&prcopt_.std[1], "m"},
     {"stats-stdtrop", 1, (void*)&prcopt_.std[2], "m"},

--- a/src/pos/mrtk_options.c
+++ b/src/pos/mrtk_options.c
@@ -55,6 +55,7 @@ static char signals_[1024];
 #define IONOPT "0:off,1:brdc,2:sbas,3:dual-freq,4:est-stec,5:ionex-tec,6:qzs-brdc,9:est-adaptive"
 #define TRPOPT "0:off,1:saas,2:sbas,3:est-ztd,4:est-ztdgrad"
 #define EPHOPT "0:brdc,1:precise,2:brdc+sbas,3:brdc+ssrapc,4:brdc+ssrcom"
+#define ROBOPT "0:off,1:igg3"
 #define NAVOPT "1:gps+2:sbas+4:glo+8:gal+16:qzs+32:bds+64:navic"
 #define GAROPT "0:off,1:on"
 #define SOLOPT "0:llh,1:xyz,2:enu,3:nmea"
@@ -95,6 +96,9 @@ opt_t sysopts[] = {
     {"pos1-tidecorr", 3, (void*)&prcopt_.tidecorr, TIDEOPT},
     {"pos1-ionoopt", 3, (void*)&prcopt_.ionoopt, IONOPT},
     {"pos1-tropopt", 3, (void*)&prcopt_.tropopt, TRPOPT},
+    {"pos1-robust", 3, (void*)&prcopt_.robust, ROBOPT},
+    {"pos1-robustk0", 1, (void*)&prcopt_.robustk[0], ""},
+    {"pos1-robustk1", 1, (void*)&prcopt_.robustk[1], ""},
     {"pos1-sateph", 3, (void*)&prcopt_.sateph, EPHOPT},
     {"pos1-posopt1", 3, (void*)&prcopt_.posopt[0], SWTOPT},
     {"pos1-posopt2", 3, (void*)&prcopt_.posopt[1], SWTOPT},

--- a/src/pos/mrtk_options.c
+++ b/src/pos/mrtk_options.c
@@ -99,6 +99,8 @@ opt_t sysopts[] = {
     {"pos1-robust", 3, (void*)&prcopt_.robust, ROBOPT},
     {"pos1-robustk0", 1, (void*)&prcopt_.robustk[0], ""},
     {"pos1-robustk1", 1, (void*)&prcopt_.robustk[1], ""},
+    {"pos1-tdcp", 3, (void*)&prcopt_.tdcp, SWTOPT},
+    {"pos1-tdcpjump", 1, (void*)&prcopt_.tdcpjump, "m"},
     {"pos1-sateph", 3, (void*)&prcopt_.sateph, EPHOPT},
     {"pos1-posopt1", 3, (void*)&prcopt_.posopt[0], SWTOPT},
     {"pos1-posopt2", 3, (void*)&prcopt_.posopt[1], SWTOPT},

--- a/src/pos/mrtk_spp.c
+++ b/src/pos/mrtk_spp.c
@@ -664,7 +664,7 @@ static int raim_fde(const obsd_t* obs, int n, const double* rs, const double* dt
  * phase (pt/ph), populated by pntpos at the end of each epoch. */
 static void spp_detslp(const obsd_t* obs, int n, const ssat_t* ssat, double thresdop, int* slip) {
     double dph, dpt, tt, mean = 0.0, dif[MAXOBS] = {0};
-    int i, sat, ndop = 0;
+    int i, sat, ndop = 0, valid[MAXOBS] = {0};
 
     for (i = 0; i < n && i < MAXOBS; i++) {
         slip[i] = (obs[i].LLI[0] & 1) ? 1 : 0; /* loss-of-lock indicator */
@@ -679,6 +679,7 @@ static void spp_detslp(const obsd_t* obs, int n, const ssat_t* ssat, double thre
         dph = (obs[i].L[0] - ssat[sat - 1].ph[0][0]) / tt; /* phase rate (cyc/s) */
         dpt = -obs[i].D[0];                                /* Doppler-predicted rate */
         dif[i] = dph - dpt;
+        valid[i] = 1; /* explicit validity — dif can legitimately be 0.0 */
         if (fabs(dif[i]) < 3.0 * thresdop) {
             mean += dif[i];
             ndop++;
@@ -689,7 +690,7 @@ static void spp_detslp(const obsd_t* obs, int n, const ssat_t* ssat, double thre
     }
     mean /= ndop; /* common-mode (receiver clock) drift */
     for (i = 0; i < n && i < MAXOBS; i++) {
-        if (dif[i] != 0.0 && fabs(dif[i] - mean) > thresdop) {
+        if (valid[i] && fabs(dif[i] - mean) > thresdop) {
             slip[i] = 1;
         }
     }
@@ -720,7 +721,7 @@ static int resdop(const obsd_t* obs, int n, const double* rs, const double* dts,
         /* measured range rate (cyc/s) and its Std (m/s): TDCP primary, Doppler fallback */
         use = 0;
         meas = sig = 0.0;
-        if (tdcp && ssat && !slip[i] && obs[i].L[0] != 0.0 && ssat[sat - 1].ph[0][0] != 0.0) {
+        if (tdcp && ssat && slip && !slip[i] && obs[i].L[0] != 0.0 && ssat[sat - 1].ph[0][0] != 0.0) {
             tt = timediff(obs[i].time, ssat[sat - 1].pt[0][0]);
             if (fabs(tt) >= DTTOL && fabs(tt) <= 3.0) {
                 meas = (obs[i].L[0] - ssat[sat - 1].ph[0][0]) / tt; /* == dph (cyc/s) */
@@ -764,11 +765,12 @@ static int resdop(const obsd_t* obs, int n, const double* rs, const double* dts,
     return nv;
 }
 /* estimate receiver velocity ------------------------------------------------*/
-static void estvel(const obsd_t* obs, int n, const double* rs, const double* dts, const nav_t* nav, const prcopt_t* opt,
-                   sol_t* sol, const double* azel, const int* vsat, const ssat_t* ssat, const int* slip) {
+/* returns 1 if the velocity converged (sol->rr[3..5] written), 0 otherwise */
+static int estvel(const obsd_t* obs, int n, const double* rs, const double* dts, const nav_t* nav, const prcopt_t* opt,
+                  sol_t* sol, const double* azel, const int* vsat, const ssat_t* ssat, const int* slip) {
     double x[4] = {0}, dx[4], Q[16], *v, *H;
     double err = opt->err[4]; /* Doppler error (Hz) */
-    int i, j, nv, tdcp = (opt->tdcp == 1 && ssat != NULL);
+    int i, j, nv, stat = 0, tdcp = (opt->tdcp == 1 && ssat != NULL);
 
     trace(NULL, 3, "estvel  : n=%d\n", n);
 
@@ -797,11 +799,13 @@ static void estvel(const obsd_t* obs, int n, const double* rs, const double* dts
             sol->qv[3] = (float)Q[1];  /* xy */
             sol->qv[4] = (float)Q[6];  /* yz */
             sol->qv[5] = (float)Q[2];  /* zx */
+            stat = 1;
             break;
         }
     }
     free(v);
     free(H);
+    return stat;
 }
 /* single-point positioning ----------------------------------------------------
  * compute receiver position, velocity, clock bias by single-point positioning
@@ -873,12 +877,14 @@ int pntpos(mrtk_ctx_t* ctx, const obsd_t* obs, int n, const nav_t* nav, const pr
     }
     /* estimate receiver velocity (TDCP primary, Doppler fallback) */
     if (stat) {
-        estvel(obs, n, rs, dts, nav, &opt_, sol, azel_, vsat, ssat, slip);
+        int velok = estvel(obs, n, rs, dts, nav, &opt_, sol, azel_, vsat, ssat, slip);
 
         /* #116 P4b: TDCP jump-rejection — drop epochs whose code position change
          * disagrees with the TDCP-derived displacement (velocity * dt). Catches
-         * the "jumpy" tail; the stable-bias tail is the EKF's remit (P6). */
-        if (opt_.tdcp == 1 && ssat && has_prev) {
+         * the "jumpy" tail; the stable-bias tail is the EKF's remit (P6).
+         * Requires a valid velocity this epoch (estvel converged) — otherwise
+         * sol->rr[3..5] is stale/zero and would falsely reject moving epochs. */
+        if (opt_.tdcp == 1 && ssat && has_prev && velok) {
             double tt = timediff(obs[0].time, prev_time);
             if (fabs(tt) > DTTOL && fabs(tt) <= 3.0) {
                 double d[3], dn, thr = opt_.tdcpjump > 0.0 ? opt_.tdcpjump : 5.0;

--- a/src/pos/mrtk_spp.c
+++ b/src/pos/mrtk_spp.c
@@ -409,7 +409,7 @@ static int valsol(const double* azel, const int* vsat, int n, const prcopt_t* op
     }
     dops(ns, azels, opt->elmin, dop);
     trace(NULL, 4, "valsol  : n=%d nv=%d vv=%.1f cs=%.1f maxgdop=%.1f gdop=%.1f pdop=%.1f hdop=%.1f vdop=%.1f\n", n, nv,
-          vv, chisqr[nv - nx - 1], opt->maxgdop, dop[0], dop[1], dop[2], dop[3]);
+          vv, nv > nx ? chisqr[nv - nx - 1] : 0.0, opt->maxgdop, dop[0], dop[1], dop[2], dop[3]);
     if (dop[0] <= 0.0 || dop[0] > opt->maxgdop) {
         sprintf(msg, "gdop error nv=%d gdop=%.1f", nv, dop[0]);
         return 0;
@@ -450,7 +450,7 @@ static double median_abs(const double* x, int n, double* work) {
 /* estimate receiver position ------------------------------------------------*/
 static int estpos(const obsd_t* obs, int n, const double* rs, const double* dts, const double* vare, const int* svh,
                   const nav_t* nav, const prcopt_t* opt, sol_t* sol, double* azel, int* vsat, double* resp, char* msg) {
-    double x[NX] = {0}, dx[NX], Q[NX * NX], *v, *H, *var, sig;
+    double x[NX] = {0}, dx[NX], Q[NX * NX], *v, *H, *var, *vpre, sig;
     int i, j, k, info, stat = 1, nv, ns;
 
     trace(NULL, 3, "estpos  : n=%d\n", n);
@@ -458,6 +458,7 @@ static int estpos(const obsd_t* obs, int n, const double* rs, const double* dts,
     v = mat(n + NT, 1);
     H = mat(NX, n + NT);
     var = mat(n + NT, 1);
+    vpre = mat(n + NT, 1); /* #116 P3: pre-robust all-sat residuals for the acceptance gate */
 
     for (i = 0; i < 3; i++) {
         x[i] = sol->rr[i];
@@ -485,10 +486,21 @@ static int estpos(const obsd_t* obs, int n, const double* rs, const double* dts,
          * standardized residuals are meaningful. Off when opt->robust==0, so the
          * default solution is bit-identical. var[] is stale here (recomputed by
          * rescode next iteration), so it doubles as the median scratch buffer. */
-        if (opt->robust == 1 && i >= 1 && ns >= 5) {
+        int gated = (opt->robust == 1 && i >= 1 && ns >= 5);
+        if (gated) {
             double k0 = opt->robustk[0] > 0.0 ? opt->robustk[0] : 1.5;
             double k1 = opt->robustk[1] > 0.0 ? opt->robustk[1] : 4.0;
-            double s0 = 1.4826 * median_abs(v, ns, var); /* MAD robust scale */
+            double s0;
+            /* #116 P3: snapshot the pre-robust residuals over ALL satellites for
+             * the acceptance gate. The gate must include the outlier rows the
+             * robust pass is about to suppress — otherwise it accepts epochs whose
+             * excluded sats disagree (consistent-bias urban epochs), which is the
+             * gate-defeat that exploded the tail in §4.3. The robust solution is
+             * still what gets output; only the accept/reject test uses vpre. */
+            for (j = 0; j < nv; j++) {
+                vpre[j] = v[j];
+            }
+            s0 = 1.4826 * median_abs(v, ns, var); /* MAD robust scale */
             if (s0 < 1.0) {
                 s0 = 1.0; /* guard against over-rejection when residuals are small */
             }
@@ -530,13 +542,16 @@ static int estpos(const obsd_t* obs, int n, const double* rs, const double* dts,
             sol->ns = (uint8_t)ns;
             sol->age = sol->ratio = 0.0;
 
-            /* validate solution */
-            if (!opt->posopt[4] || (stat = valsol(azel, vsat, n, opt, v, nv, NX, msg))) {
+            /* validate solution (#116 P3: when the robust pass ran, gate on the
+             * pre-robust all-satellite residuals so the down-weighting cannot
+             * defeat the acceptance test) */
+            if (!opt->posopt[4] || (stat = valsol(azel, vsat, n, opt, gated ? vpre : v, nv, NX, msg))) {
                 sol->stat = opt->sateph == EPHOPT_SBAS ? SOLQ_SBAS : SOLQ_SINGLE;
             }
             free(v);
             free(H);
             free(var);
+            free(vpre);
             return stat;
         }
     }
@@ -547,6 +562,7 @@ static int estpos(const obsd_t* obs, int n, const double* rs, const double* dts,
     free(v);
     free(H);
     free(var);
+    free(vpre);
     return 0;
 }
 /* RAIM FDE (failure detection and exclution) -------------------------------*/

--- a/src/pos/mrtk_spp.c
+++ b/src/pos/mrtk_spp.c
@@ -75,6 +75,7 @@ const double chisqr[100] = {10.8, 13.8, 16.3, 18.5, 20.5, 22.5, 24.3, 26.1, 27.9
 #define NX (3 + NT)        /* # of estimated parameters */
 #define MAXITR 10          /* max number of iteration for point pos */
 #define ERR_CBIAS 0.3      /* code bias error Std (m) */
+#define ERR_TDCP 0.03      /* #116 P4: TDCP phase-rate error Std (m/s) */
 #define MIN_EL (5.0 * D2R) /* min elevation for measurement error (rad) */
 
 /* pseudorange measurement error variance ------------------------------------*/
@@ -655,11 +656,53 @@ static int raim_fde(const obsd_t* obs, int n, const double* rs, const double* dt
     free(resp_e);
     return stat;
 }
+/* SPP cycle-slip detection for TDCP (#116 P4) -------------------------------
+ * Sets slip[i]=1 for obs[i] that lost lock (LLI) or whose L1 phase rate
+ * disagrees with the Doppler beyond thresdop after removing the common-mode
+ * (receiver clock) offset — the single-receiver detector from demo5/detslp_dop,
+ * kept SPP-local so PPP/RTK are untouched. ssat holds the previous epoch's
+ * phase (pt/ph), populated by pntpos at the end of each epoch. */
+static void spp_detslp(const obsd_t* obs, int n, const ssat_t* ssat, double thresdop, int* slip) {
+    double dph, dpt, tt, mean = 0.0, dif[MAXOBS] = {0};
+    int i, sat, ndop = 0;
+
+    for (i = 0; i < n && i < MAXOBS; i++) {
+        slip[i] = (obs[i].LLI[0] & 1) ? 1 : 0; /* loss-of-lock indicator */
+        sat = obs[i].sat;
+        if (thresdop <= 0.0 || obs[i].L[0] == 0.0 || obs[i].D[0] == 0.0 || ssat[sat - 1].ph[0][0] == 0.0) {
+            continue;
+        }
+        tt = timediff(obs[i].time, ssat[sat - 1].pt[0][0]);
+        if (fabs(tt) < DTTOL || fabs(tt) > 3.0) {
+            continue;
+        }
+        dph = (obs[i].L[0] - ssat[sat - 1].ph[0][0]) / tt; /* phase rate (cyc/s) */
+        dpt = -obs[i].D[0];                                /* Doppler-predicted rate */
+        dif[i] = dph - dpt;
+        if (fabs(dif[i]) < 3.0 * thresdop) {
+            mean += dif[i];
+            ndop++;
+        }
+    }
+    if (ndop == 0) {
+        return;
+    }
+    mean /= ndop; /* common-mode (receiver clock) drift */
+    for (i = 0; i < n && i < MAXOBS; i++) {
+        if (dif[i] != 0.0 && fabs(dif[i] - mean) > thresdop) {
+            slip[i] = 1;
+        }
+    }
+}
 /* range rate residuals ------------------------------------------------------*/
+/* #116 P4: per satellite use the TDCP phase rate (mm/s-class) when the phase is
+ * locked and unslipped, otherwise fall back to the Doppler (preserving the
+ * Doppler-absence invariant). ssat/slip may be NULL/absent → pure Doppler. */
 static int resdop(const obsd_t* obs, int n, const double* rs, const double* dts, const nav_t* nav, const double* rr,
-                  const double* x, const double* azel, const int* vsat, double err, double* v, double* H) {
-    double freq, rate, pos[3], E[9], a[3], e[3], vs[3], cosel, sig;
-    int i, j, nv = 0;
+                  const double* x, const double* azel, const int* vsat, double err, const ssat_t* ssat, const int* slip,
+                  int tdcp, double* v, double* H) {
+    double freq, rate, pos[3], E[9], a[3], e[3], vs[3], cosel, sig, lam, meas, tt;
+    int i, j, nv = 0, sat, use;
 
     trace(NULL, 3, "resdop  : n=%d\n", n);
 
@@ -668,8 +711,29 @@ static int resdop(const obsd_t* obs, int n, const double* rs, const double* dts,
 
     for (i = 0; i < n && i < MAXOBS; i++) {
         freq = sat2freq(obs[i].sat, obs[i].code[0], nav);
+        if (freq == 0.0 || !vsat[i] || norm(rs + 3 + i * 6, 3) <= 0.0) {
+            continue;
+        }
+        lam = CLIGHT / freq;
+        sat = obs[i].sat;
 
-        if (obs[i].D[0] == 0.0 || freq == 0.0 || !vsat[i] || norm(rs + 3 + i * 6, 3) <= 0.0) {
+        /* measured range rate (cyc/s) and its Std (m/s): TDCP primary, Doppler fallback */
+        use = 0;
+        meas = sig = 0.0;
+        if (tdcp && ssat && !slip[i] && obs[i].L[0] != 0.0 && ssat[sat - 1].ph[0][0] != 0.0) {
+            tt = timediff(obs[i].time, ssat[sat - 1].pt[0][0]);
+            if (fabs(tt) >= DTTOL && fabs(tt) <= 3.0) {
+                meas = (obs[i].L[0] - ssat[sat - 1].ph[0][0]) / tt; /* == dph (cyc/s) */
+                sig = ERR_TDCP;                                     /* phase-rate Std (m/s) */
+                use = 1;
+            }
+        }
+        if (!use && obs[i].D[0] != 0.0) {
+            meas = -obs[i].D[0];                       /* Doppler-predicted rate (cyc/s) */
+            sig = (err <= 0.0) ? 1.0 : err * lam;      /* m/s */
+            use = 1;
+        }
+        if (!use) {
             continue;
         }
         /* LOS (line-of-sight) vector in ECEF */
@@ -688,11 +752,8 @@ static int resdop(const obsd_t* obs, int n, const double* rs, const double* dts,
             dot(vs, e, 3) +
             OMGE / CLIGHT * (rs[4 + i * 6] * rr[0] + rs[1 + i * 6] * x[0] - rs[3 + i * 6] * rr[1] - rs[i * 6] * x[1]);
 
-        /* Std of range rate error (m/s) */
-        sig = (err <= 0.0) ? 1.0 : err * CLIGHT / freq;
-
         /* range rate residual (m/s) */
-        v[nv] = (-obs[i].D[0] * CLIGHT / freq - (rate + x[3] - CLIGHT * dts[1 + i * 2])) / sig;
+        v[nv] = (meas * lam - (rate + x[3] - CLIGHT * dts[1 + i * 2])) / sig;
 
         /* design matrix */
         for (j = 0; j < 4; j++) {
@@ -704,10 +765,10 @@ static int resdop(const obsd_t* obs, int n, const double* rs, const double* dts,
 }
 /* estimate receiver velocity ------------------------------------------------*/
 static void estvel(const obsd_t* obs, int n, const double* rs, const double* dts, const nav_t* nav, const prcopt_t* opt,
-                   sol_t* sol, const double* azel, const int* vsat) {
+                   sol_t* sol, const double* azel, const int* vsat, const ssat_t* ssat, const int* slip) {
     double x[4] = {0}, dx[4], Q[16], *v, *H;
     double err = opt->err[4]; /* Doppler error (Hz) */
-    int i, j, nv;
+    int i, j, nv, tdcp = (opt->tdcp == 1 && ssat != NULL);
 
     trace(NULL, 3, "estvel  : n=%d\n", n);
 
@@ -716,7 +777,7 @@ static void estvel(const obsd_t* obs, int n, const double* rs, const double* dts
 
     for (i = 0; i < MAXITR; i++) {
         /* range rate residuals (m/s) */
-        if ((nv = resdop(obs, n, rs, dts, nav, sol->rr, x, azel, vsat, err, v, H)) < 4) {
+        if ((nv = resdop(obs, n, rs, dts, nav, sol->rr, x, azel, vsat, err, ssat, slip, tdcp, v, H)) < 4) {
             break;
         }
         /* least square estimation */
@@ -760,7 +821,10 @@ int pntpos(mrtk_ctx_t* ctx, const obsd_t* obs, int n, const nav_t* nav, const pr
            ssat_t* ssat, char* msg) {
     prcopt_t opt_ = *opt;
     double *rs, *dts, *var, *azel_, *resp;
-    int i, stat, vsat[MAXOBS] = {0}, svh[MAXOBS];
+    int i, stat, vsat[MAXOBS] = {0}, svh[MAXOBS], slip[MAXOBS] = {0};
+    double prev_rr[3];
+    gtime_t prev_time;
+    int has_prev;
 
     trace(ctx, 3, "pntpos  : tobs=%s n=%d\n", time_str(obs[0].time, 3), n);
 
@@ -770,6 +834,12 @@ int pntpos(mrtk_ctx_t* ctx, const obsd_t* obs, int n, const nav_t* nav, const pr
         strcpy(msg, "no observation data");
         return 0;
     }
+    /* #116 P4: snapshot the previous solution (for TDCP jump-rejection) before it
+     * is overwritten by this epoch */
+    prev_time = sol->time;
+    matcpy(prev_rr, sol->rr, 3, 1);
+    has_prev = (prev_time.time != 0 && norm(prev_rr, 3) > 0.0);
+
     sol->time = obs[0].time;
     msg[0] = '\0';
 
@@ -797,9 +867,33 @@ int pntpos(mrtk_ctx_t* ctx, const obsd_t* obs, int n, const nav_t* nav, const pr
     if (!stat && n >= 6 && opt->posopt[4]) {
         stat = raim_fde(obs, n, rs, dts, var, svh, nav, &opt_, sol, azel_, vsat, resp, msg);
     }
-    /* estimate receiver velocity with Doppler */
+    /* #116 P4: cycle-slip detection so TDCP only uses slip-free phase */
+    if (opt_.tdcp == 1 && ssat) {
+        spp_detslp(obs, n, ssat, opt_.thresdop, slip);
+    }
+    /* estimate receiver velocity (TDCP primary, Doppler fallback) */
     if (stat) {
-        estvel(obs, n, rs, dts, nav, &opt_, sol, azel_, vsat);
+        estvel(obs, n, rs, dts, nav, &opt_, sol, azel_, vsat, ssat, slip);
+
+        /* #116 P4b: TDCP jump-rejection — drop epochs whose code position change
+         * disagrees with the TDCP-derived displacement (velocity * dt). Catches
+         * the "jumpy" tail; the stable-bias tail is the EKF's remit (P6). */
+        if (opt_.tdcp == 1 && ssat && has_prev) {
+            double tt = timediff(obs[0].time, prev_time);
+            if (fabs(tt) > DTTOL && fabs(tt) <= 3.0) {
+                double d[3], dn, thr = opt_.tdcpjump > 0.0 ? opt_.tdcpjump : 5.0;
+                for (i = 0; i < 3; i++) {
+                    d[i] = (sol->rr[i] - prev_rr[i]) - sol->rr[i + 3] * tt;
+                }
+                dn = norm(d, 3);
+                if (dn > thr) {
+                    sprintf(msg, "tdcp jump reject %.1fm", dn);
+                    trace(ctx, 2, "pntpos  : %s\n", msg);
+                    stat = 0;
+                    sol->stat = SOLQ_NONE;
+                }
+            }
+        }
     }
     if (azel) {
         for (i = 0; i < n * 2; i++) {
@@ -814,9 +908,16 @@ int pntpos(mrtk_ctx_t* ctx, const obsd_t* obs, int n, const nav_t* nav, const pr
             ssat[i].snr[0] = 0;
         }
         for (i = 0; i < n; i++) {
+            int f;
             ssat[obs[i].sat - 1].azel[0] = azel_[i * 2];
             ssat[obs[i].sat - 1].azel[1] = azel_[1 + i * 2];
             ssat[obs[i].sat - 1].snr[0] = obs[i].SNR[0];
+            /* #116 P4: store carrier phase for next-epoch TDCP / slip detection
+             * (unconditional — keep continuity even for this epoch's unused sats) */
+            for (f = 0; f < NFREQ; f++) {
+                ssat[obs[i].sat - 1].ph[0][f] = obs[i].L[f];
+                ssat[obs[i].sat - 1].pt[0][f] = obs[i].time;
+            }
             if (!vsat[i]) {
                 continue;
             }

--- a/src/pos/mrtk_spp.c
+++ b/src/pos/mrtk_spp.c
@@ -78,7 +78,7 @@ const double chisqr[100] = {10.8, 13.8, 16.3, 18.5, 20.5, 22.5, 24.3, 26.1, 27.9
 #define MIN_EL (5.0 * D2R) /* min elevation for measurement error (rad) */
 
 /* pseudorange measurement error variance ------------------------------------*/
-static double varerr(const prcopt_t* opt, double el, int sys) {
+static double varerr(const prcopt_t* opt, double el, double snr, int sys) {
     double fact, varr;
     fact = sys == SYS_GLO ? EFACT_GLO : (sys == SYS_SBS ? EFACT_SBS : EFACT_GPS);
     if (el < MIN_EL) {
@@ -88,7 +88,18 @@ static double varerr(const prcopt_t* opt, double el, int sys) {
     if (opt->ionoopt == IONOOPT_IFLC) {
         varr *= SQR(3.0); /* iono-free */
     }
-    return SQR(fact) * varr;
+    varr = SQR(fact) * varr;
+
+    /* #116 P1: optional C/N0 (Sigma-epsilon) term, identical in form to the RTK
+     * varerr(). Off when err[6]<=0 (default) -> bit-identical to the previous
+     * elevation-only model; skipped when SNR is absent (snr==0) so a receiver
+     * that reports no C/N0 keeps the legacy behaviour. */
+    if (opt->err[6] > 0.0 && snr > 0.0) {
+        double e = fact * opt->err[6];
+        double d = opt->err[5] - snr; /* dB-Hz below snr_max */
+        varr += SQR(e) * pow(10.0, 0.1 * (d > 0.0 ? d : 0.0));
+    }
+    return varr;
 }
 /* get group delay parameter (m) ---------------------------------------------*/
 static double gettgd(int sat, const nav_t* nav, int type) {
@@ -352,7 +363,7 @@ static int rescode(int iter, const obsd_t* obs, int n, const double* rs, const d
         (*ns)++;
 
         /* variance of pseudorange error */
-        var[nv++] = varerr(opt, azel[1 + i * 2], sys) + vare[i] + vmeas + vion + vtrp;
+        var[nv++] = varerr(opt, azel[1 + i * 2], obs[i].SNR[0] * SNR_UNIT, sys) + vare[i] + vmeas + vion + vtrp;
 
         trace(NULL, 4, "sat=%2d azel=%5.1f %4.1f res=%7.3f sig=%5.3f\n", obs[i].sat, azel[i * 2] * R2D,
               azel[1 + i * 2] * R2D, resp[i], sqrt(var[nv - 1]));

--- a/src/pos/mrtk_spp.c
+++ b/src/pos/mrtk_spp.c
@@ -416,6 +416,37 @@ static int valsol(const double* azel, const int* vsat, int n, const prcopt_t* op
     }
     return 1;
 }
+/* IGG-III three-segment equivalent-weight factor (#116 P2) ------------------
+ * rt = standardized residual; returns a multiplicative weight in [0,1].
+ * |rt|<=k0: full weight; k0<|rt|<=k1: smooth down-weight; |rt|>k1: reject. */
+static double igg3_weight(double rt, double k0, double k1) {
+    double a = fabs(rt), t;
+    if (a <= k0) {
+        return 1.0;
+    }
+    if (a <= k1) {
+        t = (k1 - a) / (k1 - k0);
+        return (k0 / a) * t * t;
+    }
+    return 0.0;
+}
+/* ascending compare for qsort of doubles ------------------------------------*/
+static int cmp_dbl(const void* a, const void* b) {
+    double d = *(const double*)a - *(const double*)b;
+    return (d < 0.0) ? -1 : (d > 0.0 ? 1 : 0);
+}
+/* median of |x[0..n-1]| using work[] as scratch (work may equal nothing live)*/
+static double median_abs(const double* x, int n, double* work) {
+    int i;
+    if (n <= 0) {
+        return 0.0;
+    }
+    for (i = 0; i < n; i++) {
+        work[i] = fabs(x[i]);
+    }
+    qsort(work, n, sizeof(double), cmp_dbl);
+    return (n % 2) ? work[n / 2] : 0.5 * (work[n / 2 - 1] + work[n / 2]);
+}
 /* estimate receiver position ------------------------------------------------*/
 static int estpos(const obsd_t* obs, int n, const double* rs, const double* dts, const double* vare, const int* svh,
                   const nav_t* nav, const prcopt_t* opt, sol_t* sol, double* azel, int* vsat, double* resp, char* msg) {
@@ -446,6 +477,27 @@ static int estpos(const obsd_t* obs, int n, const double* rs, const double* dts,
             v[j] /= sig;
             for (k = 0; k < NX; k++) {
                 H[k + j * NX] /= sig;
+            }
+        }
+        /* #116 P2: IGG-III robust re-weighting of the pseudorange rows (0..ns-1;
+         * the trailing rank constraints are left untouched). Applied from the
+         * 2nd Gauss-Newton step (i>=1) so the clock is already estimated and the
+         * standardized residuals are meaningful. Off when opt->robust==0, so the
+         * default solution is bit-identical. var[] is stale here (recomputed by
+         * rescode next iteration), so it doubles as the median scratch buffer. */
+        if (opt->robust == 1 && i >= 1 && ns >= 5) {
+            double k0 = opt->robustk[0] > 0.0 ? opt->robustk[0] : 1.5;
+            double k1 = opt->robustk[1] > 0.0 ? opt->robustk[1] : 4.0;
+            double s0 = 1.4826 * median_abs(v, ns, var); /* MAD robust scale */
+            if (s0 < 1.0) {
+                s0 = 1.0; /* guard against over-rejection when residuals are small */
+            }
+            for (j = 0; j < ns; j++) {
+                double w = sqrt(igg3_weight(v[j] / s0, k0, k1));
+                v[j] *= w;
+                for (k = 0; k < NX; k++) {
+                    H[k + j * NX] *= w;
+                }
             }
         }
         /* least square estimation */


### PR DESCRIPTION
## Summary

SPP (`PMODE_SINGLE`) accuracy enhancement for #116, staged P0–P4. All algorithm
features are **default-off** in `prcopt_default` (bit-identical existing
behaviour, zero ctest regression); they are enabled together in the new
benchmark config `conf/benchmark/single.toml`.

Measured on the six PPC-Dataset urban-driving runs (mean), P0 baseline → P1+P2+P3+P4:

| Metric | P0 | **shipped** | change |
|--------|---:|------------:|-------:|
| <2 m fix rate | 41.2% | **61.2%** | **+20.0 pp** |
| p68 (median) | 5.61 m | **2.83 m** | **−50%** |
| p95 (tail) | 17.71 m | **12.42 m** | **−30%** |
| RMS 2D | 17.07 m | **7.54 m** | **−56%** |

## What's in it

- **P0** — `single` mode in the PPC benchmark (`run_benchmark.py`, migrated to `mrtk post`) + baseline.
- **P1** — C/N0 (Sigma-ε) pseudorange weighting in `varerr()` (also makes the RTK engine's dormant SNR term configurable).
- **P2** — IGG-III robust re-weighting in `estpos()` with a MAD robust scale.
- **P3** — pre-robust all-satellite acceptance gate (fixes the gate-defeat that P1/P2 alone cause; the piece that turns P1+P2 into a clean win).
- **P4** — TDCP velocity (Doppler fallback) + SPP cycle-slip detection + jump-rejection QC (collapses the extreme tail).

## Design rationale

Full rationale, per-step before/after benchmarks, verified bibliography, and the
negative findings are in [`docs/design/spp-accuracy.md`](docs/design/spp-accuracy.md).

## Deferred (follow-up)

P5 (common-mode clock-jump) and P6 (position EKF) are **not** in this PR: they
are not validatable on the geodetic PPC set and, for P6, an untuned first cut
gave no gain there. They are deferred to a smartphone (GSDC) benchmark follow-up
where jitter is large and clock jumps actually occur — see §4.6 and the planned
GSDC issue.

## Tests

`ctest`: zero regression. The two perennial failures (`rtkrcv_rt` vt-NULL
environmental; `madocalib_pppar_ion_check` LAPACK numerical-noise band) are
pre-existing and unrelated; the SPP regression (`rnx2rtkp_spp`/`_check`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)