### PR TITLE
docs: SPP benchmark section + condensed README release table

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,35 +35,19 @@ With the MADOCALIB integration complete, users can process L6E (orbit/clock/bias
 
 ### Algorithm Improvements
 
-In addition to library integration, selected algorithm improvements from community forks are
-incrementally back-ported to each engine:
+MRTKLIB's positioning engines have been progressively modernized across releases
+(community-fork back-ports, new correction sources, tooling). Per-version detail
+is in the [CHANGELOG](CHANGELOG.md) and [release notes](docs/releases/):
 
-| Version | Engine | Improvements | Status |
-|---------|--------|-------------|--------|
-| **v0.4.1** | RTK | demo5 Partial AR (PAR), `detslp_dop` / `detslp_code`, full-constellation `varerr`, false-fix persistence fix | ✅ Released |
-| **v0.4.2** | PPP-RTK, PPP | demo5 `detslp_dop` / `detslp_code`, GLONASS clock guard in `ephpos()`, PAR variance gate + arfilter, full-constellation EFACT, adaptive outlier threshold (PPP-RTK only) | ✅ Released |
-| **v0.4.3** | PPP-RTK | Real-time CLAS PPP-RTK via `rtkrcv` (BINEX+L6, SBF+L6, RTCM3+UBX; 97.7% fix rate) | ✅ Released |
-| **v0.4.4** | PPP-RTK | Dual-channel CLAS real-time via `rtkrcv` (base stream slot repurposed for L6 ch2) | ✅ Released |
-| **v0.5.0** | All | TOML configuration (replaces legacy `.conf`); legacy `doc/` removed | ✅ Released |
-| **v0.5.1** | PPP-RTK | Bug fix: dual-channel CLAS RT fix rate degradation ([#35](https://github.com/h-shiono/MRTKLIB/issues/35)); `gen_l6_tag.py` tick_scale fix | ✅ Released |
-| **v0.5.2** | All | Code quality: mandatory braces on control flow, nested/complex ternary elimination (67 files) | ✅ Released |
-| **v0.5.3** | All | Code quality: full `clang-format` application (116 files, Google style) | ✅ Released |
-| **v0.5.4** | All | Signals update: frequency / physical band separation and structuring | ✅ Released |
-| **v0.5.5** | PPP-RTK | Bug fix: CLAS real-time positioning via UBX does not work ([#31](https://github.com/h-shiono/MRTKLIB/issues/31)) | ✅ Released |
-| **v0.5.6** | All | RINEX 4.00 CNAV/CNV2 NAV support (GPS, QZSS, BDS) | ✅ Released |
-| **v0.5.7** | — | Port RTKLIB `convbin` and `str2str` CLI applications | ✅ Released |
-| **v0.6.0** | All | Single CLI App: Unified `mrtk` binary with subcommands (`run`, `post`, `relay`, `convert`, etc.); BSS reduced from 3 GB to 34 MB | ✅ Released |
-| **v0.6.1** | All | Config UX: `systems` string list, `excluded_sats` list, `taplo` formatter, section reorganization | ✅ Released |
-| **v0.6.2** | — | Documentation: MkDocs Material site + Doxygen API reference + GitHub Pages deployment | ✅ Released |
-| **v0.6.3** | Stream | NTRIP v2 (HTTP/1.1) protocol support with auto-negotiation, chunked transfer encoding, URL percent-decoding | ✅ Released |
-| **v0.6.4** | rtkrcv / Repo | rtkrcv status-path stability fixes (data race + OOB + async-signal-safe SIGSEGV handler); GitHub Community Profile (issue/PR templates, labels, CONTRIBUTING/SECURITY/CoC) | ✅ Released |
-| **v0.6.5** | cssr2rtcm3 | First official release of `mrtk cssr2rtcm3` (real-time CSSR→RTCM3 MSM converter) and `mrtk l6extract`; Septentrio mosaic-G5 P3 hardware integration guide; 24-hour static endurance test | ✅ Released |
-| **v0.6.6** | CLI | Unified `mrtk` subcommand help format and added GNU-style long-option aliases (`--config`, `--output`, `--start`, `--end`, `--interval`, `--trace`, `--input`, `--nav`, `--device`, `--port`, `--freq`, `--help`); legacy binary headers (`usage: rtkrcv`, `usage: rnx2rtkp`, …) removed | ✅ Released |
-| **v0.6.7** | PPP | IGS-products float PPP via the `correction = "igs"` axis (precise SP3/CLK + Bias-SINEX/DCB); iono-free 2nd-frequency fallback for F9P-class receivers ([#130](https://github.com/h-shiono/MRTKLIB/issues/130) / [#135](https://github.com/h-shiono/MRTKLIB/issues/135)) | ✅ Released |
-| **v0.6.8** | PPP | Real-time IGS-RTS float PPP via `correction = "igs-rts"` (RTCM-SSR / IGS-SSR MT4076; IGS01/03, CNES `CLK9x`, BKG) ([#138](https://github.com/h-shiono/MRTKLIB/issues/138)) | ✅ Released |
-| **v0.6.9** | PPP-AR | IGS-products integer PPP-AR: `correction = "igs"` + Bias-SINEX OSB phase biases in the uncombined model; dual-frequency PPP-AR zero-ambiguity (DGETRF) guard ([#142](https://github.com/h-shiono/MRTKLIB/issues/142)) | ✅ Released |
-| **v0.6.10** | SPP | Single-point positioning accuracy (opt-in / default-off): C/N0 weighting, IGG-III robust estimation + pre-robust acceptance gate, TDCP velocity + jump rejection; PPC benchmark `single` mode (fix rate +20 pp, RMS −56 %) ([#116](https://github.com/h-shiono/MRTKLIB/issues/116)) | ✅ Released |
-| **v0.6.x** | All | Doxygen docstring coverage expansion | 💭 Backlog |
+| Era | Theme |
+|-----|-------|
+| **v0.4.x** | demo5 RTK / PPP-RTK algorithm port (PAR, `detslp_dop` / `detslp_code`, full-constellation `varerr`, false-fix fixes); real-time CLAS PPP-RTK (1ch / 2ch) |
+| **v0.5.x** | TOML configuration; code-quality sweeps (`clang-format`, mandatory braces); signals restructuring; RINEX 4.00 CNAV; `convbin` / `str2str` ports |
+| **v0.6.x** | Unified `mrtk` CLI; NTRIP v2; `mrtk cssr2rtcm3` (CSSR→RTCM3); IGS-products float / RTS / integer PPP-AR (the `correction` axis); SPP accuracy |
+
+**Latest — v0.6.10:** single-point positioning accuracy (opt-in / default-off) — C/N0 weighting, IGG-III robust estimation + pre-robust gate, TDCP velocity + jump rejection ([#116](https://github.com/h-shiono/MRTKLIB/issues/116))
+
+**Next:** SPP P5/P6 (clock-jump + position EKF) on a smartphone (GSDC) benchmark ([#165](https://github.com/h-shiono/MRTKLIB/issues/165)); Doxygen docstring coverage
 
 > [!NOTE]
 > demo5 algorithm improvements are adapted from **[demo5 RTKLIB](https://github.com/rtklibexplorer/RTKLIB)**

--- a/conf/benchmark/clas.toml
+++ b/conf/benchmark/clas.toml
@@ -2,7 +2,8 @@
 # Converted from: clas.conf
 
 [positioning]
-mode = "ppp-rtk" # (9:ppp-rtk)
+mode = "ppp-rtk"        # (9:ppp-rtk)
+correction = "qzs-clas" # QZSS CLAS (L6D CSSR); explicit (was inferred from mode+sateph)
 # frequency           = "l1+2+3"  # GPS/QZSS L1+L2+L5, Galileo E1+E5
 signals = ["G1C", "G2W", "E1C", "E5Q", "E7Q", "J1C", "J5Q", "J2X"]
 solution_type = "forward"                                          # (0:forward)

--- a/conf/benchmark/madoca.toml
+++ b/conf/benchmark/madoca.toml
@@ -3,6 +3,7 @@
 
 [positioning]
 mode = "ppp-kine"
+correction = "qzs-madoca"           # QZSS MADOCA-PPP (L6E SSR); explicit (was inferred from mode+sateph)
 frequency = "l1+2"
 solution_type = "forward"
 elevation_mask = 10.0

--- a/conf/benchmark/rtk.toml
+++ b/conf/benchmark/rtk.toml
@@ -2,7 +2,8 @@
 # Converted from: rtk.conf
 
 [positioning]
-mode = "kinematic" # (2:kinematic)
+mode = "kinematic"  # (2:kinematic)
+correction = "none" # relative RTK uses rover+base, no SSR correction (explicit)
 # frequency           = "l1+2+3"  # triple-freq
 signals = ["G1C", "G2W", "G5X", "E1C", "E5Q", "E7Q", "J1C", "J5Q", "J2X", "C2I", "C6I", "C7I"]
 solution_type = "forward"

--- a/conf/benchmark/single.toml
+++ b/conf/benchmark/single.toml
@@ -7,6 +7,7 @@
 
 [positioning]
 mode = "single"
+correction = "none"                            # SPP uses broadcast ephemeris only, no SSR correction (explicit)
 frequency = "l1"
 solution_type = "forward"
 elevation_mask = 15.0

--- a/docs/reference/benchmark.md
+++ b/docs/reference/benchmark.md
@@ -4,13 +4,14 @@ This benchmark evaluates MRTKLIB's kinematic (vehicle-mounted) positioning
 performance using the open-data [PPC2024 (Precise Positioning Challenge)][ppc]
 dataset collected for the contest organised by the Institute of Navigation Japan
 (測位航法学会).  It covers six urban driving runs
-(Nagoya × 3, Tokyo × 3) and supports three positioning modes:
+(Nagoya × 3, Tokyo × 3) and supports four positioning modes:
 
 | Mode | Engine | Correction |
 |------|--------|------------|
 | CLAS | PPP-RTK | QZSS L6D (IS-QZSS-L6-003) |
 | MADOCA | PPP | QZSS L6E (MADOCA-PPP) |
 | RTK | Kinematic RTK | Rover + base station RINEX |
+| single | SPP (single-point) | None — broadcast ephemeris only (`base.nav`) |
 
 > **Note:** This benchmark is intentionally excluded from the regular CTest
 > suite because it requires large external datasets.  Run it on demand.
@@ -112,6 +113,10 @@ python download_l6.py --mode both
 This downloads the CLAS L6D and MADOCA L6E files for all six runs into
 `data/benchmark/l6/`.  Use `--dry-run` to preview the URLs without downloading.
 
+> **`single` mode needs no correction data** — it uses only `rover.obs` +
+> `base.nav` (broadcast ephemeris). Skip this step and run
+> `run_benchmark.py --mode single --skip-download`.
+
 Options:
 
 | Option | Default | Description |
@@ -140,7 +145,7 @@ Full options:
 | `--dataset-dir DIR` | `data/benchmark` | PPC-Dataset root |
 | `--l6-dir DIR` | `data/benchmark/l6` | L6 file cache |
 | `--out-dir DIR` | `data/benchmark/results` | NMEA output dir |
-| `--mode clas\|madoca\|rtk\|both\|all` | `all` | Positioning mode (`both`=clas+madoca, `all`=all three) |
+| `--mode single\|clas\|madoca\|rtk\|both\|all` | `all` | Positioning mode (`single`=SPP, `both`=clas+madoca, `all`=clas+madoca+rtk) |
 | `--case ID[,ID...]` | all | Run specific cases only |
 | `--rnx2rtkp PATH` | auto | Path to rnx2rtkp binary |
 | `--skip-download` | off | Skip L6 download |
@@ -175,6 +180,7 @@ MADOCA-PPP never produces an integer fix and is reported as a single **PPP** tie
 | **FF** | CLAS, RTK | Q=4, 5 | Fix + float; excludes SPP fallback (Q=1) |
 | **ALL** | CLAS, RTK | any | Every matched epoch including SPP |
 | **PPP** | MADOCA | Q=3 | All valid PPP-float epochs (Q=0 already filtered) |
+| **SPP** | single | Q=1 | All valid single-point epochs; Rate% = fraction with 2D error < 2 m |
 
 **Rate% column:**
 - FIX / FF rows: fraction of that tier among all matched epochs
@@ -465,6 +471,79 @@ explicitly excluded from PPP to avoid undifferenced-observation regression.
 
 ---
 
+## v0.6.10 Single-Point Positioning (SPP) Benchmark Results
+
+MRTKLIB v0.6.10 ([#116](https://github.com/h-shiono/MRTKLIB/issues/116)) adds
+opt-in, **default-off** accuracy improvements to the single-point (`single`)
+engine — historically a near-verbatim RTKLIB 2.4.3 snapshot WLS solver:
+
+1. **C/N0 (Sigma-ε) pseudorange weighting** — down-weight low-C/N0 signals.
+2. **IGG-III robust re-weighting** + a **pre-robust acceptance gate** that keeps
+   the chi-square test effective under weighting (without it, weighting inflates
+   the error tail).
+3. **TDCP velocity** (time-differenced carrier phase, mm/s-class) with Doppler
+   fallback, a SPP-local cycle-slip detector, and a **jump-rejection QC** that
+   drops epochs whose code position change disagrees with the TDCP displacement.
+
+The full design rationale, staged per-feature analysis, and the deferred work
+are in [`docs/design/spp-accuracy.md`](../design/spp-accuracy.md).
+
+### Configuration
+
+The features are gated under `[positioning]` / `[kalman_filter.measurement_error]`
+and shipped enabled together in `conf/benchmark/single.toml`:
+
+```toml
+[positioning]
+mode = "single"
+robust = "igg3"     # IGG-III robust + pre-robust gate
+tdcp = true         # TDCP velocity + jump rejection
+tdcp_jump = 5.0     # m
+
+[slip_detection]
+doppler = 1.0       # Doppler-vs-phase slip threshold (cyc/s)
+
+[kalman_filter.measurement_error]
+snr_max = 50.0      # dB-Hz
+snr_error = 0.5     # m  (0 = C/N0 weighting off)
+```
+
+`prcopt_default` keeps all of these off, so any other configuration is
+bit-identical to the previous snapshot WLS.
+
+### Results: baseline (off) → v0.6.10 (enabled)
+
+`--mode single --skip-epochs 60`. **Rate%** is the fraction of epochs with 2D
+horizontal error < 2 m.
+
+| Case | Rate% | RMS 2D | p68 (1σ) | p95 |
+|------|------:|-------:|---------:|----:|
+| nagoya_run1 | 57.1 → **81.6 %** | 27.92 → **15.10 m** | 3.31 → **1.59 m** | 17.82 → **10.08 m** |
+| nagoya_run2 | 56.9 → **75.5 %** | 11.12 → **6.17 m** | 3.41 → **1.44 m** | 20.30 → **13.00 m** |
+| nagoya_run3 | 25.7 → **44.3 %** | 10.59 → **8.34 m** | 12.15 → **6.98 m** | 18.36 → **17.60 m** |
+| tokyo_run1  | 33.0 → **56.5 %** | 11.59 → **7.34 m** | 6.90 → **2.57 m** | 24.41 → **14.91 m** |
+| tokyo_run2  | 44.3 → **66.9 %** | 5.19 → **3.45 m** | 3.91 → **2.03 m** | 10.67 → **7.23 m** |
+| tokyo_run3  | 30.1 → **42.2 %** | 36.02 → **4.84 m** | 3.91 → **2.34 m** | 14.69 → **11.69 m** |
+| **Mean** | **41.2 → 61.2 %** | **17.07 → 7.54 m** | **5.61 → 2.83 m** | **17.71 → 12.42 m** |
+
+### Key findings (v0.6.10)
+
+- **All six runs improve** on every aggregate metric: <2 m rate **+20 pp**,
+  median **−50 %**, p95 **−30 %**, RMS **−56 %**.
+- The **jump-rejection QC collapses the extreme tail** — e.g. tokyo_run3 RMS
+  36.02 → 4.84 m — by removing code position spikes that the precise TDCP
+  displacement contradicts.
+- C/N0 weighting and robust estimation alone improve the bulk (rate, median) but
+  defeat the snapshot chi-square gate; the **pre-robust gate** is what turns them
+  into a clean win rather than a tail-inflating one.
+- The residual tail is **consistent NLOS bias**, which snapshot methods cannot
+  detect. P5 (common-mode clock-jump correction) and P6 (position EKF) need a
+  smartphone dataset where clock jumps and large jitter occur, and are deferred
+  to the GSDC benchmark follow-up
+  ([#165](https://github.com/h-shiono/MRTKLIB/issues/165)).
+
+---
+
 ## Metrics Definitions
 
 | Metric | Description |
@@ -485,19 +564,20 @@ coordinate as the reference origin (moving-base projection).
 ## Configuration
 
 The benchmark uses layered configuration files.  Each run is processed with
-`rnx2rtkp -k <mode>.conf -k <city>.conf`, so the city conf overrides only
+`mrtk post -k <mode>.toml -k <city>.toml`, so the city conf overrides only
 the keys it specifies.
 
 **Mode confs** (common settings per algorithm):
 
-- `conf/benchmark/clas.conf` — CLAS PPP-RTK
-- `conf/benchmark/madoca.conf` — MADOCA PPP
-- `conf/benchmark/rtk.conf` — Baseline RTK
+- `conf/benchmark/clas.toml` — CLAS PPP-RTK
+- `conf/benchmark/madoca.toml` — MADOCA PPP
+- `conf/benchmark/rtk.toml` — Baseline RTK
+- `conf/benchmark/single.toml` — SPP (single-point), with the v0.6.10 accuracy features enabled
 
 **City confs** (antenna types and reference-station coordinates):
 
-- `conf/benchmark/nagoya.conf` — Nagoya overrides
-- `conf/benchmark/tokyo.conf` — Tokyo overrides
+- `conf/benchmark/nagoya.toml` — Nagoya overrides
+- `conf/benchmark/tokyo.toml` — Tokyo overrides
 
 Key differences from the standard test configurations:
 

--- a/docs/reference/benchmark.md
+++ b/docs/reference/benchmark.md
@@ -497,6 +497,7 @@ and shipped enabled together in `conf/benchmark/single.toml`:
 ```toml
 [positioning]
 mode = "single"
+correction = "none"
 robust = "igg3"     # IGG-III robust + pre-robust gate
 tdcp = true         # TDCP velocity + jump rejection
 tdcp_jump = 5.0     # m

--- a/docs/reference/benchmark.md
+++ b/docs/reference/benchmark.md
@@ -4,14 +4,15 @@ This benchmark evaluates MRTKLIB's kinematic (vehicle-mounted) positioning
 performance using the open-data [PPC2024 (Precise Positioning Challenge)][ppc]
 dataset collected for the contest organised by the Institute of Navigation Japan
 (測位航法学会).  It covers six urban driving runs
-(Nagoya × 3, Tokyo × 3) and supports four positioning modes:
+(Nagoya × 3, Tokyo × 3) and supports four positioning modes.  Each benchmark
+config sets the [`correction`](../design/configuration.md) axis explicitly:
 
-| Mode | Engine | Correction |
-|------|--------|------------|
-| CLAS | PPP-RTK | QZSS L6D (IS-QZSS-L6-003) |
-| MADOCA | PPP | QZSS L6E (MADOCA-PPP) |
-| RTK | Kinematic RTK | Rover + base station RINEX |
-| single | SPP (single-point) | None — broadcast ephemeris only (`base.nav`) |
+| Mode | Engine | `correction` | Correction source |
+|------|--------|--------------|-------------------|
+| CLAS | PPP-RTK | `qzs-clas` | QZSS L6D (IS-QZSS-L6-003) |
+| MADOCA | PPP | `qzs-madoca` | QZSS L6E (MADOCA-PPP) |
+| RTK | Kinematic RTK | `none` | Rover + base station RINEX |
+| single | SPP (single-point) | `none` | Broadcast ephemeris only (`base.nav`) |
 
 > **Note:** This benchmark is intentionally excluded from the regular CTest
 > suite because it requires large external datasets.  Run it on demand.


### PR DESCRIPTION
Documentation follow-up to the v0.6.10 SPP accuracy work (#116).

## benchmark.md — add the `single` (SPP) mode

`docs/reference/benchmark.md` only covered CLAS / MADOCA / RTK. Adds:

- `single` row in the mode table; `--mode single` in the runner options; a note
  that SPP needs no correction data (`rover.obs` + `base.nav` only).
- An **SPP** solution-quality tier (Q=1, Rate% = fraction < 2 m).
- A **v0.6.10 Single-Point Positioning Benchmark Results** section: the opt-in
  features, `conf/benchmark/single.toml`, and a baseline → enabled table
  (mean: <2 m rate 41.2 → 61.2 %, RMS 17.07 → 7.54 m), with key findings and the
  P5/P6 deferral to #165.
- Refresh the Configuration conf list to `.toml` / `mrtk post` (the older
  `.conf` / `rnx2rtkp` references in that list were stale post-v0.5.0/v0.6.0).

## README.md — condense the release table

The "Algorithm Improvements" table had grown to 23 per-version rows. Condense it
to three era themes (v0.4.x / v0.5.x / v0.6.x) + a **Latest** (v0.6.10) and
**Next** line, with per-version detail delegated to the CHANGELOG / release notes.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)