### PR TITLE
feat(benchmark): GSDC-2023 smartphone SPP benchmark (#165)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,8 @@ upstream/RTKLIB/
 
 # PPC benchmark dataset, L6 data, and positioning results (large; download on demand)
 data/benchmark/
+
+# GSDC (Google Smartphone Decimeter Challenge 2023) benchmark dataset and results
+# (3.5 GB zip -> 16 GB extracted; manual download, see docs/reference/benchmark-gsdc.md)
+tests/data/sdc2023.zip
+data/gsdc/

--- a/conf/benchmark/gsdc_p0.toml
+++ b/conf/benchmark/gsdc_p0.toml
@@ -1,0 +1,21 @@
+# GSDC smartphone SPP P0 baseline overlay (issue #165).
+#
+# Layered on top of single.toml to recover the classic-SPP "P0" reference
+# (analogous to the #116 P0 baseline in docs/design/spp-accuracy.md 4.1):
+# elevation-only weighting, Klobuchar iono, Saastamoinen tropo, broadcast
+# ephemeris, RAIM-FDE -- i.e. the #116 P1-P4 additions (C/N0 weighting, IGG-III
+# robust + gate, TDCP jump rejection) are turned OFF so the table shows the raw
+# smartphone SPP that P5 (clock-jump) and P6 (position EKF) are measured against.
+#
+#   python run_gsdc_benchmark.py --conf conf/benchmark/single.toml \
+#                                --conf conf/benchmark/gsdc_p0.toml
+
+[positioning]
+robust = "off" # #116 P2/P3 off
+tdcp = false   # #116 P4 off
+
+[positioning.corrections]
+raim_fde = true # classic SPP fault exclusion stays on (part of the P0 baseline)
+
+[kalman_filter.measurement_error]
+snr_error = 0.0 # #116 P1 C/N0 weighting off

--- a/docs/reference/benchmark-gsdc.md
+++ b/docs/reference/benchmark-gsdc.md
@@ -1,0 +1,261 @@
+# Smartphone SPP Benchmark (GSDC-2023)
+
+This benchmark evaluates MRTKLIB's single-point positioning (SPP) on **low-cost
+smartphone** GNSS data using the open
+[Google Smartphone Decimeter Challenge 2023 (GSDC-2023)][gsdc] dataset.
+
+It is the smartphone counterpart of the geodetic-grade
+[PPC kinematic benchmark](benchmark.md).  Smartphone data is where the #116 SPP
+accuracy work's last two stages are validated — the geodetic PPC set cannot
+exercise them (see [`docs/design/spp-accuracy.md`](../design/spp-accuracy.md)
+§4.6):
+
+- **P5 — common-mode clock-jump correction.** Geodetic clocks don't step;
+  smartphones do (the GSDC `device_gnss.csv` carries
+  `HardwareClockDiscontinuityCount`).
+- **P6 — position EKF (smoothing / coasting).** After P1–P4 the geodetic
+  per-epoch WLS is already smooth, so there is nothing to smooth; smartphone
+  data has large jitter and a real smoothing/coasting payoff.
+
+> **Note:** Like the PPC benchmark, this is intentionally excluded from the
+> regular CTest suite — it needs a large external dataset and network access for
+> broadcast ephemeris.  Run it on demand.
+
+> **Disclaimer:** The SPP configuration here is **not** tuned for the smartphone
+> regime.  These are baseline/reference numbers, not best-achievable accuracy.
+
+---
+
+## Dataset
+
+| | |
+|---|---|
+| **Source** | Google Smartphone Decimeter Challenge 2023 (Kaggle) |
+| **Receivers** | Android phones (Pixel 4/4XL/5/6Pro/7Pro, Xiaomi Mi8, Samsung S20/A32, …) |
+| **Rate** | 1 Hz |
+| **Reference** | NovAtel SPAN (post-processed), `ground_truth.csv` |
+| **Train cases** | 156 `trip/device` combinations with ground truth |
+| **Raw format** | `device_gnss.csv` (Google-derived) — **not RINEX** |
+
+The raw measurements are *not* RINEX.  GSDC ships a **derived** CSV in which
+Google has already reconstructed the pseudorange, classified the signal and
+provided carrier phase / Doppler / C/N0, so a direct CSV → RINEX mapping
+(`gsdc_to_rinex.py`) is simpler and less error-prone than re-deriving the
+pseudorange from the raw Android clock fields.
+
+### Manual download
+
+The archive (~3.5 GB zip → ~16 GB extracted) must be downloaded manually from
+Kaggle (account + competition rules acceptance required):
+
+1. Visit the [GSDC-2023 data page][gsdc] and download the competition data
+   (or use the Kaggle CLI: `kaggle competitions download -c smartphone-decimeter-2023`).
+2. Place the zip at `tests/data/sdc2023.zip` (git-ignored), or extract it so the
+   layout matches:
+
+```
+data/gsdc/
+  train/
+    2020-06-25-00-34-us-ca-mtv-sb-101/
+      pixel4/
+        device_gnss.csv      # raw (derived) measurements
+        ground_truth.csv     # reference track (lat/lon/alt + speed/bearing)
+    ...
+  brdc/                      # broadcast nav cache (auto-downloaded)
+  results/                  # OBS + NMEA output
+```
+
+Only `device_gnss.csv` and `ground_truth.csv` are needed per case; the
+`device_imu.csv` and `supplemental/` files are not used.  Both `data/gsdc/` and
+`tests/data/sdc2023.zip` are git-ignored.
+
+Extract just the curated subset (≈250 MB) without unpacking the whole archive:
+
+```bash
+for tp in \
+  train/2020-06-25-00-34-us-ca-mtv-sb-101/pixel4 \
+  train/2020-07-17-23-13-us-ca-sf-mtv-280/pixel4 \
+  train/2020-12-10-22-52-us-ca-sjc-c/mi8 \
+  train/2021-04-02-20-43-us-ca-mtv-f/sm-g988b \
+  train/2021-12-07-19-22-us-ca-lax-d/pixel5 \
+  train/2023-09-05-23-07-us-ca-routen/pixel7pro ; do
+  unzip -o -q tests/data/sdc2023.zip "$tp/device_gnss.csv" "$tp/ground_truth.csv" -d data/gsdc/
+done
+```
+
+---
+
+## Conversion: `device_gnss.csv` → RINEX 3.04
+
+`gsdc_to_rinex.py` maps each measurement row to a RINEX 3.04 observation:
+
+| RINEX | Source column | Notes |
+|-------|---------------|-------|
+| C (pseudorange) | `RawPseudorangeMeters` | already reconstructed by Google |
+| L (carrier) | `AccumulatedDeltaRangeMeters` / λ | only when ADR state = VALID; LLI set on RESET/CYCLE_SLIP |
+| D (Doppler) | −`PseudorangeRateMetersPerSecond` / λ | |
+| S (C/N0) | `Cn0DbHz` | → RINEX SSI 1–9 |
+
+with λ = c / `CarrierFrequencyHz`.  Satellite id is `(ConstellationType, Svid)`
+→ `G/R/E/C/J` (QZSS PRN = Svid − 192).  Epoch GPS time = `utcTimeMillis`/1000
+− 315964800 + `LeapSecond` (cross-checked against the CSV's own
+`ArrivalTimeNanosSinceGpsEpoch`).
+
+Signal → RINEX 3.04 observation code:
+
+| Android `SignalType` | RINEX code | | Android `SignalType` | RINEX code |
+|----------------------|:----------:|---|----------------------|:----------:|
+| `GPS_L1_CA` | `1C` | | `GAL_E5A_Q` | `5Q` |
+| `GPS_L5_Q` | `5Q` | | `GLO_G1_CA` | `1C` |
+| `GAL_E1_C_P` | `1C` | | `QZS_L1_CA` | `1C` |
+| `BDS_B1_I` | `2I` | | `QZS_L5_Q` | `5Q` |
+
+GLONASS is converted but excluded from positioning by the SPP config's
+`systems` list (FDMA, no broadcast iono model fit for single-frequency SPP).
+
+**Converter self-check.** `--self-check` reproduces Google's per-epoch WLS from
+the CSV's own `SvPosition*`/clock/iono/tropo columns and compares it to the
+`WlsPosition*` column.  Agreement to a few metres confirms the
+pseudorange / satellite-id / epoch-grouping reading (a reading bug diverges by
+orders of magnitude, not metres):
+
+```bash
+python scripts/benchmark/gsdc_to_rinex.py \
+    data/gsdc/train/.../pixel4/device_gnss.csv --self-check
+```
+
+---
+
+## Broadcast ephemeris
+
+`device_gnss.csv` carries no ephemeris, so `download_brdc.py` fetches the daily
+merged multi-GNSS broadcast nav (RINEX 3, GPS+GLO+GAL+BDS+QZS) for each UTC day
+a trip spans.  The source is **BKG** (`BRDM00DLR_S`, falling back to
+`BRDC00WRD_S` / `BRDC00IGS_R`), which serves without authentication (CDDIS
+requires an Earthdata login).  Files are cached under `data/gsdc/brdc/`.
+
+---
+
+## Quick start
+
+```bash
+# 1. Build mrtk and extract the test ATX/ISB/ERP data (as for any benchmark).
+cmake --build build
+cd build && ctest -R setup --output-on-failure && cd ..
+
+# 2. Run the curated subset (downloads broadcast nav automatically).
+python scripts/benchmark/run_gsdc_benchmark.py --case curated
+
+# 3. Single case, or every discovered train case:
+python scripts/benchmark/run_gsdc_benchmark.py \
+    --case 2021-12-07-19-22-us-ca-lax-d/pixel5
+python scripts/benchmark/run_gsdc_benchmark.py --case all
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--dataset-dir DIR` | `data/gsdc` | GSDC root (contains `train/`) |
+| `--brdc-dir DIR` | `data/gsdc/brdc` | broadcast-nav cache |
+| `--out-dir DIR` | `data/gsdc/results` | OBS + NMEA output |
+| `--case curated\|all\|<id,…>` | `curated` | which cases to run |
+| `--conf PATH` (repeatable) | `conf/benchmark/single.toml` | layered config |
+| `--skip-download` | off | use cached nav only |
+| `--threshold M` | `2.0` | 2D `<N m` rate threshold |
+| `--force` | off | re-convert even if cached |
+
+---
+
+## Baseline results (v0.6.10, curated subset)
+
+GNSS-only SPP, broadcast ephemeris, all matched epochs (no skip).  Two
+configurations bracket the #116 work and form the before/after reference for the
+P5/P6 effort:
+
+- **P0** — classic SPP: elevation-only weighting, Klobuchar iono, Saastamoinen
+  tropo, RAIM-FDE (`single.toml` + `gsdc_p0.toml`).
+- **P1–P4** — `single.toml` as shipped: + C/N0 weighting, IGG-III robust +
+  pre-robust gate, TDCP jump rejection.
+
+### P0 (classic SPP)
+
+| Case | N | nSV | <2 m | RMS 2D | p68 | p95 |
+|------|--:|----:|-----:|-------:|----:|----:|
+| mtv-sb-101 / pixel4 | 1289 | 14.3 | 21.5% | 4.30 m | 4.40 m | 7.61 m |
+| sf-mtv-280 / pixel4 | 1680 | 11.6 | 20.7% | 4.98 m | 4.94 m | 8.94 m |
+| sjc-c / mi8 | 1266 | 15.0 | 24.7% | 4.71 m | 4.32 m | 8.72 m |
+| mtv-f / sm-g988b | 2284 | 19.9 | 37.0% | 3.35 m | 3.43 m | 6.03 m |
+| lax-d / pixel5 | 1716 | 12.4 | 22.1% | 4.30 m | 4.26 m | 7.56 m |
+| routen / pixel7pro | 1545 | 14.7 | 22.7% | 4.58 m | 4.48 m | 8.68 m |
+| **mean** | **1630** | **14.6** | **24.8%** | **4.37 m** | **4.31 m** | **7.92 m** |
+
+### P1–P4 (`single.toml`)
+
+| Case | N | nSV | <2 m | RMS 2D | p68 | p95 |
+|------|--:|----:|-----:|-------:|----:|----:|
+| mtv-sb-101 / pixel4 | 685 | 14.4 | 36.8% | 3.00 m | 3.09 m | 5.45 m |
+| sf-mtv-280 / pixel4 | 370 | 11.8 | 34.3% | 3.12 m | 3.27 m | 5.47 m |
+| sjc-c / mi8 | 815 | 15.1 | 36.0% | 3.62 m | 3.30 m | 6.88 m |
+| mtv-f / sm-g988b | 2072 | 19.9 | 42.2% | 2.93 m | 3.09 m | 5.26 m |
+| lax-d / pixel5 | 735 | 12.5 | 37.6% | 3.13 m | 3.22 m | 5.25 m |
+| routen / pixel7pro | 768 | 14.8 | 28.6% | 3.86 m | 3.84 m | 6.64 m |
+| **mean** | **907** | **14.7** | **35.9%** | **3.28 m** | **3.30 m** | **5.82 m** |
+
+### Reading the two tables
+
+P1–P4 improves accuracy across the board (`<2 m` +11 pp, p68 −1.0 m, p95
+−2.1 m, RMS −1.1 m) **but the matched-epoch count drops ~44 %** (mean 1630 →
+907): the QC rejects the noisy/blunder epochs rather than solving them poorly.
+This availability/accuracy trade-off is exactly the gap the remaining work
+targets:
+
+- **P6 (position EKF)** should *coast* through the rejected epochs, recovering
+  availability without giving back accuracy — and smartphone jitter (3–4 m, vs
+  the geodetic set's sub-decimetre) is where smoothing actually pays
+  ([`spp-accuracy.md`](../design/spp-accuracy.md) §4.6).
+- **P5 (clock-jump correction)** should recover epochs lost to receiver clock
+  steps and stabilise TDCP on low-cost hardware.
+
+Google's own WLS (the `WlsPosition*` column) lands at ~2.3 m 2D RMS on the open
+trips, so MRTKLIB's untuned SPP is already in the same regime; the headroom is
+in availability and the urban tail.
+
+---
+
+## Metrics
+
+Identical to the [PPC benchmark](benchmark.md#metrics-definitions): per-epoch ENU
+error against the matched ground-truth coordinate (moving-base projection), 2D
+RMS / p68 (1σ) / p95, and the `<2 m` fraction.  Reference epochs are
+matched to NMEA GGA epochs by UTC seconds-of-day within 0.15 s.
+
+---
+
+## Known limitations
+
+- **Untuned SPP config.** `single.toml` was tuned on the geodetic PPC set; the
+  smartphone regime (clock jumps, larger noise, NLOS) is not yet tuned — that is
+  the P5/P6 work.
+- **No antenna / ISB calibration.** Phone antennas have no PCV; Google's
+  satellite ISB is not applied (the converter keeps `RawPseudorangeMeters`).
+- **GLONASS excluded** from positioning (converted but dropped by the config).
+- **Train split only.** The `test/` split has no public ground truth.
+- **IMU not used.** GNSS-only.
+
+---
+
+## Acknowledgements
+
+The dataset is the **Google Smartphone Decimeter Challenge 2023**, hosted on
+Kaggle and released by Google's Android GNSS team in collaboration with the
+ION GNSS+ conference.  Please observe the Kaggle competition rules and cite the
+GSDC-2023 materials when publishing results derived from this data.
+
+---
+
+## References
+
+- [GSDC-2023 on Kaggle][gsdc]
+- [SPP accuracy design](../design/spp-accuracy.md) (#116 P0–P6)
+- [PPC kinematic benchmark](benchmark.md)
+
+[gsdc]: https://www.kaggle.com/competitions/smartphone-decimeter-2023

--- a/docs/reference/benchmark-gsdc.md
+++ b/docs/reference/benchmark-gsdc.md
@@ -94,7 +94,7 @@ done
 | C (pseudorange) | `RawPseudorangeMeters` | already reconstructed by Google |
 | L (carrier) | `AccumulatedDeltaRangeMeters` / λ | only when ADR state = VALID; LLI set on RESET/CYCLE_SLIP |
 | D (Doppler) | −`PseudorangeRateMetersPerSecond` / λ | |
-| S (C/N0) | `Cn0DbHz` | → RINEX SSI 1–9 |
+| S (C/N0) | `Cn0DbHz` | full dB-Hz in the S obs (e.g. `S1C` = `40.200`); a 1–9 SSI digit is also appended to every field per RINEX |
 
 with λ = c / `CarrierFrequencyHz`.  Satellite id is `(ConstellationType, Svid)`
 → `G/R/E/C/J` (QZSS PRN = Svid − 192).  Epoch GPS time = `utcTimeMillis`/1000
@@ -165,6 +165,28 @@ python scripts/benchmark/run_gsdc_benchmark.py --case all
 
 ---
 
+## Scoring (official GSDC metric)
+
+The Google Smartphone Decimeter Challenge scores each run by the **mean of the
+50th and 95th percentile horizontal positioning error** (metres); the per-run
+scores are averaged to give the leaderboard number.  The official competition
+computes this over the **36 test runs** (public/private split), whose ground
+truth is withheld.
+
+This benchmark reports the **same metric** (`score` column = `(p50 + p95) / 2`)
+but on the **train** split, which has public ground truth, so the numbers are
+directly interpretable on the leaderboard's scale.  Top GSDC entries reach
+~1–2 m using carrier-phase PPP/RTK + IMU + map-matching; the SPP-only figures
+here are a code-pseudorange baseline, not a leaderboard-competitive solution.
+
+The runner also prints `<2 m` rate, RMS and matched-epoch count `N`
+(availability) for engineering insight.  Per-epoch ENU error is taken against
+the matched ground-truth coordinate (moving-base projection), exactly as in the
+[PPC benchmark](benchmark.md#metrics-definitions); reference and NMEA GGA epochs
+are matched by UTC seconds-of-day within 0.15 s.
+
+---
+
 ## Baseline results (v0.6.10, curated subset)
 
 GNSS-only SPP, broadcast ephemeris, all matched epochs (no skip).  Two
@@ -176,37 +198,39 @@ P5/P6 effort:
 - **P1–P4** — `single.toml` as shipped: + C/N0 weighting, IGG-III robust +
   pre-robust gate, TDCP jump rejection.
 
+`score` is the official GSDC metric; lower is better.
+
 ### P0 (classic SPP)
 
-| Case | N | nSV | <2 m | RMS 2D | p68 | p95 |
-|------|--:|----:|-----:|-------:|----:|----:|
-| mtv-sb-101 / pixel4 | 1289 | 14.3 | 21.5% | 4.30 m | 4.40 m | 7.61 m |
-| sf-mtv-280 / pixel4 | 1680 | 11.6 | 20.7% | 4.98 m | 4.94 m | 8.94 m |
-| sjc-c / mi8 | 1266 | 15.0 | 24.7% | 4.71 m | 4.32 m | 8.72 m |
-| mtv-f / sm-g988b | 2284 | 19.9 | 37.0% | 3.35 m | 3.43 m | 6.03 m |
-| lax-d / pixel5 | 1716 | 12.4 | 22.1% | 4.30 m | 4.26 m | 7.56 m |
-| routen / pixel7pro | 1545 | 14.7 | 22.7% | 4.58 m | 4.48 m | 8.68 m |
-| **mean** | **1630** | **14.6** | **24.8%** | **4.37 m** | **4.31 m** | **7.92 m** |
+| Case | N | nSV | <2 m | RMS 2D | p50 | p95 | **score** |
+|------|--:|----:|-----:|-------:|----:|----:|----------:|
+| mtv-sb-101 / pixel4 | 1289 | 14.3 | 21.5% | 4.30 m | 3.34 m | 7.61 m | 5.47 m |
+| sf-mtv-280 / pixel4 | 1680 | 11.6 | 20.7% | 4.98 m | 3.68 m | 8.94 m | 6.31 m |
+| sjc-c / mi8 | 1266 | 15.0 | 24.7% | 4.71 m | 3.16 m | 8.72 m | 5.94 m |
+| mtv-f / sm-g988b | 2284 | 19.9 | 37.0% | 3.35 m | 2.58 m | 6.03 m | 4.30 m |
+| lax-d / pixel5 | 1716 | 12.4 | 22.1% | 4.30 m | 3.37 m | 7.56 m | 5.47 m |
+| routen / pixel7pro | 1545 | 14.7 | 22.7% | 4.58 m | 3.41 m | 8.68 m | 6.05 m |
+| **mean** | **1630** | **14.6** | **24.8%** | **4.37 m** | **3.26 m** | **7.92 m** | **5.59 m** |
 
 ### P1–P4 (`single.toml`)
 
-| Case | N | nSV | <2 m | RMS 2D | p68 | p95 |
-|------|--:|----:|-----:|-------:|----:|----:|
-| mtv-sb-101 / pixel4 | 685 | 14.4 | 36.8% | 3.00 m | 3.09 m | 5.45 m |
-| sf-mtv-280 / pixel4 | 370 | 11.8 | 34.3% | 3.12 m | 3.27 m | 5.47 m |
-| sjc-c / mi8 | 815 | 15.1 | 36.0% | 3.62 m | 3.30 m | 6.88 m |
-| mtv-f / sm-g988b | 2072 | 19.9 | 42.2% | 2.93 m | 3.09 m | 5.26 m |
-| lax-d / pixel5 | 735 | 12.5 | 37.6% | 3.13 m | 3.22 m | 5.25 m |
-| routen / pixel7pro | 768 | 14.8 | 28.6% | 3.86 m | 3.84 m | 6.64 m |
-| **mean** | **907** | **14.7** | **35.9%** | **3.28 m** | **3.30 m** | **5.82 m** |
+| Case | N | nSV | <2 m | RMS 2D | p50 | p95 | **score** |
+|------|--:|----:|-----:|-------:|----:|----:|----------:|
+| mtv-sb-101 / pixel4 | 685 | 14.4 | 36.8% | 3.00 m | 2.41 m | 5.45 m | 3.93 m |
+| sf-mtv-280 / pixel4 | 370 | 11.8 | 34.3% | 3.12 m | 2.63 m | 5.47 m | 4.05 m |
+| sjc-c / mi8 | 815 | 15.1 | 36.0% | 3.62 m | 2.51 m | 6.88 m | 4.69 m |
+| mtv-f / sm-g988b | 2072 | 19.9 | 42.2% | 2.93 m | 2.33 m | 5.26 m | 3.80 m |
+| lax-d / pixel5 | 735 | 12.5 | 37.6% | 3.13 m | 2.42 m | 5.25 m | 3.84 m |
+| routen / pixel7pro | 768 | 14.8 | 28.6% | 3.86 m | 3.03 m | 6.64 m | 4.84 m |
+| **mean** | **907** | **14.7** | **35.9%** | **3.28 m** | **2.56 m** | **5.82 m** | **4.19 m** |
 
 ### Reading the two tables
 
-P1–P4 improves accuracy across the board (`<2 m` +11 pp, p68 −1.0 m, p95
-−2.1 m, RMS −1.1 m) **but the matched-epoch count drops ~44 %** (mean 1630 →
-907): the QC rejects the noisy/blunder epochs rather than solving them poorly.
-This availability/accuracy trade-off is exactly the gap the remaining work
-targets:
+P1–P4 improves the GSDC score from **5.59 m → 4.19 m (−25 %)** (p50 3.26 →
+2.56 m, p95 7.92 → 5.82 m, `<2 m` +11 pp) **but the matched-epoch count drops
+~44 %** (mean 1630 → 907): the QC rejects the noisy/blunder epochs rather than
+solving them poorly.  This availability/accuracy trade-off is exactly the gap
+the remaining work targets:
 
 - **P6 (position EKF)** should *coast* through the rejected epochs, recovering
   availability without giving back accuracy — and smartphone jitter (3–4 m, vs
@@ -218,15 +242,6 @@ targets:
 Google's own WLS (the `WlsPosition*` column) lands at ~2.3 m 2D RMS on the open
 trips, so MRTKLIB's untuned SPP is already in the same regime; the headroom is
 in availability and the urban tail.
-
----
-
-## Metrics
-
-Identical to the [PPC benchmark](benchmark.md#metrics-definitions): per-epoch ENU
-error against the matched ground-truth coordinate (moving-base projection), 2D
-RMS / p68 (1σ) / p95, and the `<2 m` fraction.  Reference epochs are
-matched to NMEA GGA epochs by UTC seconds-of-day within 0.15 s.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,7 +102,8 @@ nav:
   - Reference:
     - Configuration Options: reference/config-options.md
     - API Reference (Doxygen): reference/api.md
-    - Benchmark: reference/benchmark.md
+    - Benchmark (PPC kinematic): reference/benchmark.md
+    - Benchmark (GSDC smartphone): reference/benchmark-gsdc.md
     - Real-Time CLAS: reference/rtkrcv-clas-realtime.md
     - Test Methodology: reference/test-accuracy-methodology.md
   - Design:

--- a/scripts/benchmark/compare_gsdc.py
+++ b/scripts/benchmark/compare_gsdc.py
@@ -1,0 +1,150 @@
+"""compare_gsdc.py - Compare mrtk NMEA output against a GSDC ground_truth.csv.
+
+The GSDC-2023 reference track is ``ground_truth.csv`` (NovAtel SPAN, post-
+processed).  This module parses it into the same timed-position record shape the
+PPC comparator uses, then reuses ``compare_ppc``'s epoch matching and metric
+computation so the two benchmarks report identical statistics.
+
+ground_truth.csv columns (subset used)
+--------------------------------------
+    LatitudeDegrees, LongitudeDegrees, AltitudeMeters (WGS84 ellipsoidal),
+    SpeedMps, BearingDegrees, UnixTimeMillis (UTC)
+
+Usage
+-----
+    compare_gsdc.py --ref <ground_truth.csv> <result.nmea>
+                    [--skip-epochs N] [--threshold M] [--plot]
+"""
+
+import argparse
+import csv
+import math
+import os
+import sys
+from pathlib import Path
+
+# Reuse the PPC comparator's NMEA parser, epoch matcher and metric computation.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from compare_ppc import _match_epochs, compute_metrics, parse_nmea, plot_results  # noqa: E402
+
+
+def parse_ground_truth(csv_path: str) -> list[tuple[float, float, float, float]]:
+    """Parse a GSDC ground_truth.csv into timed position records.
+
+    Args:
+        csv_path: Path to ``ground_truth.csv``.
+
+    Returns:
+        List of ``(utc_sod, lat_deg, lon_deg, h_ell)`` tuples sorted by
+        ``utc_sod`` (UTC seconds-of-day from ``UnixTimeMillis``).
+    """
+    rows = []
+    with open(csv_path, newline="") as fh:
+        for r in csv.DictReader(fh):
+            try:
+                t = int(r["UnixTimeMillis"])
+                lat = float(r["LatitudeDegrees"])
+                lon = float(r["LongitudeDegrees"])
+                h = float(r["AltitudeMeters"])
+            except (KeyError, ValueError):
+                continue
+            rows.append(((t / 1000.0) % 86400.0, lat, lon, h))
+    rows.sort(key=lambda x: x[0])
+    return rows
+
+
+def parse_ground_truth_velocity(csv_path: str) -> dict[float, tuple[float, float]]:
+    """Parse ground-truth horizontal velocity, keyed by UTC seconds-of-day.
+
+    Provided for the deferred TDCP velocity validation (#165 task 6); the
+    position comparison does not use it.
+
+    Returns:
+        ``{utc_sod: (speed_mps, bearing_deg)}``.
+    """
+    out = {}
+    with open(csv_path, newline="") as fh:
+        for r in csv.DictReader(fh):
+            try:
+                t = int(r["UnixTimeMillis"])
+                speed = float(r["SpeedMps"])
+                bearing = float(r["BearingDegrees"])
+            except (KeyError, ValueError):
+                continue
+            out[(t / 1000.0) % 86400.0] = (speed, bearing)
+    return out
+
+
+def _fmt(v: float, unit: str = "m", digits: int = 3) -> str:
+    """Format a metric value, showing 'nan' for math.nan."""
+    return "nan" if math.isnan(v) else f"{v:.{digits}f} {unit}"
+
+
+def main() -> int:
+    """Compare one NMEA result against one GSDC ground_truth.csv."""
+    p = argparse.ArgumentParser(
+        description="Compare mrtk NMEA output against a GSDC ground_truth.csv"
+    )
+    p.add_argument("--ref", required=True, metavar="CSV", help="GSDC ground_truth.csv")
+    p.add_argument("result", metavar="NMEA", help="mrtk NMEA output file")
+    p.add_argument("--skip-epochs", type=int, default=0,
+                   help="initial epochs to skip (convergence exclusion, default 0)")
+    p.add_argument("--threshold", type=float, default=2.0,
+                   help="2D horizontal error threshold in metres (default 2.0)")
+    p.add_argument("--plot", action="store_true", help="generate ENU time-series PNG")
+    p.add_argument("--plot-out", default="", help="output path for plot")
+    args = p.parse_args()
+
+    if not os.path.isfile(args.ref):
+        print(f"FAIL: ground truth not found: {args.ref}", file=sys.stderr)
+        return 1
+    if not os.path.isfile(args.result):
+        print(f"FAIL: result not found: {args.result}", file=sys.stderr)
+        return 1
+
+    ref_rows = parse_ground_truth(args.ref)
+    nmea_rows = parse_nmea(args.result)
+    if not ref_rows:
+        print("FAIL: no data in ground_truth.csv", file=sys.stderr)
+        return 1
+    if not nmea_rows:
+        print("FAIL: no GGA sentences in result", file=sys.stderr)
+        return 1
+
+    pairs = _match_epochs(ref_rows, nmea_rows)
+    if not pairs:
+        print("FAIL: no matching epochs (check date / time range)", file=sys.stderr)
+        return 1
+
+    m = compute_metrics(pairs, args.skip_epochs, threshold_2d=args.threshold)
+    if m is None:
+        print("FAIL: no usable epochs after skip", file=sys.stderr)
+        return 1
+
+    thr = args.threshold
+    thr_label = f"<{thr:.1f}m" if thr >= 1.0 else f"<{thr * 100:.0f}cm"
+    print(f"Reference : {args.ref}")
+    print(f"Result    : {args.result}")
+    print()
+    print(f"Matched epochs : {m['n_matched']}")
+    print(f"{thr_label} rate    : {m['thr_rate']:.1f}%")
+    print(f"mean nSV       : {m['mean_sv_all']:.1f}")
+    print()
+    print("  2D horizontal (all epochs):")
+    print(f"    RMS    : {_fmt(m['rms_2d_all'])}")
+    print(f"    p68    : {_fmt(m['p68_2d_all'])}  (1-sigma)")
+    print(f"    95%    : {_fmt(m['p95_2d_all'])}")
+    print(f"    Max    : {_fmt(m['max_2d_all'])}")
+    print()
+    print("  ENU RMS (all epochs):")
+    print(f"    East/North/Up : {m['rms_e']:.3f} / {m['rms_n']:.3f} / {m['rms_u']:.3f} m")
+
+    if args.plot:
+        out = args.plot_out or (os.path.splitext(args.result)[0] + ".png")
+        plot_results(m, title=os.path.basename(args.result), output_path=out)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmark/compare_gsdc.py
+++ b/scripts/benchmark/compare_gsdc.py
@@ -123,6 +123,7 @@ def main() -> int:
 
     thr = args.threshold
     thr_label = f"<{thr:.1f}m" if thr >= 1.0 else f"<{thr * 100:.0f}cm"
+    score = (m["p50_2d_all"] + m["p95_2d_all"]) / 2.0
     print(f"Reference : {args.ref}")
     print(f"Result    : {args.result}")
     print()
@@ -130,11 +131,13 @@ def main() -> int:
     print(f"{thr_label} rate    : {m['thr_rate']:.1f}%")
     print(f"mean nSV       : {m['mean_sv_all']:.1f}")
     print()
-    print("  2D horizontal (all epochs):")
+    print("  2D horizontal error (all epochs):")
+    print(f"    p50    : {_fmt(m['p50_2d_all'])}")
+    print(f"    p95    : {_fmt(m['p95_2d_all'])}")
     print(f"    RMS    : {_fmt(m['rms_2d_all'])}")
-    print(f"    p68    : {_fmt(m['p68_2d_all'])}  (1-sigma)")
-    print(f"    95%    : {_fmt(m['p95_2d_all'])}")
     print(f"    Max    : {_fmt(m['max_2d_all'])}")
+    print()
+    print(f"  GSDC score (mean of p50 & p95) : {_fmt(score)}")
     print()
     print("  ENU RMS (all epochs):")
     print(f"    East/North/Up : {m['rms_e']:.3f} / {m['rms_n']:.3f} / {m['rms_u']:.3f} m")

--- a/scripts/benchmark/compare_ppc.py
+++ b/scripts/benchmark/compare_ppc.py
@@ -316,6 +316,7 @@ def compute_metrics(
         "mean_sv_all": mean_sv_all,
         "rms_2d_all": float(np.sqrt(np.mean(horiz**2))),
         "rms_3d_all": float(np.sqrt(np.mean(e3d**2))),
+        "p50_2d_all": float(np.percentile(horiz, 50)),
         "p68_2d_all": float(np.percentile(horiz, 68)),
         "p95_2d_all": float(np.percentile(horiz, 95)),
         "max_2d_all": float(np.max(horiz)),

--- a/scripts/benchmark/download_brdc.py
+++ b/scripts/benchmark/download_brdc.py
@@ -1,0 +1,136 @@
+"""download_brdc.py - Download daily merged multi-GNSS broadcast ephemeris.
+
+The GSDC ``device_gnss.csv`` carries no broadcast ephemeris, so the SPP
+benchmark needs an external broadcast-navigation file per UTC day.  This module
+fetches the daily *merged* multi-GNSS (GPS+GLO+GAL+BDS+QZS) RINEX 3 navigation
+file from BKG, which serves it without authentication (CDDIS requires an
+Earthdata login; GSSC returned 403 from CI).
+
+Archive URL (BKG)
+-----------------
+    https://igs.bkg.bund.de/root_ftp/IGS/BRDC/{year}/{doy}/{name}_{year}{doy}0000_01D_MN.rnx.gz
+
+``name`` candidates are tried in order; the first that exists is used:
+    BRDM00DLR_S  - DLR merged multi-GNSS (most complete)
+    BRDC00WRD_S  - BKG combined broadcast
+    BRDC00IGS_R  - IGS combined broadcast
+
+Requires only the Python standard library.
+
+Usage
+-----
+    python download_brdc.py --date 2020-06-25 [--brdc-dir DIR] [--dry-run]
+    python download_brdc.py --year 2020 --doy 177
+"""
+
+import argparse
+import gzip
+import shutil
+import sys
+import urllib.error
+import urllib.request
+from datetime import date, datetime
+from pathlib import Path
+
+_BKG_URL = (
+    "https://igs.bkg.bund.de/root_ftp/IGS/BRDC/{year}/{doy:03d}/"
+    "{name}_{year}{doy:03d}0000_01D_MN.rnx.gz"
+)
+# Tried in priority order; first existing wins.
+_BRDC_NAMES = ["BRDM00DLR_S", "BRDC00WRD_S", "BRDC00IGS_R"]
+
+
+def ymd_to_doy(d: date) -> int:
+    """Return the day-of-year for a date."""
+    return d.timetuple().tm_yday
+
+
+def _local_path(brdc_dir: Path, name: str, year: int, doy: int) -> Path:
+    """Local (uncompressed) path for a given product name/day."""
+    return brdc_dir / f"{name}_{year}{doy:03d}0000_01D_MN.rnx"
+
+
+def find_cached(brdc_dir: Path, year: int, doy: int) -> Path | None:
+    """Return a cached broadcast-nav file for the day, or None."""
+    for name in _BRDC_NAMES:
+        p = _local_path(brdc_dir, name, year, doy)
+        if p.is_file() and p.stat().st_size > 0:
+            return p
+    return None
+
+
+def ensure_brdc(year: int, doy: int, brdc_dir: Path, dry_run: bool = False) -> Path | None:
+    """Ensure a broadcast-nav file for ``(year, doy)`` exists locally.
+
+    Args:
+        year: Four-digit year.
+        doy: Day of year (1-366).
+        brdc_dir: Cache directory.
+        dry_run: Print URLs without downloading.
+
+    Returns:
+        Path to the local uncompressed RINEX nav file, or None if unavailable.
+    """
+    cached = find_cached(brdc_dir, year, doy)
+    if cached is not None:
+        return cached
+    brdc_dir.mkdir(parents=True, exist_ok=True)
+
+    for name in _BRDC_NAMES:
+        url = _BKG_URL.format(year=year, doy=doy, name=name)
+        if dry_run:
+            print(f"  [dry-run] {url}")
+            return None
+        dest = _local_path(brdc_dir, name, year, doy)
+        gz = dest.with_suffix(dest.suffix + ".gz")
+        try:
+            urllib.request.urlretrieve(url, gz)
+            with gzip.open(gz, "rb") as fin, open(dest, "wb") as fout:
+                shutil.copyfileobj(fin, fout)
+            gz.unlink(missing_ok=True)
+            if dest.stat().st_size > 0:
+                print(f"  downloaded {dest.name}")
+                return dest
+        except (urllib.error.HTTPError, urllib.error.URLError, OSError, EOFError):
+            gz.unlink(missing_ok=True)
+            dest.unlink(missing_ok=True)
+            continue
+
+    print(f"  FAIL: no broadcast nav found for {year} doy {doy}", file=sys.stderr)
+    return None
+
+
+def _parse_args_to_day(args: argparse.Namespace) -> tuple[int, int]:
+    """Resolve CLI args to a (year, doy) pair."""
+    if args.date:
+        d = datetime.strptime(args.date, "%Y-%m-%d").date()
+        return d.year, ymd_to_doy(d)
+    if args.year and args.doy:
+        return args.year, args.doy
+    sys.exit("FAIL: provide --date YYYY-MM-DD, or both --year and --doy")
+
+
+def main() -> int:
+    """Download one day's merged broadcast navigation file."""
+    p = argparse.ArgumentParser(description="Download daily merged multi-GNSS broadcast nav")
+    p.add_argument("--date", default="", help="UTC date YYYY-MM-DD")
+    p.add_argument("--year", type=int, default=0, help="four-digit year")
+    p.add_argument("--doy", type=int, default=0, help="day of year (1-366)")
+    p.add_argument("--brdc-dir", default="data/gsdc/brdc", help="cache directory")
+    p.add_argument("--dry-run", action="store_true", help="print URL without downloading")
+    args = p.parse_args()
+
+    year, doy = _parse_args_to_day(args)
+    brdc_dir = Path(args.brdc_dir)
+    if not brdc_dir.is_absolute():
+        brdc_dir = Path(__file__).resolve().parent.parent.parent / brdc_dir
+
+    print(f"Broadcast nav for {year} doy {doy:03d} -> {brdc_dir}")
+    path = ensure_brdc(year, doy, brdc_dir, dry_run=args.dry_run)
+    if path:
+        print(f"  ready: {path.name}")
+    return 0 if (path or args.dry_run) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmark/gsdc_cases.py
+++ b/scripts/benchmark/gsdc_cases.py
@@ -1,0 +1,111 @@
+"""gsdc_cases.py - GSDC-2023 benchmark case metadata and discovery.
+
+Unlike the PPC benchmark (six fixed runs with hard-coded GPS time windows), the
+GSDC set has 156 train ``trip/device`` combinations.  Cases are therefore
+*discovered* by scanning the extracted dataset directory, and a small curated
+default subset keeps the routine run manageable and representative.
+
+A GSDC "tripId" is ``<trip>/<device>`` (e.g.
+``2021-12-07-19-22-us-ca-lax-d/pixel5``).  Each train case directory holds
+``device_gnss.csv`` (raw measurements) and ``ground_truth.csv`` (reference).
+"""
+
+from datetime import date, datetime
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Curated default subset
+# ---------------------------------------------------------------------------
+# A representative spread across years (2020-2023), devices (Pixel 4/5/7 Pro,
+# Xiaomi Mi8, Samsung S20) and environments (suburban highway, San Francisco,
+# San Jose, downtown Los Angeles canyon, mixed route).  ``--case all`` runs
+# every discovered train case instead.
+CURATED: list[str] = [
+    "2020-06-25-00-34-us-ca-mtv-sb-101/pixel4",   # suburban highway, Pixel 4
+    "2020-07-17-23-13-us-ca-sf-mtv-280/pixel4",   # SF -> MTV, urban + highway
+    "2020-12-10-22-52-us-ca-sjc-c/mi8",           # San Jose, Xiaomi Mi8
+    "2021-04-02-20-43-us-ca-mtv-f/sm-g988b",      # Mountain View, Samsung S20
+    "2021-12-07-19-22-us-ca-lax-d/pixel5",        # downtown LA canyon, Pixel 5
+    "2023-09-05-23-07-us-ca-routen/pixel7pro",    # mixed route, Pixel 7 Pro
+]
+
+
+def trip_date(trip: str) -> date | None:
+    """Parse the leading ``YYYY-MM-DD`` of a trip name into a date."""
+    try:
+        return datetime.strptime(trip[:10], "%Y-%m-%d").date()
+    except (ValueError, IndexError):
+        return None
+
+
+def discover_cases(dataset_dir: Path, split: str = "train") -> list[dict]:
+    """Scan ``<dataset_dir>/<split>`` for usable benchmark cases.
+
+    Args:
+        dataset_dir: GSDC dataset root (the directory that contains ``train``).
+        split: ``"train"`` (has ground truth) or ``"test"``.
+
+    Returns:
+        Sorted list of case dicts, each with keys ``id`` (``trip/device``),
+        ``trip``, ``device``, ``gnss_csv`` (Path), ``ground_truth`` (Path or
+        None for test) and ``date`` (datetime.date or None).
+    """
+    root = dataset_dir / split
+    cases = []
+    if not root.is_dir():
+        return cases
+    for gnss in sorted(root.glob("*/*/device_gnss.csv")):
+        device = gnss.parent.name
+        trip = gnss.parent.parent.name
+        gt = gnss.parent / "ground_truth.csv"
+        cases.append({
+            "id": f"{trip}/{device}",
+            "trip": trip,
+            "device": device,
+            "gnss_csv": gnss,
+            "ground_truth": gt if gt.is_file() else None,
+            "date": trip_date(trip),
+        })
+    return cases
+
+
+def select_cases(dataset_dir: Path, which: str = "curated") -> list[dict]:
+    """Return the cases to run.
+
+    Args:
+        dataset_dir: GSDC dataset root.
+        which: ``"curated"`` (intersection with CURATED, preserving CURATED
+            order), ``"all"`` (every discovered train case), or a
+            comma-separated list of ``trip/device`` ids.
+
+    Returns:
+        List of case dicts (see :func:`discover_cases`).
+    """
+    discovered = {c["id"]: c for c in discover_cases(dataset_dir, "train")}
+    if which == "all":
+        return list(discovered.values())
+    if which == "curated":
+        wanted = CURATED
+    else:
+        wanted = [w.strip() for w in which.split(",") if w.strip()]
+    return [discovered[i] for i in wanted if i in discovered]
+
+
+def safe_name(case_id: str) -> str:
+    """Filesystem-safe stem for a case id (``trip/device`` -> ``trip__device``)."""
+    return case_id.replace("/", "__")
+
+
+# ---------------------------------------------------------------------------
+# Sanity check (python gsdc_cases.py [dataset_dir])
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import sys
+
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("data/gsdc")
+    found = discover_cases(root, "train")
+    print(f"discovered {len(found)} train cases under {root}")
+    curated = select_cases(root, "curated")
+    print(f"curated present: {len(curated)}/{len(CURATED)}")
+    for c in curated:
+        print(f"  {c['id']:50s}  date={c['date']}")

--- a/scripts/benchmark/gsdc_to_rinex.py
+++ b/scripts/benchmark/gsdc_to_rinex.py
@@ -264,7 +264,7 @@ def write_rinex(
     hdr(f"{3.04:9.2f}{'':<11}OBSERVATION DATA{'':<4}M", "RINEX VERSION / TYPE")
     hdr(f"{'gsdc_to_rinex':<20}{'MRTKLIB':<20}{now:<20}", "PGM / RUN BY / DATE")
     hdr(f"{marker:<60}", "MARKER NAME")
-    hdr(f"{'GEODETIC':<20}", "MARKER TYPE")
+    hdr(f"{'NON_GEODETIC':<20}", "MARKER TYPE")
     hdr(f"{'MRTKLIB':<20}{'MRTKLIB':<40}", "OBSERVER / AGENCY")
     hdr(f"{'0000':<20}{'Android':<20}{'1':<20}", "REC # / TYPE / VERS")
     hdr(f"{'0000':<20}{'NONE':<20}", "ANT # / TYPE")

--- a/scripts/benchmark/gsdc_to_rinex.py
+++ b/scripts/benchmark/gsdc_to_rinex.py
@@ -1,0 +1,521 @@
+"""gsdc_to_rinex.py - Convert a GSDC-2023 ``device_gnss.csv`` to RINEX 3.04 OBS.
+
+The Google Smartphone Decimeter Challenge (GSDC) 2023 dataset ships its raw
+measurements as ``device_gnss.csv`` - a *derived* CSV in which Google has already
+reconstructed the pseudorange (``RawPseudorangeMeters``), classified the signal
+(``SignalType``), and provided carrier phase (``AccumulatedDeltaRangeMeters``),
+Doppler (``PseudorangeRateMetersPerSecond``) and C/N0 (``Cn0DbHz``).  Because the
+pseudorange is already reconstructed (clock, week-rollover and inter-signal-bias
+handling done), a direct CSV -> RINEX mapping is simpler and less error-prone than
+re-deriving it from the raw Android clock fields.
+
+This converter performs that mapping only; broadcast ephemeris (NAV) is acquired
+separately (see ``download_brdc.py``) because the CSV carries no ephemeris.
+
+Field mapping (per measurement row)
+-----------------------------------
+    C (pseudorange) = RawPseudorangeMeters                          [m]
+    L (carrier)     = AccumulatedDeltaRangeMeters / lambda          [cycles]
+    D (Doppler)     = -PseudorangeRateMetersPerSecond / lambda      [Hz]
+    S (C/N0)        = Cn0DbHz                                        [dB-Hz]
+    lambda          = c / CarrierFrequencyHz
+
+The carrier phase is emitted only when ``AccumulatedDeltaRangeState`` has the
+VALID bit set; the RINEX LLI flag is raised on a RESET or CYCLE_SLIP bit so the
+downstream TDCP/cycle-slip logic (#116 P4) sees the discontinuity.
+
+Epoch time
+----------
+GPS time (continuous) = utcTimeMillis/1000 - 315964800 + LeapSecond.  This was
+cross-checked against the CSV's own ``ArrivalTimeNanosSinceGpsEpoch`` column and
+agrees to sub-millisecond.
+
+Usage
+-----
+    python gsdc_to_rinex.py <device_gnss.csv> -o <out.obs> [--marker NAME]
+    python gsdc_to_rinex.py <device_gnss.csv> --self-check   # validate parsing
+"""
+
+import argparse
+import csv
+import math
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+CLIGHT = 299792458.0
+GPS_UNIX_EPOCH = 315964800.0  # Unix time (s) of 1980-01-06 00:00:00 UTC
+GPS_EPOCH = datetime(1980, 1, 6)  # naive datetime, interpreted as GPST
+
+# ConstellationType -> (RINEX system char, svid offset).  PRN = Svid - offset.
+#   1 GPS, 2 SBAS, 3 GLONASS, 4 QZSS, 5 BeiDou, 6 Galileo, 7 IRNSS
+# QZSS Android svid is 193-202 -> RINEX J01-J10 (offset 192).  SBAS/IRNSS are
+# not used by the SPP benchmark and are dropped.
+CONSTELLATION = {
+    1: ("G", 0),
+    3: ("R", 0),
+    4: ("J", 192),
+    5: ("C", 0),
+    6: ("E", 0),
+}
+
+# Android SignalType -> (RINEX band char, RINEX attribute char).  Galileo E1 OS
+# (pilot) maps to 1C and BeiDou B1I to 2I, per RINEX 3.04.  The list mirrors the
+# signal universe observed across the GSDC-2023 archive (GPS/GAL/GLO/QZS/BDS).
+SIGNAL_MAP = {
+    "GPS_L1_CA": ("1", "C"),
+    "GPS_L5_Q": ("5", "Q"),
+    "GPS_L5_I": ("5", "I"),
+    "GAL_E1_C_P": ("1", "C"),
+    "GAL_E5A_Q": ("5", "Q"),
+    "GAL_E5A_I": ("5", "I"),
+    "GLO_G1_CA": ("1", "C"),
+    "QZS_L1_CA": ("1", "C"),
+    "QZS_L5_Q": ("5", "Q"),
+    "QZS_L5_I": ("5", "I"),
+    "BDS_B1_I": ("2", "I"),
+}
+
+# AccumulatedDeltaRangeState bits (metadata/accumulated_delta_range_state_bit_map.json)
+ADR_VALID = 0x1
+ADR_RESET = 0x2
+ADR_CYCLE_SLIP = 0x4
+
+OBS_KINDS = ("C", "L", "D", "S")  # observable order within a band
+
+
+# ---------------------------------------------------------------------------
+# CSV parsing
+# ---------------------------------------------------------------------------
+def _f(row: dict, key: str):
+    """Parse a CSV cell as float, returning None when blank/invalid."""
+    v = row.get(key, "")
+    if v is None or v == "":
+        return None
+    try:
+        return float(v)
+    except ValueError:
+        return None
+
+
+def sat_id(const_type: int, svid: int) -> str | None:
+    """Map (ConstellationType, Svid) to a RINEX 3 satellite id, or None."""
+    if const_type not in CONSTELLATION:
+        return None
+    sys_char, offset = CONSTELLATION[const_type]
+    prn = svid - offset
+    if prn < 1 or prn > 99:
+        return None
+    return f"{sys_char}{prn:02d}"
+
+
+def parse_csv(path: str) -> tuple[dict, dict]:
+    """Parse a device_gnss.csv into per-epoch observation records.
+
+    Args:
+        path: Path to ``device_gnss.csv``.
+
+    Returns:
+        ``(epochs, sys_bands)`` where ``epochs`` is an ordered dict keyed by the
+        integer ``utcTimeMillis`` mapping to ``{sat_id: {(band, attr): obs}}``
+        (``obs`` is ``{"C","L","D","S","lli"}``), and ``sys_bands`` maps each
+        RINEX system char to the sorted set of ``(band, attr)`` tuples seen.
+    """
+    epochs: dict[int, dict] = {}
+    sys_bands: dict[str, set] = {}
+
+    with open(path, newline="") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            sig = row.get("SignalType", "")
+            if sig not in SIGNAL_MAP:
+                continue
+            pr = _f(row, "RawPseudorangeMeters")
+            if pr is None or pr <= 0.0:
+                continue
+            try:
+                const_type = int(float(row["ConstellationType"]))
+                svid = int(float(row["Svid"]))
+                tms = int(row["utcTimeMillis"])
+            except (KeyError, ValueError):
+                continue
+            sid = sat_id(const_type, svid)
+            if sid is None:
+                continue
+
+            band, attr = SIGNAL_MAP[sig]
+            sysc = sid[0]
+            sys_bands.setdefault(sysc, set()).add((band, attr))
+
+            fc = _f(row, "CarrierFrequencyHz")
+            lam = CLIGHT / fc if fc and fc > 0 else None
+
+            # Carrier phase: only when ADR is valid; LLI on reset / cycle slip.
+            ph = None
+            lli = 0
+            adr = _f(row, "AccumulatedDeltaRangeMeters")
+            try:
+                adr_state = int(float(row.get("AccumulatedDeltaRangeState", "0") or 0))
+            except ValueError:
+                adr_state = 0
+            if lam and adr is not None and (adr_state & ADR_VALID):
+                ph = adr / lam
+                if adr_state & (ADR_RESET | ADR_CYCLE_SLIP):
+                    lli = 1
+
+            # Doppler [Hz] from pseudorange rate [m/s].
+            dop = None
+            prr = _f(row, "PseudorangeRateMetersPerSecond")
+            if lam and prr is not None:
+                dop = -prr / lam
+
+            snr = _f(row, "Cn0DbHz")
+
+            sat_map = epochs.setdefault(tms, {})
+            obs = sat_map.setdefault(sid, {})
+            obs[(band, attr)] = {"C": pr, "L": ph, "D": dop, "S": snr, "lli": lli}
+
+    return dict(sorted(epochs.items())), sys_bands
+
+
+# ---------------------------------------------------------------------------
+# RINEX writing
+# ---------------------------------------------------------------------------
+def _gpst_calendar(utc_millis: int, leap: int) -> datetime:
+    """Convert ``utcTimeMillis`` (UTC) to a GPST calendar datetime."""
+    gps_total = utc_millis / 1000.0 - GPS_UNIX_EPOCH + leap
+    return GPS_EPOCH + timedelta(seconds=gps_total)
+
+
+def _snr2ssi(snr: float | None) -> int:
+    """Map C/N0 [dB-Hz] to a RINEX signal-strength indicator (1-9), 0 if none."""
+    if snr is None or snr <= 0:
+        return 0
+    return min(9, max(1, int(snr / 6.0)))
+
+
+def _obs_field(val: float | None, lli: int, ssi: int) -> str:
+    """Format one RINEX 3 observable: F14.3 value + LLI + SSI (16 chars)."""
+    if val is None:
+        return " " * 16
+    return f"{val:14.3f}{lli if lli else ' '}{ssi if ssi else ' '}"
+
+
+def _obs_types(sys_bands: dict[str, set]) -> dict[str, list[tuple[str, str, str]]]:
+    """Build the ordered (kind, band, attr) obs-type list for each system."""
+    out: dict[str, list] = {}
+    for sysc, bands in sys_bands.items():
+        codes = []
+        for band, attr in sorted(bands):
+            for kind in OBS_KINDS:
+                codes.append((kind, band, attr))
+        out[sysc] = codes
+    return out
+
+
+def _approx_xyz(csv_path: str) -> tuple[float, float, float]:
+    """Median Google WLS position (ECEF) from the CSV, for APPROX POSITION XYZ."""
+    xs, ys, zs = [], [], []
+    with open(csv_path, newline="") as fh:
+        for row in csv.DictReader(fh):
+            x = _f(row, "WlsPositionXEcefMeters")
+            y = _f(row, "WlsPositionYEcefMeters")
+            z = _f(row, "WlsPositionZEcefMeters")
+            if None not in (x, y, z) and (x or y or z):
+                xs.append(x)
+                ys.append(y)
+                zs.append(z)
+    if not xs:
+        return (0.0, 0.0, 0.0)
+    xs.sort(); ys.sort(); zs.sort()
+    m = len(xs) // 2
+    return (xs[m], ys[m], zs[m])
+
+
+def write_rinex(
+    epochs: dict,
+    sys_bands: dict,
+    out_path: str,
+    marker: str,
+    approx: tuple[float, float, float],
+    leap: int = 18,
+    interval: float = 1.0,
+) -> int:
+    """Write the parsed epochs to a RINEX 3.04 OBS file.
+
+    Returns:
+        Number of epoch records written.
+    """
+    obs_types = _obs_types(sys_bands)
+    systems = sorted(obs_types)
+
+    first_tms = next(iter(epochs))
+    t0 = _gpst_calendar(first_tms, leap)
+    now = datetime.now(timezone.utc).strftime("%Y%m%d %H%M%S UTC")
+
+    lines = []
+
+    def hdr(body: str, label: str) -> None:
+        lines.append(f"{body:<60}{label}")
+
+    hdr(f"{3.04:9.2f}{'':<11}OBSERVATION DATA{'':<4}M", "RINEX VERSION / TYPE")
+    hdr(f"{'gsdc_to_rinex':<20}{'MRTKLIB':<20}{now:<20}", "PGM / RUN BY / DATE")
+    hdr(f"{marker:<60}", "MARKER NAME")
+    hdr(f"{'GEODETIC':<20}", "MARKER TYPE")
+    hdr(f"{'MRTKLIB':<20}{'MRTKLIB':<40}", "OBSERVER / AGENCY")
+    hdr(f"{'0000':<20}{'Android':<20}{'1':<20}", "REC # / TYPE / VERS")
+    hdr(f"{'0000':<20}{'NONE':<20}", "ANT # / TYPE")
+    hdr(f"{approx[0]:14.4f}{approx[1]:14.4f}{approx[2]:14.4f}", "APPROX POSITION XYZ")
+    hdr(f"{0.0:14.4f}{0.0:14.4f}{0.0:14.4f}", "ANTENNA: DELTA H/E/N")
+
+    for sysc in systems:
+        codes = obs_types[sysc]
+        names = [f"{k}{b}{a}" for (k, b, a) in codes]
+        # First line holds up to 13 codes; continuation lines are padded.
+        first = names[:13]
+        body = f"{sysc}  {len(names):3d}" + "".join(f" {n}" for n in first)
+        hdr(body, "SYS / # / OBS TYPES")
+        for i in range(13, len(names), 13):
+            chunk = names[i : i + 13]
+            body = " " * 6 + "".join(f" {n}" for n in chunk)
+            hdr(body, "SYS / # / OBS TYPES")
+
+    hdr(f"{interval:10.3f}", "INTERVAL")
+    sec = t0.second + t0.microsecond / 1e6
+    hdr(
+        f"{t0.year:6d}{t0.month:6d}{t0.day:6d}{t0.hour:6d}{t0.minute:6d}"
+        f"{sec:13.7f}{'':5}GPS",
+        "TIME OF FIRST OBS",
+    )
+    hdr("", "END OF HEADER")
+
+    n_epoch = 0
+    for tms, sat_map in epochs.items():
+        t = _gpst_calendar(tms, leap)
+        sec = t.second + t.microsecond / 1e6
+        sats = sorted(sat_map)
+        lines.append(
+            f"> {t.year:4d} {t.month:02d} {t.day:02d} "
+            f"{t.hour:02d} {t.minute:02d}{sec:11.7f}  0{len(sats):3d}"
+        )
+        for sid in sats:
+            obs = sat_map[sid]
+            row = sid
+            for kind, band, attr in obs_types[sid[0]]:
+                cell = obs.get((band, attr))
+                if cell is None:
+                    row += " " * 16
+                    continue
+                val = cell[kind]
+                ssi = _snr2ssi(cell["S"])
+                lli = cell["lli"] if kind == "L" else 0
+                row += _obs_field(val, lli, ssi)
+            lines.append(row.rstrip())
+        n_epoch += 1
+
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as fh:
+        fh.write("\n".join(lines) + "\n")
+    return n_epoch
+
+
+# ---------------------------------------------------------------------------
+# Self-check: independent WLS from the CSV's own derived columns
+# ---------------------------------------------------------------------------
+def self_check(csv_path: str) -> int:
+    """Reproduce Google's WLS from the CSV's pre-computed columns.
+
+    Solves a per-epoch single-clock WLS using ``RawPseudorangeMeters`` plus the
+    CSV's own ``SvPosition*``/``SvClockBias``/iono/tropo/Isrb corrections, and
+    compares the solution to the ``WlsPosition*`` columns.  Agreement to ~metre
+    level confirms the pseudorange / satellite-id / epoch-grouping reading that
+    the converter relies on.  Pure validation; writes nothing.
+    """
+    OMGE = 7.2921151467e-5  # Earth rotation rate [rad/s]
+    # One signal per satellite (prefer the lowest band) so a dual-frequency sat
+    # is not double-counted; elevation-weighted to mirror a basic SPP estimator.
+    _BAND_RANK = {"1": 0, "2": 1, "5": 2}
+    by_epoch: dict[int, dict] = {}
+    wls: dict[int, tuple] = {}
+
+    with open(csv_path, newline="") as fh:
+        for row in csv.DictReader(fh):
+            sig = row.get("SignalType", "")
+            if sig not in SIGNAL_MAP:
+                continue
+            pr = _f(row, "RawPseudorangeMeters")
+            sx = _f(row, "SvPositionXEcefMeters")
+            sy = _f(row, "SvPositionYEcefMeters")
+            sz = _f(row, "SvPositionZEcefMeters")
+            dts = _f(row, "SvClockBiasMeters")
+            if None in (pr, sx, sy, sz, dts):
+                continue
+            try:
+                tms = int(row["utcTimeMillis"])
+                sid = sat_id(int(float(row["ConstellationType"])), int(float(row["Svid"])))
+            except (KeyError, ValueError):
+                continue
+            if sid is None:
+                continue
+            iono = _f(row, "IonosphericDelayMeters") or 0.0
+            trop = _f(row, "TroposphericDelayMeters") or 0.0
+            isrb = _f(row, "IsrbMeters") or 0.0
+            el = _f(row, "SvElevationDegrees")
+            w = math.sin(math.radians(el)) ** 2 if el and el > 0 else 0.25
+            # Corrected pseudorange referred to a single (GPS) receiver clock.
+            prc = pr + dts - iono - trop - isrb
+            band = SIGNAL_MAP[sig][0]
+            sats = by_epoch.setdefault(tms, {})
+            prev = sats.get(sid)
+            if prev is None or _BAND_RANK.get(band, 9) < prev[4]:
+                sats[sid] = (sx, sy, sz, prc, _BAND_RANK.get(band, 9), w)
+            wx = _f(row, "WlsPositionXEcefMeters")
+            wy = _f(row, "WlsPositionYEcefMeters")
+            wz = _f(row, "WlsPositionZEcefMeters")
+            if None not in (wx, wy, wz):
+                wls[tms] = (wx, wy, wz)
+
+    errs = []
+    for tms, sats in by_epoch.items():
+        meas = list(sats.values())
+        if len(meas) < 5 or tms not in wls:
+            continue
+        x = list(wls[tms]) + [0.0]  # initial guess at Google WLS + zero clock
+        reject: set = set()
+        for it in range(12):
+            H, r, w = [], [], []
+            for k, (sx, sy, sz, prc, _rank, wt) in enumerate(meas):
+                if k in reject:
+                    continue
+                dx, dy, dz = x[0] - sx, x[1] - sy, x[2] - sz
+                rng = math.sqrt(dx * dx + dy * dy + dz * dz)
+                sag = OMGE * (sx * x[1] - sy * x[0]) / CLIGHT  # Sagnac
+                r.append(prc - (rng + sag + x[3]))
+                H.append([dx / rng, dy / rng, dz / rng, 1.0])
+                w.append(wt)
+            dxv = _lsq(H, r, w)
+            if dxv is None:
+                break
+            x = [x[i] + dxv[i] for i in range(4)]
+            converged = max(abs(v) for v in dxv[:3]) < 1e-3
+            if converged and it >= 1:
+                # Single 3-sigma residual rejection pass, then resolve once more.
+                res = []
+                for k, (sx, sy, sz, prc, _rank, wt) in enumerate(meas):
+                    if k in reject:
+                        continue
+                    dx, dy, dz = x[0] - sx, x[1] - sy, x[2] - sz
+                    rng = math.sqrt(dx * dx + dy * dy + dz * dz)
+                    sag = OMGE * (sx * x[1] - sy * x[0]) / CLIGHT
+                    res.append((k, abs(prc - (rng + sag + x[3]))))
+                rr = [v for _, v in res]
+                sig_r = 1.4826 * sorted(rr)[len(rr) // 2] if rr else 0.0
+                new = {k for k, v in res if sig_r > 0 and v > max(30.0, 3 * sig_r)}
+                if not new:
+                    break
+                reject |= new
+        wx, wy, wz = wls[tms]
+        errs.append(math.sqrt((x[0] - wx) ** 2 + (x[1] - wy) ** 2 + (x[2] - wz) ** 2))
+
+    if not errs:
+        print("self-check: no usable epochs", file=sys.stderr)
+        return 1
+    errs.sort()
+    n = len(errs)
+    rms = math.sqrt(sum(e * e for e in errs) / n)
+    p50 = errs[n // 2]
+    print(f"self-check: {n} epochs, independent elev-weighted WLS vs Google WLS (3D)")
+    print(f"  RMS  = {rms:8.3f} m")
+    print(f"  p50  = {p50:8.3f} m")
+    print(f"  p95  = {errs[min(n - 1, int(n * 0.95))]:8.3f} m")
+    print(f"  max  = {errs[-1]:8.3f} m")
+    # Judge on the median: a reading bug (wrong unit/sat-id/epoch) would make the
+    # solution diverge from Google's by orders of magnitude, not a few metres.
+    ok = p50 < 5.0
+    print(f"  verdict: {'OK (CSV reading validated)' if ok else 'SUSPECT (median > 5 m)'}")
+    return 0 if ok else 2
+
+
+def _lsq(H: list[list[float]], r: list[float], w: list[float] | None = None) -> list[float] | None:
+    """Tiny (optionally weighted) normal-equations least squares.
+
+    ``H`` is m x 4, ``r`` length m, ``w`` optional per-row weights; returns the
+    4-vector solution of ``min sum w*(H dx - r)^2``.
+    """
+    n = len(H[0])
+    ata = [[0.0] * n for _ in range(n)]
+    atb = [0.0] * n
+    for i in range(len(H)):
+        wi = w[i] if w else 1.0
+        for a in range(n):
+            atb[a] += wi * H[i][a] * r[i]
+            for b in range(n):
+                ata[a][b] += wi * H[i][a] * H[i][b]
+    # Gauss-Jordan solve.
+    for c in range(n):
+        piv = ata[c][c]
+        if abs(piv) < 1e-12:
+            return None
+        for b in range(n):
+            ata[c][b] /= piv
+        atb[c] /= piv
+        for rr in range(n):
+            if rr == c:
+                continue
+            f = ata[rr][c]
+            for b in range(n):
+                ata[rr][b] -= f * ata[c][b]
+            atb[rr] -= f * atb[c]
+    return atb
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def main() -> int:
+    """Entry point for the GSDC device_gnss.csv -> RINEX converter."""
+    p = argparse.ArgumentParser(
+        description="Convert a GSDC-2023 device_gnss.csv to RINEX 3.04 OBS"
+    )
+    p.add_argument("csv", help="path to device_gnss.csv")
+    p.add_argument("-o", "--out", default="", help="output RINEX OBS path")
+    p.add_argument("--marker", default="", help="MARKER NAME (default: derived from path)")
+    p.add_argument("--leap", type=int, default=18, help="GPS-UTC leap seconds (default 18)")
+    p.add_argument("--self-check", action="store_true",
+                   help="validate CSV reading via an independent WLS vs the "
+                        "WlsPosition columns (writes no output)")
+    args = p.parse_args()
+
+    if not Path(args.csv).is_file():
+        sys.exit(f"FAIL: device_gnss.csv not found: {args.csv}")
+
+    if args.self_check:
+        return self_check(args.csv)
+
+    out = args.out
+    if not out:
+        out = str(Path(args.csv).with_suffix(".obs"))
+    marker = args.marker
+    if not marker:
+        # .../train/<trip>/<device>/device_gnss.csv -> <trip>_<device>
+        parts = Path(args.csv).resolve().parts
+        marker = "_".join(parts[-3:-1]) if len(parts) >= 3 else "GSDC"
+
+    epochs, sys_bands = parse_csv(args.csv)
+    if not epochs:
+        sys.exit("FAIL: no usable measurements in CSV")
+    approx = _approx_xyz(args.csv)
+    n = write_rinex(epochs, sys_bands, out, marker[:60], approx, leap=args.leap)
+    n_sat = sum(len(s) for s in epochs.values())
+    print(f"wrote {out}")
+    print(f"  epochs   : {n}")
+    print(f"  sat-obs  : {n_sat}")
+    print(f"  systems  : {' '.join(f'{s}({len(b)} bands)' for s, b in sorted(sys_bands.items()))}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmark/run_gsdc_benchmark.py
+++ b/scripts/benchmark/run_gsdc_benchmark.py
@@ -31,7 +31,7 @@ import os
 import subprocess
 import sys
 import time
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -45,7 +45,6 @@ from gsdc_to_rinex import _approx_xyz, parse_csv, write_rinex  # noqa: E402
 _CANDIDATE_BINS = [
     "build/mrtk", "build/Release/mrtk", "build/Debug/mrtk",
 ]
-_GPS_UNIX_EPOCH = 315964800.0
 
 
 def _find_mrtk(hint: str = "") -> str:

--- a/scripts/benchmark/run_gsdc_benchmark.py
+++ b/scripts/benchmark/run_gsdc_benchmark.py
@@ -110,7 +110,7 @@ def _run_mrtk(mrtk: str, confs: list[str], obs: Path, navs: list[Path],
 # Summary table
 # ---------------------------------------------------------------------------
 _HDR = (f"{'Case':<42} {'N':>5} {'nSV':>5} {'<2m%':>6} "
-        f"{'RMS2D':>8} {'p68':>8} {'p95':>8} {'max':>8}")
+        f"{'RMS2D':>8} {'p50':>8} {'p95':>8} {'score':>8}")
 _SEP = "-" * len(_HDR)
 
 
@@ -118,8 +118,19 @@ def _m(v: float) -> str:
     return "nan" if math.isnan(v) else f"{v:.2f}"
 
 
+def gsdc_score(m: dict) -> float:
+    """Official GSDC metric for one case: mean of the 50th and 95th percentile
+    2D horizontal error (metres)."""
+    return (m["p50_2d_all"] + m["p95_2d_all"]) / 2.0
+
+
 def print_summary(rows: list[dict]) -> None:
-    """Print the fixed-width GSDC SPP summary table."""
+    """Print the fixed-width GSDC SPP summary table.
+
+    The ``score`` column is the official Google Smartphone Decimeter Challenge
+    metric — the mean of the 50th and 95th percentile horizontal error — here
+    computed on the train split (which has public ground truth).
+    """
     print()
     print(_SEP)
     print(_HDR)
@@ -132,8 +143,8 @@ def print_summary(rows: list[dict]) -> None:
             continue
         print(f"{cid:<42} {m['n_matched']:>5} {m['mean_sv_all']:>5.1f} "
               f"{m['thr_rate']:>5.1f}% {_m(m['rms_2d_all']):>8} "
-              f"{_m(m['p68_2d_all']):>8} {_m(m['p95_2d_all']):>8} "
-              f"{_m(m['max_2d_all']):>8}")
+              f"{_m(m['p50_2d_all']):>8} {_m(m['p95_2d_all']):>8} "
+              f"{_m(gsdc_score(m)):>8}")
     print(_SEP)
     ok = [r["metrics"] for r in rows if r["metrics"]]
     if ok:
@@ -142,9 +153,11 @@ def print_summary(rows: list[dict]) -> None:
               f"{np.mean([m['mean_sv_all'] for m in ok]):>5.1f} "
               f"{np.mean([m['thr_rate'] for m in ok]):>5.1f}% "
               f"{np.mean([m['rms_2d_all'] for m in ok]):>8.2f} "
-              f"{np.mean([m['p68_2d_all'] for m in ok]):>8.2f} "
-              f"{np.mean([m['p95_2d_all'] for m in ok]):>8.2f}")
-    print("  N=matched epochs  <2m%=fraction within 2 m 2D  p68/p95=2D pctiles  (all in m)")
+              f"{np.mean([m['p50_2d_all'] for m in ok]):>8.2f} "
+              f"{np.mean([m['p95_2d_all'] for m in ok]):>8.2f} "
+              f"{np.mean([gsdc_score(m) for m in ok]):>8.2f}")
+    print("  score = mean(p50, p95) 2D horizontal [m] = official GSDC metric "
+          "(here on the train split)")
 
 
 def run(args: argparse.Namespace) -> int:
@@ -218,8 +231,8 @@ def run(args: argparse.Namespace) -> int:
             rows.append({"id": case["id"], "metrics": None, "status": "no-match"})
             continue
         print(f"  N={m['n_matched']}  <2m={m['thr_rate']:.1f}%  "
-              f"RMS2D={m['rms_2d_all']:.2f}m  p68={m['p68_2d_all']:.2f}m  "
-              f"p95={m['p95_2d_all']:.2f}m  ({dt:.1f}s)")
+              f"p50={m['p50_2d_all']:.2f}m  p95={m['p95_2d_all']:.2f}m  "
+              f"score={gsdc_score(m):.2f}m  ({dt:.1f}s)")
         rows.append({"id": case["id"], "metrics": m, "status": "ok"})
 
     print_summary(rows)

--- a/scripts/benchmark/run_gsdc_benchmark.py
+++ b/scripts/benchmark/run_gsdc_benchmark.py
@@ -1,0 +1,255 @@
+"""run_gsdc_benchmark.py - Run MRTKLIB SPP on the GSDC-2023 smartphone dataset.
+
+For each selected ``trip/device`` case this:
+  1. converts ``device_gnss.csv`` to RINEX 3.04 OBS (``gsdc_to_rinex``),
+  2. fetches the daily merged broadcast nav for the UTC day(s) it spans
+     (``download_brdc``),
+  3. runs ``mrtk post`` single-point positioning with a SPP config, and
+  4. compares the NMEA output against ``ground_truth.csv`` (``compare_gsdc``).
+
+Results are summarised in a fixed-width table.  This is the smartphone analogue
+of ``run_benchmark.py`` (PPC) and is the venue where the #116 SPP work's P5
+(clock-jump) and P6 (position EKF) stages are validated - see issue #165 and
+``docs/design/spp-accuracy.md`` 4.6.
+
+Requirements
+------------
+- GSDC-2023 extracted under --dataset-dir (manual download; see
+  docs/reference/benchmark-gsdc.md).
+- mrtk binary built under build/ (auto-detected) or passed via --mrtk.
+- Network access for broadcast-nav download (unless --skip-download and cached).
+- Python: numpy.
+
+Usage
+-----
+    python run_gsdc_benchmark.py [--case curated|all|<id,...>] [--conf PATH]...
+"""
+
+import argparse
+import math
+import os
+import subprocess
+import sys
+import time
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from compare_ppc import _match_epochs, compute_metrics, parse_nmea  # noqa: E402
+from compare_gsdc import parse_ground_truth  # noqa: E402
+from download_brdc import ensure_brdc  # noqa: E402
+from gsdc_cases import safe_name, select_cases  # noqa: E402
+from gsdc_to_rinex import _approx_xyz, parse_csv, write_rinex  # noqa: E402
+
+# mrtk binary auto-detection (mirrors run_benchmark.py).
+_CANDIDATE_BINS = [
+    "build/mrtk", "build/Release/mrtk", "build/Debug/mrtk",
+]
+_GPS_UNIX_EPOCH = 315964800.0
+
+
+def _find_mrtk(hint: str = "") -> str:
+    """Locate the mrtk binary (build/ first, then PATH)."""
+    if hint:
+        if not os.path.isfile(hint):
+            sys.exit(f"FAIL: mrtk not found at {hint!r}")
+        return hint
+    root = Path(__file__).resolve().parent.parent.parent
+    for rel in _CANDIDATE_BINS:
+        p = root / rel
+        if p.is_file():
+            return str(p)
+    import shutil
+    p = shutil.which("mrtk")
+    if p:
+        return p
+    sys.exit("FAIL: mrtk not found. Build with 'cmake --build build' or pass --mrtk.")
+
+
+def _utc_days(epoch_millis) -> list[tuple[int, int]]:
+    """Return the sorted set of (year, doy) UTC days an epoch span covers."""
+    lo, hi = min(epoch_millis), max(epoch_millis)
+    days = set()
+    t = datetime.fromtimestamp(lo / 1000.0, tz=timezone.utc).date()
+    end = datetime.fromtimestamp(hi / 1000.0, tz=timezone.utc).date()
+    while t <= end:
+        days.add((t.year, t.timetuple().tm_yday))
+        t += timedelta(days=1)
+    return sorted(days)
+
+
+def _convert(case: dict, out_dir: Path, force: bool) -> tuple[Path, list]:
+    """Convert a case's device_gnss.csv to RINEX OBS (cached); return (obs, days)."""
+    obs = out_dir / f"{safe_name(case['id'])}.obs"
+    epochs, sys_bands = parse_csv(str(case["gnss_csv"]))
+    if not epochs:
+        raise RuntimeError("no usable measurements")
+    days = _utc_days(epochs.keys())
+    if force or not obs.exists() or obs.stat().st_mtime <= case["gnss_csv"].stat().st_mtime:
+        approx = _approx_xyz(str(case["gnss_csv"]))
+        write_rinex(epochs, sys_bands, str(obs), safe_name(case["id"])[:60], approx)
+    return obs, days
+
+
+def _run_mrtk(mrtk: str, confs: list[str], obs: Path, navs: list[Path],
+              out: Path, verbose: bool) -> bool:
+    """Invoke ``mrtk post`` for one case; return True on success."""
+    cmd = [mrtk, "post"]
+    for c in confs:
+        cmd += ["-k", c]
+    cmd += ["-o", str(out.resolve()), str(obs.resolve())]
+    cmd += [str(n.resolve()) for n in navs]
+    if verbose:
+        print("  $", " ".join(cmd))
+    r = subprocess.run(cmd, stdout=None if verbose else subprocess.DEVNULL,
+                       stderr=None if verbose else subprocess.DEVNULL)
+    return r.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Summary table
+# ---------------------------------------------------------------------------
+_HDR = (f"{'Case':<42} {'N':>5} {'nSV':>5} {'<2m%':>6} "
+        f"{'RMS2D':>8} {'p68':>8} {'p95':>8} {'max':>8}")
+_SEP = "-" * len(_HDR)
+
+
+def _m(v: float) -> str:
+    return "nan" if math.isnan(v) else f"{v:.2f}"
+
+
+def print_summary(rows: list[dict]) -> None:
+    """Print the fixed-width GSDC SPP summary table."""
+    print()
+    print(_SEP)
+    print(_HDR)
+    print(_SEP)
+    for r in rows:
+        m = r["metrics"]
+        cid = r["id"][:42]
+        if m is None:
+            print(f"{cid:<42} {'—':>5}  [{r['status']}]")
+            continue
+        print(f"{cid:<42} {m['n_matched']:>5} {m['mean_sv_all']:>5.1f} "
+              f"{m['thr_rate']:>5.1f}% {_m(m['rms_2d_all']):>8} "
+              f"{_m(m['p68_2d_all']):>8} {_m(m['p95_2d_all']):>8} "
+              f"{_m(m['max_2d_all']):>8}")
+    print(_SEP)
+    ok = [r["metrics"] for r in rows if r["metrics"]]
+    if ok:
+        import numpy as np
+        print(f"{'MEAN':<42} {int(np.mean([m['n_matched'] for m in ok])):>5} "
+              f"{np.mean([m['mean_sv_all'] for m in ok]):>5.1f} "
+              f"{np.mean([m['thr_rate'] for m in ok]):>5.1f}% "
+              f"{np.mean([m['rms_2d_all'] for m in ok]):>8.2f} "
+              f"{np.mean([m['p68_2d_all'] for m in ok]):>8.2f} "
+              f"{np.mean([m['p95_2d_all'] for m in ok]):>8.2f}")
+    print("  N=matched epochs  <2m%=fraction within 2 m 2D  p68/p95=2D pctiles  (all in m)")
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the GSDC benchmark loop."""
+    root = Path(__file__).resolve().parent.parent.parent
+    dataset_dir = Path(args.dataset_dir)
+    if not dataset_dir.is_absolute():
+        dataset_dir = root / dataset_dir
+    brdc_dir = Path(args.brdc_dir)
+    if not brdc_dir.is_absolute():
+        brdc_dir = root / brdc_dir
+    out_dir = Path(args.out_dir)
+    if not out_dir.is_absolute():
+        out_dir = root / out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    confs = args.conf or [str(root / "conf" / "benchmark" / "single.toml")]
+    mrtk = _find_mrtk(args.mrtk)
+
+    cases = select_cases(dataset_dir, args.case)
+    if not cases:
+        sys.exit(f"FAIL: no cases under {dataset_dir} (extract the dataset; "
+                 "see docs/reference/benchmark-gsdc.md)")
+
+    print(f"mrtk     : {mrtk}")
+    print(f"dataset  : {dataset_dir}")
+    print(f"conf     : {' + '.join(confs)}")
+    print(f"cases    : {len(cases)} ({args.case})")
+
+    rows = []
+    for case in cases:
+        print(f"\n[{case['id']}]")
+        try:
+            obs, days = _convert(case, out_dir, args.force)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  FAIL convert: {exc}")
+            rows.append({"id": case["id"], "metrics": None, "status": "convert-fail"})
+            continue
+
+        navs = []
+        for (year, doy) in days:
+            nav = ensure_brdc(year, doy, brdc_dir, dry_run=False) if not args.skip_download \
+                else _cached_nav(brdc_dir, year, doy)
+            if nav:
+                navs.append(nav)
+        if not navs:
+            print("  FAIL: no broadcast nav available")
+            rows.append({"id": case["id"], "metrics": None, "status": "no-nav"})
+            continue
+
+        if case["ground_truth"] is None:
+            print("  skip: no ground truth (test split)")
+            rows.append({"id": case["id"], "metrics": None, "status": "no-truth"})
+            continue
+
+        out = out_dir / f"{safe_name(case['id'])}.nmea"
+        t0 = time.monotonic()
+        ok = _run_mrtk(mrtk, confs, obs, navs, out, args.verbose)
+        dt = time.monotonic() - t0
+        if not ok or not out.exists():
+            print(f"  FAIL mrtk post ({dt:.1f}s)")
+            rows.append({"id": case["id"], "metrics": None, "status": "mrtk-fail"})
+            continue
+
+        ref = parse_ground_truth(str(case["ground_truth"]))
+        nmea = parse_nmea(str(out))
+        pairs = _match_epochs(ref, nmea)
+        m = compute_metrics(pairs, args.skip_epochs, threshold_2d=args.threshold)
+        if m is None:
+            print("  FAIL: no matching epochs")
+            rows.append({"id": case["id"], "metrics": None, "status": "no-match"})
+            continue
+        print(f"  N={m['n_matched']}  <2m={m['thr_rate']:.1f}%  "
+              f"RMS2D={m['rms_2d_all']:.2f}m  p68={m['p68_2d_all']:.2f}m  "
+              f"p95={m['p95_2d_all']:.2f}m  ({dt:.1f}s)")
+        rows.append({"id": case["id"], "metrics": m, "status": "ok"})
+
+    print_summary(rows)
+    return 0
+
+
+def _cached_nav(brdc_dir: Path, year: int, doy: int):
+    """Return a cached nav file path for the day, or None (no download)."""
+    from download_brdc import find_cached
+    return find_cached(brdc_dir, year, doy)
+
+
+def main() -> int:
+    """Entry point for the GSDC smartphone SPP benchmark runner."""
+    p = argparse.ArgumentParser(description="Run MRTKLIB SPP benchmark on GSDC-2023")
+    p.add_argument("--dataset-dir", default="data/gsdc", help="GSDC root (has train/)")
+    p.add_argument("--brdc-dir", default="data/gsdc/brdc", help="broadcast-nav cache")
+    p.add_argument("--out-dir", default="data/gsdc/results", help="OBS/NMEA output dir")
+    p.add_argument("--case", default="curated",
+                   help="'curated' (default), 'all', or comma-separated trip/device ids")
+    p.add_argument("--conf", action="append", default=[],
+                   help="config file(s), layered; default conf/benchmark/single.toml")
+    p.add_argument("--mrtk", default="", help="mrtk binary path (default: auto)")
+    p.add_argument("--threshold", type=float, default=2.0, help="2D <Nm rate threshold")
+    p.add_argument("--skip-epochs", type=int, default=0, help="initial epochs to skip")
+    p.add_argument("--skip-download", action="store_true", help="use cached nav only")
+    p.add_argument("--force", action="store_true", help="re-convert even if cached")
+    p.add_argument("-v", "--verbose", action="store_true", help="show mrtk output")
+    return run(p.parse_args())
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds the **GSDC-2023 smartphone SPP benchmark** — the smartphone counterpart of
the PPC kinematic benchmark, and the prerequisite for the remaining #116 SPP
work. P5 (common-mode clock-jump correction) and P6 (position EKF
smoothing/coasting) cannot be validated on the geodetic PPC set — geodetic
clocks don't step and the post-P1–P4 WLS has no jitter to smooth
(`docs/design/spp-accuracy.md` §4.6). Smartphone data has both, so this
benchmark is where those stages get measured.

This PR is **tasks 1–3 only** (benchmark foundation). **P5/P6 (tasks 4–6) are a
separate PR** — they are C-side algorithm changes that will be measured
*against* this benchmark.

## What's added

A pipeline mirroring `run_benchmark.py` (PPC):

- **`gsdc_to_rinex.py`** — converts Google's derived `device_gnss.csv` to
  RINEX 3.04 OBS (uses the already-reconstructed `RawPseudorangeMeters` /
  `SignalType` / phase / Doppler / C/N0). `--self-check` reproduces Google's WLS
  from the CSV's own columns to validate the reading.
- **`download_brdc.py`** — daily merged multi-GNSS broadcast nav from BKG
  (no auth required).
- **`compare_gsdc.py`** — `ground_truth.csv` parser reusing the PPC metrics.
- **`gsdc_cases.py`** — dataset discovery + a curated 6-trip subset.
- **`run_gsdc_benchmark.py`** — convert → `mrtk post` (SPP) → compare harness,
  reporting the **official GSDC score** = mean of the 50th & 95th percentile 2D
  horizontal error.
- **`conf/benchmark/gsdc_p0.toml`** — classic-SPP P0 baseline overlay.
- **`docs/reference/benchmark-gsdc.md`** + mkdocs nav; `.gitignore` for the
  dataset.

## Baseline results (curated 6 trips, official GSDC score, lower = better)

| Config | GSDC score | p50 | p95 | <2 m | availability N |
|--------|-----------:|----:|----:|-----:|---------------:|
| **P0** (classic SPP) | 5.59 m | 3.26 m | 7.92 m | 24.8% | 1630 |
| **P1–P4** (`single.toml`) | **4.19 m** (−25%) | 2.56 m | 5.82 m | 35.9% | 907 (−44%) |

P1–P4 improves the score 25% but drops availability 44% (its QC rejects the
noisy epochs rather than solving them poorly). That availability/accuracy gap is
exactly what **P6** (coast through rejected epochs) and **P5** (clock-jump
recovery) target. The numbers are on the same scale as the GSDC leaderboard
(top entries ~1–2 m use carrier PPP/RTK + IMU + map-matching; this is an
SPP-only baseline).

## Data / reproducibility

The GSDC-2023 archive (~3.5 GB) is **manual-download from Kaggle** and
git-ignored (`tests/data/sdc2023.zip`, `data/gsdc/`), exactly like the PPC
dataset. Download/extract instructions and the signal-mapping table are in
`docs/reference/benchmark-gsdc.md`.

## Testing

- **No C / CMake changes** — purely Python tooling, TOML config and docs; the
  CTest suite is unaffected (and the benchmark is excluded from CTest by design,
  like PPC).
- `compare_ppc.compute_metrics` gains an additive `p50_2d_all` key; the PPC
  benchmark output is unchanged.
- Validated end-to-end: converter self-check vs Google WLS (p50 ≈ 4 m), and
  `mrtk post` SPP on the converted RINEX + BKG broadcast nav tracks
  `ground_truth.csv` (~3 m).

Refs #165 · follow-up to #116 / #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
