### PR TITLE
P6 SPP EKF: GSDC negative result (reverted) + Cov% benchmark metric (#165)

### DIFF
--- a/docs/design/spp-accuracy.md
+++ b/docs/design/spp-accuracy.md
@@ -121,8 +121,8 @@ the maintainer explicitly wants improved and which TDCP/EKF cannot.
 | **P2** | IGG-III robust re-weighting in `estpos()` (MAD scale) *(implemented)* | WLS | bulk (rate +11pp, median); defeats gate → §4.3 | low |
 | **P3** | Pre-robust all-satellite acceptance gate *(implemented)* — unblocks P1+P2 → clean win (§4.4) | WLS | **tail control; rate +16pp, median −43%** | medium |
 | **P4** | TDCP velocity + jump-rejection QC + slip detection *(implemented)* — §4.5 | WLS + light coupling | **tail/RMS −56% vs P0; rate +20pp** | medium |
-| **P5** | Common-mode clock-jump correction + logging / reset strategy | infra | low-cost-receiver continuity; EKF prerequisite | medium |
-| **P6** | SPP position EKF (loosely-coupled) — *investigated, reverted* (§4.6) | EKF | no gain on PPC; diverges | — |
+| **P5** | Common-mode clock-jump correction + logging / reset strategy | infra | low-cost-receiver continuity; EKF prerequisite — *N/A on the GSDC `device_gnss.csv` source* (§4.7) | medium |
+| **P6** | SPP position EKF (loosely-coupled) — *investigated, reverted twice* (§4.6 PPC, §4.7 GSDC) | EKF | no accuracy gain (PPC or smartphone); smoothing adds lag | — |
 
 Each step ships as an independent, reviewable commit, must pass the full
 `ctest --output-on-failure`, and records numerical deltas (CLAUDE.md §7.2 —
@@ -348,6 +348,67 @@ smartphone/static benchmark — the GSDC / SDC sets, where jitter is large and
 clock jumps actually occur (which also makes that the right venue for P5's
 clock-jump correction).
 
+### 4.7 P6 re-attempt on smartphone data (GSDC) — confirmed and reverted (2026-05-25)
+
+[#165](https://github.com/h-shiono/MRTKLIB/issues/165) built the GSDC-2023
+smartphone SPP benchmark precisely to give P6 (and P5) the favourable data §4.6
+said they needed: large per-epoch jitter and real outage bursts. The loosely
+coupled position EKF was re-implemented there — this time *tuned* (a robust
+innovation gate, a covariance-bounded coast, and TDCP/Doppler velocity rows to
+pin the velocity state) and finally as a **coast-only sidecar** (accepted WLS
+epochs pass through unchanged; the EKF only fills the epochs the P1–P4 QC
+rejects). Measured on the curated-6 anchor (official GSDC metric = mean of the
+2D-horizontal p50 and p95, plus a `Cov%` = predicted ÷ reference epochs):
+
+| Variant | N | Cov% | p50 | p95 | score |
+|---------|---:|---:|---:|---:|---:|
+| P1–P4 (snapshot WLS) | 907 | 52.3 | 2.56 | 5.82 | **4.19** |
+| P6 untuned (no gate / no coast bound) | 1665 | — | 185 | 3297 | **1741** *(diverges)* |
+| P6 smoothing-only (coast disabled) | 906 | 52.3 | 2.61 | 6.07 | **4.34** |
+| P6 coast-only (tuned) | 941 | 54.4 | 2.59 | 6.00 | **4.29** |
+
+Two findings, both confirming and **extending §4.6 to smartphone data**:
+
+1. **Smoothing actively hurts — it is not merely neutral.** With the coast
+   disabled (so only the measured epochs are touched), the EKF makes accuracy
+   *worse* (4.19 → 4.34). The constant-velocity/acceleration model lags real
+   stop-go / turning smartphone motion, and that lag outweighs the jitter it
+   removes; the post-P1–P4 WLS is already good enough that there is no net
+   averaging gain. This is the *second* independent negative result for the
+   loosely-coupled position EKF (PPC in §4.6, GSDC here).
+2. **The matched-only metric cannot reward P6's only contribution.**
+   `compute_metrics` scores the epochs a run *predicts*; ground-truth epochs left
+   unpredicted are simply absent. So it rewards aggressive QC (P1–P4 discarding
+   ~48 % of epochs) and penalises coast (the filled epochs are harder than the
+   median, so they raise p50/p95). The real GSDC requires a position for *every*
+   sample-submission epoch, so the +2.1 pp of coverage P6 recovers would there
+   replace default/penalty rows — but our harness, by design, undercounts that.
+   The lasting fix kept from this work is the **`Cov%` column** (added to
+   `run_gsdc_benchmark.py` / `compare_gsdc.py`), which surfaces the
+   availability⇄accuracy trade-off for *every* config without re-scoring the
+   already-published P1–P4 numbers over all epochs.
+
+**P5 is not applicable on this data either.** P5 targets the millisecond
+common-mode clock steering of low-cost receivers, but the chosen OBS source —
+Google's derived `device_gnss.csv` — already reconstructs the clock: across all
+six curated trips the `HardwareClockDiscontinuityCount` never increments (zero
+common-mode jumps). The remaining slips are per-satellite and already handled by
+the converter's `LLI`-on-`ADR_RESET`/`SLIP` plus P4's `spp_detslp`. P5's premise
+holds only for the raw `gnss_log.txt` path, which #165 deliberately did not use.
+demo5 confirms there is no smartphone clock-jump primitive to port: its
+`pntpos.c` is clean and only `ppp.c` carries a *day-boundary* ambiguity reset.
+
+**Decision: P6 reverted (the finding is the deliverable, not the code).** As a
+reference implementation, MRTKLIB should carry only algorithms that earn their
+place; a default-off EKF known not to improve accuracy is debt, not a feature.
+The C code (`spp_filter` option, `spp_posfilt()`, the `pntpos` velocity-covariance
+clear, the `gsdc_p6.toml` overlay) was reverted; the `Cov%` benchmark metric was
+kept. The only credible accuracy path left for SPP is a **tightly-coupled**
+raw-pseudorange/Doppler EKF with clock + inter-system-bias states (§5.2/§5.3 —
+*not* pursued now); a loose post-filter over the WLS output structurally cannot
+absorb the clock/ISB and NLOS-bias errors that dominate the residual tail.
+Independently cross-reviewed (Codex), which reached the same conclusion.
+
 ## 5. Design
 
 ### 5.1 Architecture decision — reuse `rtk_t` for `PMODE_SINGLE`
@@ -444,6 +505,13 @@ Gated by `[positioning] tdcp` (default off → bit-identical). Measured effect:
 [§4.5](#45-p4-result--tdcp-velocity--jump-rejection-measured-2026-05-24).
 
 ### 5.5 Common-mode clock-jump correction (P5)
+
+> **Status: deferred — no validation target in the available data ([§4.7](#47-p6-re-attempt-on-smartphone-data-gsdc--confirmed-and-reverted-2026-05-25)).**
+> PPC is geodetic (clocks do not step) and the GSDC `device_gnss.csv` source has
+> its clock already reconstructed (zero `HardwareClockDiscontinuityCount`
+> increments). P5 only bites on the raw `gnss_log.txt` smartphone path or a live
+> low-cost stream, neither of which is currently benchmarked. Design retained for
+> when such data is available.
 
 Low-cost receivers steer their clock, producing simultaneous millisecond jumps
 on every satellite's carrier phase. `rescode()` already processes all visible
@@ -657,7 +725,14 @@ primary, ○ corroborating / applied.
   (epoch-propagated, not a station webpage coordinate).
 - **`detslp_*` sharing.** Exact refactor to expose cycle-slip detection to SPP
   without disturbing PPP/RTK — settled at P4.
-- **demo5 clock-jump parity.** Read the demo5 `pntpos.c` implementation before
-  P5 rather than assuming behaviour (CLAUDE.md §3).
+- **demo5 clock-jump parity.** *Resolved ([§4.7](#47-p6-re-attempt-on-smartphone-data-gsdc--confirmed-and-reverted-2026-05-25)):* demo5 has no
+  smartphone clock-jump primitive to port — `pntpos.c` is clean and only `ppp.c`
+  carries a day-boundary ambiguity reset. P5 deferred for want of a data source
+  that actually exhibits common-mode clock jumps.
 - **IGG-III thresholds.** The `k0`/`k1` segment thresholds need tuning against
   the P0 baseline; start from the literature range and validate per [§4.1](#41-p0-baseline-measured-2026-05-24).
+- **Tightly-coupled SPP EKF (Stage B).** The only credible remaining accuracy
+  lever ([§4.7](#47-p6-re-attempt-on-smartphone-data-gsdc--confirmed-and-reverted-2026-05-25)): a raw-pseudorange/Doppler EKF with clock + ISB states
+  (§5.2/§5.3), able to absorb errors the loose post-filter cannot. Not pursued
+  now; the residual tail is largely NLOS bias, which no filter fixes (needs
+  3DMA / external aiding).

--- a/scripts/benchmark/compare_gsdc.py
+++ b/scripts/benchmark/compare_gsdc.py
@@ -124,10 +124,14 @@ def main() -> int:
     thr = args.threshold
     thr_label = f"<{thr:.1f}m" if thr >= 1.0 else f"<{thr * 100:.0f}cm"
     score = (m["p50_2d_all"] + m["p95_2d_all"]) / 2.0
+    ref_usable = max(0, len(ref_rows) - args.skip_epochs)
+    coverage = m["n_matched"] / ref_usable * 100.0 if ref_usable else math.nan
     print(f"Reference : {args.ref}")
     print(f"Result    : {args.result}")
     print()
+    print(f"Reference epochs : {ref_usable}")
     print(f"Matched epochs : {m['n_matched']}")
+    print(f"Coverage       : {coverage:.1f}%")
     print(f"{thr_label} rate    : {m['thr_rate']:.1f}%")
     print(f"mean nSV       : {m['mean_sv_all']:.1f}")
     print()

--- a/scripts/benchmark/run_gsdc_benchmark.py
+++ b/scripts/benchmark/run_gsdc_benchmark.py
@@ -138,7 +138,9 @@ def print_summary(rows: list[dict]) -> None:
         m = r["metrics"]
         cid = r["id"][:42]
         if m is None:
-            print(f"{cid:<42} {'—':>5}  [{r['status']}]")
+            d = "—"
+            print(f"{cid:<42} {d:>5} {d:>6} {d:>5} {d:>6} "
+                  f"{d:>8} {d:>8} {d:>8} {d:>8}  [{r['status']}]")
             continue
         print(f"{cid:<42} {m['n_matched']:>5} {r['coverage']:>5.1f}% "
               f"{m['mean_sv_all']:>5.1f} "

--- a/scripts/benchmark/run_gsdc_benchmark.py
+++ b/scripts/benchmark/run_gsdc_benchmark.py
@@ -108,7 +108,7 @@ def _run_mrtk(mrtk: str, confs: list[str], obs: Path, navs: list[Path],
 # ---------------------------------------------------------------------------
 # Summary table
 # ---------------------------------------------------------------------------
-_HDR = (f"{'Case':<42} {'N':>5} {'nSV':>5} {'<2m%':>6} "
+_HDR = (f"{'Case':<42} {'N':>5} {'Cov%':>6} {'nSV':>5} {'<2m%':>6} "
         f"{'RMS2D':>8} {'p50':>8} {'p95':>8} {'score':>8}")
 _SEP = "-" * len(_HDR)
 
@@ -140,7 +140,8 @@ def print_summary(rows: list[dict]) -> None:
         if m is None:
             print(f"{cid:<42} {'—':>5}  [{r['status']}]")
             continue
-        print(f"{cid:<42} {m['n_matched']:>5} {m['mean_sv_all']:>5.1f} "
+        print(f"{cid:<42} {m['n_matched']:>5} {r['coverage']:>5.1f}% "
+              f"{m['mean_sv_all']:>5.1f} "
               f"{m['thr_rate']:>5.1f}% {_m(m['rms_2d_all']):>8} "
               f"{_m(m['p50_2d_all']):>8} {_m(m['p95_2d_all']):>8} "
               f"{_m(gsdc_score(m)):>8}")
@@ -149,6 +150,7 @@ def print_summary(rows: list[dict]) -> None:
     if ok:
         import numpy as np
         print(f"{'MEAN':<42} {int(np.mean([m['n_matched'] for m in ok])):>5} "
+              f"{np.mean([r['coverage'] for r in rows if r['metrics']]):>5.1f}% "
               f"{np.mean([m['mean_sv_all'] for m in ok]):>5.1f} "
               f"{np.mean([m['thr_rate'] for m in ok]):>5.1f}% "
               f"{np.mean([m['rms_2d_all'] for m in ok]):>8.2f} "
@@ -229,10 +231,12 @@ def run(args: argparse.Namespace) -> int:
             print("  FAIL: no matching epochs")
             rows.append({"id": case["id"], "metrics": None, "status": "no-match"})
             continue
+        ref_usable = max(0, len(ref) - args.skip_epochs)
+        coverage = m["n_matched"] / ref_usable * 100.0 if ref_usable else math.nan
         print(f"  N={m['n_matched']}  <2m={m['thr_rate']:.1f}%  "
               f"p50={m['p50_2d_all']:.2f}m  p95={m['p95_2d_all']:.2f}m  "
-              f"score={gsdc_score(m):.2f}m  ({dt:.1f}s)")
-        rows.append({"id": case["id"], "metrics": m, "status": "ok"})
+              f"score={gsdc_score(m):.2f}m  cov={coverage:.1f}%  ({dt:.1f}s)")
+        rows.append({"id": case["id"], "metrics": m, "coverage": coverage, "status": "ok"})
 
     print_summary(rows)
     return 0


### PR DESCRIPTION
## Summary

Re-attempted the loosely-coupled SPP **position EKF (P6)** on the new GSDC-2023 smartphone benchmark — the favourable data §4.6 said it needed — and **reverted it again**. This PR keeps the *finding* (design doc) and a lasting benchmark improvement (coverage metric); the P6 C code is fully reverted.

Continues #116 (P0–P4 shipped in v0.6.10) and #165 (GSDC benchmark foundation, PR #170).

## Findings (both confirm + extend §4.6 to smartphone data)

1. **Smoothing hurts, not neutral.** With coast disabled, the EKF makes the measured epochs *worse* (GSDC score 4.19 → 4.34) — the CV/CA model lags real stop-go / turning motion, and the post-P1–P4 WLS is already good enough that there is no averaging gain. Second independent negative result (PPC §4.6 + GSDC).
2. **The matched-only metric can't reward P6.** The score counts only the epochs a run predicts, so QC that drops hard epochs flatters it and coast (gap-filling) penalises it. The tuned coast-only EKF recovered **+2.1 pp coverage** (52.3% → 54.4%) at a small matched-only accuracy cost (4.19 → 4.29) — invisible-to-penalised under the current metric, though it would count on the real all-epoch GSDC.

| Variant | N | Cov% | p50 | p95 | score |
|---|--:|--:|--:|--:|--:|
| P1–P4 (snapshot WLS) | 907 | 52.3 | 2.56 | 5.82 | **4.19** |
| P6 smoothing-only | 906 | 52.3 | 2.61 | 6.07 | 4.34 |
| P6 coast-only (tuned) | 941 | 54.4 | 2.59 | 6.00 | 4.29 |

**P5 (clock-jump) is also N/A** on the chosen `device_gnss.csv` source: Google's derived pseudorange already reconstructs the clock (zero `HardwareClockDiscontinuityCount` increments across all curated trips), and demo5 has no smartphone clock-jump primitive to port.

## Changes

- **Kept** — `Cov%` coverage column in the GSDC harness (`compare_gsdc.py`, `run_gsdc_benchmark.py`): surfaces the availability⇄accuracy trade-off for *every* config, without re-scoring published numbers.
- **Docs** — `spp-accuracy.md` §4.7 (GSDC result + metric limitation), §5.5 (P5 deferred), §10 (open questions incl. tightly-coupled Stage B as the only credible accuracy path), delivery table.
- **Reverted** — all P6 C code (`spp_filter` option, `spp_posfilt()`, `pntpos` velocity-covariance clear, `gsdc_p6.toml`). As a reference implementation, MRTKLIB should carry only algorithms that earn their place; a default-off EKF known not to improve accuracy is debt.

## Decision

P6 (loose) is concluded as an availability/coast experiment, not a precision improvement. The only credible accuracy path left for SPP is a **tightly-coupled** raw-pseudorange/Doppler EKF with clock + ISB states (§5.2/§5.3) — explicitly *not* pursued now (residual tail is largely NLOS bias). Independently cross-reviewed (Codex), same conclusion.

## Test status

`ctest`: 68/70 pass. The 2 failures (`rtkrcv_rt`, `madocalib_pppar_ion_check`) are the documented pre-existing develop baseline (environmental RT-daemon init; LAPACK-vs-LU numerical band, CLAUDE.md §7.2). **This PR changes zero C code**, so it cannot affect them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)