### PR TITLE
chore: back-merge v0.6.10 release into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to MRTKLIB are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.6.10] - 2026-05-24
+
+**Feature** — single-point positioning (SPP) accuracy enhancements: C/N0
+weighting, IGG-III robust estimation with a pre-robust acceptance gate, and
+time-differenced carrier phase (TDCP) velocity + jump rejection. All opt-in and
+**default-off**, so existing behaviour is bit-identical.
+
+### Added
+
+- **SPP C/N0 (Sigma-ε) pseudorange weighting** (#116) — `varerr()` gains an
+  optional SNR-dependent variance term, identical in form to the RTK engine's.
+  Exposed as `[kalman_filter.measurement_error] snr_max / snr_error` (legacy
+  `stats-snrmax` / `stats-errsnr`); this also makes the RTK engine's
+  previously-unreachable SNR term configurable. `snr_error = 0` (default) → off.
+- **SPP IGG-III robust re-weighting** (#116) — `estpos()` down-weights/rejects
+  pseudorange outliers via a three-segment equivalent-weight function on the
+  MAD-standardised residual. Gated by `[positioning] robust = "igg3"`
+  (`robust_k0` / `robust_k1`); `robust = "off"` (default) → bit-identical.
+- **SPP pre-robust acceptance gate** (#116) — when robust is active, the
+  chi-square gate runs on the pre-robust all-satellite residuals so the
+  weighting cannot defeat it (the piece that turns C/N0 + robust into a clean
+  win rather than a tail-inflating one).
+- **SPP TDCP velocity, slip detection and jump rejection** (#116) — `resdop()`
+  uses the time-differenced carrier-phase rate (mm/s-class) when locked and
+  slip-free, falling back to Doppler; a SPP-local cycle-slip detector and a
+  TDCP-vs-code jump-rejection QC remove position spikes. Gated by
+  `[positioning] tdcp` / `tdcp_jump`; `tdcp = false` (default) → bit-identical.
+- **Benchmark `single` mode** — `scripts/benchmark/run_benchmark.py` gains an
+  SPP mode (and prefers the unified `mrtk post`, with `rnx2rtkp` fallback);
+  `conf/benchmark/single.toml` enables the features for evaluation.
+- **Design record** [`docs/design/spp-accuracy.md`](docs/design/spp-accuracy.md)
+  — rationale, per-step before/after benchmarks, and the deferred P5/P6.
+
+### Performance
+
+- On the PPC-Dataset (six urban-driving runs, mean), enabling the features
+  improves SPP vs the baseline: **<2 m fix rate 41.2 → 61.2 %**, median (p68)
+  **5.61 → 2.83 m**, p95 **17.71 → 12.42 m**, RMS **17.07 → 7.54 m**.
+
+### Notes
+
+- P5 (common-mode clock-jump) and P6 (position EKF) are deferred to a smartphone
+  benchmark follow-up ([#165](https://github.com/h-shiono/MRTKLIB/issues/165)),
+  where clock jumps and large jitter actually occur.
+
 ## [v0.6.9] - 2026-05-24
 
 **Feature** — IGS-product **integer PPP-AR**: resolve integer ambiguities for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,10 @@ See [`docs/releases/changelog.md`](docs/releases/changelog.md) for the full hist
 | v0.6.4 | rtkrcv status-path stability + GitHub Community Profile |
 | v0.6.5 | First official `mrtk cssr2rtcm3` release + 24-hour endurance test |
 | v0.6.6 | Unified subcommand help format + GNU-style long-option aliases |
+| v0.6.7 | IGS-products float PPP via `correction = "igs"` |
+| v0.6.8 | Real-time IGS-RTS float PPP via `correction = "igs-rts"` |
+| v0.6.9 | IGS-products integer PPP-AR (Bias-SINEX OSB phase biases) |
+| v0.6.10 | SPP accuracy (opt-in): C/N0 weighting, IGG-III robust, TDCP |
 
 ### Test Status
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(MRTKLIB VERSION 0.6.9 LANGUAGES C)
+project(MRTKLIB VERSION 0.6.10 LANGUAGES C)
 
 # ── Version header generation ─────────────────────────────────────────────────
 set(MRTKLIB_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ incrementally back-ported to each engine:
 | **v0.6.7** | PPP | IGS-products float PPP via the `correction = "igs"` axis (precise SP3/CLK + Bias-SINEX/DCB); iono-free 2nd-frequency fallback for F9P-class receivers ([#130](https://github.com/h-shiono/MRTKLIB/issues/130) / [#135](https://github.com/h-shiono/MRTKLIB/issues/135)) | ✅ Released |
 | **v0.6.8** | PPP | Real-time IGS-RTS float PPP via `correction = "igs-rts"` (RTCM-SSR / IGS-SSR MT4076; IGS01/03, CNES `CLK9x`, BKG) ([#138](https://github.com/h-shiono/MRTKLIB/issues/138)) | ✅ Released |
 | **v0.6.9** | PPP-AR | IGS-products integer PPP-AR: `correction = "igs"` + Bias-SINEX OSB phase biases in the uncombined model; dual-frequency PPP-AR zero-ambiguity (DGETRF) guard ([#142](https://github.com/h-shiono/MRTKLIB/issues/142)) | ✅ Released |
+| **v0.6.10** | SPP | Single-point positioning accuracy (opt-in / default-off): C/N0 weighting, IGG-III robust estimation + pre-robust acceptance gate, TDCP velocity + jump rejection; PPC benchmark `single` mode (fix rate +20 pp, RMS −56 %) ([#116](https://github.com/h-shiono/MRTKLIB/issues/116)) | ✅ Released |
 | **v0.6.x** | All | Doxygen docstring coverage expansion | 💭 Backlog |
 
 > [!NOTE]

--- a/docs/releases/release-notes-v0.6.10.md
+++ b/docs/releases/release-notes-v0.6.10.md
@@ -1,0 +1,133 @@
+# Release Notes — v0.6.10
+
+## SPP accuracy: C/N0 weighting, IGG-III robust estimation, and TDCP
+
+**Release date:** 2026-05-24
+**Type:** Feature — single-point positioning (SPP) accuracy, opt-in / default-off
+**Branch:** `release/v0.6.10`
+
+---
+
+### Overview
+
+v0.6.10 modernises the **single-point positioning** engine (`PMODE_SINGLE`,
+`mrtk post -p 0` / `mrtk run` with `mode = "single"`), which until now was a
+near-verbatim RTKLIB 2.4.3 snapshot least-squares solver. It adds four staged,
+independently-gated improvements (P1–P4 of the plan in
+[`docs/design/spp-accuracy.md`](../design/spp-accuracy.md)):
+
+1. **C/N0 (Sigma-ε) pseudorange weighting** — down-weight low-C/N0 signals.
+2. **IGG-III robust re-weighting** — down-weight / reject pseudorange outliers.
+3. **Pre-robust acceptance gate** — keep the chi-square gate effective under
+   robust weighting (the piece that makes 1+2 a *clean* win).
+4. **TDCP velocity + jump rejection** — mm/s-class velocity from
+   time-differenced carrier phase, plus rejection of code position spikes that
+   disagree with the TDCP displacement.
+
+Every feature is **TOML-gated and off by default** (`prcopt_default` unchanged),
+so any existing configuration produces **bit-identical** results; the gains
+appear only when the new keys are set (see `conf/benchmark/single.toml`).
+
+This is the SPP counterpart to the v0.6.7–v0.6.9 PPP/PPP-AR work on the
+`correction` axis — a substantial new capability shipped as an opt-in patch.
+
+---
+
+### Major changes (#116)
+
+#### 1. C/N0 (Sigma-ε) weighting
+
+`varerr()` ([`src/pos/mrtk_spp.c`](https://github.com/h-shiono/MRTKLIB/blob/main/src/pos/mrtk_spp.c))
+adds `σ² += (fact·snr_error)² · 10^(0.1·max(0, snr_max − C/N0))`, identical in
+form to the RTK engine's `varerr()`. The parameters `snr_max` / `snr_error`
+(`err[5]` / `err[6]`) were previously zero-initialised and unreachable from any
+config; exposing them also makes the RTK engine's dormant SNR term configurable.
+Gated by `snr_error > 0` (default 0 → off).
+
+#### 2. IGG-III robust re-weighting + 3. pre-robust gate
+
+`estpos()` applies an IGG-III three-segment equivalent-weight function to the
+standardised pseudorange residuals, scaled by a **MAD robust scale**
+(`σ̂ = max(1, 1.4826·median|r̃|)`; Rousseeuw & Croux 1993). Robust weighting
+alone defeats the chi-square gate (it shrinks the residuals the gate inspects),
+which inflates the error tail; so when robust is active, `valsol()` is fed the
+**pre-robust, all-satellite** residuals — the outliers the robust pass suppresses
+still trigger rejection of inconsistent epochs. Gated by `robust = "igg3"`
+(default `"off"` → bit-identical).
+
+#### 4. TDCP velocity, slip detection, jump rejection
+
+- `pntpos()` stores per-satellite carrier-phase history (`ssat.ph/pt`) each epoch.
+- `spp_detslp()` flags cycle slips (LLI + Doppler-vs-phase-rate consistency).
+- `resdop()` uses the TDCP phase rate (mm/s-class) when locked and slip-free,
+  else falls back to Doppler (preserving the Doppler-absence behaviour).
+- A jump-rejection QC drops epochs whose code position change disagrees with the
+  TDCP displacement (`velocity·Δt`) by more than `tdcp_jump`.
+
+Gated by `tdcp = true` (default `false` → bit-identical).
+
+---
+
+### Performance
+
+Measured with `scripts/benchmark/run_benchmark.py --mode single` on the
+PPC-Dataset (six Nagoya/Tokyo urban-driving runs), mean across runs, baseline
+(features off) → all four enabled:
+
+| Metric | Baseline | v0.6.10 (enabled) | change |
+|--------|---------:|------------------:|-------:|
+| <2 m fix rate | 41.2 % | **61.2 %** | **+20.0 pp** |
+| median (p68) | 5.61 m | **2.83 m** | **−50 %** |
+| 95th pct (p95) | 17.71 m | **12.42 m** | **−30 %** |
+| RMS 2D | 17.07 m | **7.54 m** | **−56 %** |
+
+The jump-rejection QC in particular collapses the catastrophic tail (e.g. one
+run's RMS 36.85 → 4.84 m).
+
+---
+
+### Configuration
+
+Enable the features under `[positioning]` / `[kalman_filter.measurement_error]`,
+e.g. (see `conf/benchmark/single.toml`):
+
+```toml
+[positioning]
+mode = "single"
+robust = "igg3"     # IGG-III robust re-weighting + pre-robust gate
+robust_k0 = 1.5
+robust_k1 = 4.0
+tdcp = true         # TDCP velocity + jump rejection
+tdcp_jump = 5.0     # m
+
+[slip_detection]
+doppler = 1.0       # Doppler-vs-phase slip threshold (cyc/s)
+
+[kalman_filter.measurement_error]
+snr_max = 50.0      # dB-Hz
+snr_error = 0.5     # m  (0 = C/N0 weighting off)
+```
+
+---
+
+### Tests
+
+`ctest`: **zero regression**. The SPP regression (`rnx2rtkp_spp` /
+`rnx2rtkp_spp_check`) and the PPP/IGS/RTK suites pass unchanged; the two
+perennial failures (`rtkrcv_rt` — a headless-terminal environmental issue;
+`madocalib_pppar_ion_check` — a LAPACK-vs-embedded-LU numerical-noise difference)
+are pre-existing and unrelated. Default-off keeps all existing outputs
+bit-identical.
+
+---
+
+### Deferred to the smartphone benchmark ([#165](https://github.com/h-shiono/MRTKLIB/issues/165))
+
+- **P5 — common-mode clock-jump correction**: only relevant to receivers that
+  step their clock (smartphones / low-cost), not the geodetic PPC set.
+- **P6 — position EKF (track smoothing / coasting)**: an untuned first cut gave
+  no gain and diverged on the geodetic kinematic data (the post-P1–P4 WLS is
+  already good there); it belongs on a smartphone/static benchmark where jitter
+  is large. See [`docs/design/spp-accuracy.md`](../design/spp-accuracy.md) §4.6.
+
+A GSDC-2023 smartphone benchmark plus tuned P5/P6 re-attempt is tracked in #165.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
     - Positioning Configuration Model: design/configuration.md
   - Releases:
     - Changelog: releases/changelog.md
+    - v0.6.10: releases/release-notes-v0.6.10.md
     - v0.6.9: releases/release-notes-v0.6.9.md
     - v0.6.8: releases/release-notes-v0.6.8.md
     - v0.6.7: releases/release-notes-v0.6.7.md


### PR DESCRIPTION
Back-merge of the **v0.6.10** release (PR #167) from `main` into `develop`, so the
version bump and release artifacts are in sync on `develop` (standard
post-release flow, cf. #102).

Brings in:
- `CMakeLists.txt` VERSION → 0.6.10
- `CHANGELOG.md` + `docs/releases/release-notes-v0.6.10.md`
- README release-history row, mkdocs nav, CLAUDE.md recent-releases table

No code changes (release chore only); `develop` is strictly behind `main`, so
this is a clean merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)