### PR TITLE
ci(format): add build-free formatter gate (clang-format/taplo/ruff) (#166)

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,0 +1,57 @@
+name: Formatter Check
+
+# Lightweight, build-free gate that fails when code is not formatted with the
+# project's pinned formatters. Kept separate from build.yaml (the ~10-min
+# regression job) so style feedback is fast. Check-only: it never pushes
+# formatting commits back (signing policy + fork-PR token constraints; see #166).
+#
+# Pinned versions MUST match CONTRIBUTING.md / CLAUDE.md and the versions used
+# for the one-time sweep in #166. Bumping a version here is a deliberate change
+# that reformats the codebase — do it in its own PR.
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # clang-format (C/C++) and ruff (Python) ship exact-versioned wheels.
+      - name: Install pinned clang-format + ruff
+        run: |
+          pip install "clang-format==21.1.6" "ruff==0.15.2"
+          clang-format --version
+          ruff --version
+
+      - name: Install pinned taplo
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-x86_64.gz \
+            | gunzip > "$HOME/.local/bin/taplo"
+          chmod +x "$HOME/.local/bin/taplo"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/taplo" --version
+
+      # Vendored / upstream-derived code (src/core/tomlc99, util/) is skipped via
+      # .clang-format-ignore — the same exclude list used by the #166 sweep.
+      - name: clang-format (C/C++)
+        run: git ls-files '*.c' '*.cpp' '*.h' '*.hpp' | xargs clang-format --dry-run --Werror
+
+      # Run the remaining checks even if an earlier one failed, so a PR sees all
+      # formatting problems at once instead of one formatter at a time.
+      - name: taplo (TOML)
+        if: ${{ !cancelled() }}
+        run: taplo fmt --check
+
+      - name: ruff format (Python)
+        if: ${{ !cancelled() }}
+        run: ruff format --check .

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -6,8 +6,9 @@ name: Formatter Check
 # formatting commits back (signing policy + fork-PR token constraints; see #166).
 #
 # Pinned versions MUST match CONTRIBUTING.md / CLAUDE.md and the versions used
-# for the one-time sweep in #166. Bumping a version here is a deliberate change
-# that reformats the codebase — do it in its own PR.
+# for the one-time sweep (PR #177, issue #166). Bumping a version here is a
+# deliberate change that reformats the codebase — do it in its own PR, and
+# update the taplo checksum below.
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -32,19 +33,28 @@ jobs:
           clang-format --version
           ruff --version
 
+      # taplo has no pip wheel; pin the release asset and verify its SHA-256
+      # (immutable once published) before executing it.
       - name: Install pinned taplo
+        env:
+          TAPLO_SHA256: 8fe196b894ccf9072f98d4e1013a180306e17d244830b03986ee5e8eabeb6156
         run: |
           mkdir -p "$HOME/.local/bin"
-          curl -fsSL https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-x86_64.gz \
-            | gunzip > "$HOME/.local/bin/taplo"
+          curl -fsSL -o taplo.gz \
+            https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-x86_64.gz
+          echo "${TAPLO_SHA256}  taplo.gz" | sha256sum -c -
+          gunzip -c taplo.gz > "$HOME/.local/bin/taplo"
           chmod +x "$HOME/.local/bin/taplo"
+          rm -f taplo.gz
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/taplo" --version
 
-      # Vendored / upstream-derived code (src/core/tomlc99, util/) is skipped via
-      # .clang-format-ignore — the same exclude list used by the #166 sweep.
+      # Vendored / upstream-derived code (src/core/tomlc99, util/) is skipped by
+      # clang-format itself via .clang-format-ignore — the single exclude source,
+      # honored even for files passed explicitly (clang-format >= 18). NUL-delimited
+      # paths + xargs -r keep this robust for odd names / empty input.
       - name: clang-format (C/C++)
-        run: git ls-files '*.c' '*.cpp' '*.h' '*.hpp' | xargs clang-format --dry-run --Werror
+        run: git ls-files -z '*.c' '*.cpp' '*.h' '*.hpp' | xargs -0 -r clang-format --dry-run --Werror
 
       # Run the remaining checks even if an earlier one failed, so a PR sees all
       # formatting problems at once instead of one formatter at a time.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,12 @@ Project-wide rules are in [CLAUDE.md §4](CLAUDE.md). The headline items:
   `.clang-format-ignore` (`src/core/tomlc99`, `util/`) — do not reformat it.
   `ruff check` (lint) is **not** part of the formatting gate and is tracked
   separately.
+
+  CI enforces all three checks via the `Formatter Check` workflow
+  (`.github/workflows/format.yaml`, build-free): a PR that is not
+  formatter-clean fails. The workflow uses the pinned versions above and the
+  same `.clang-format-ignore` exclude, so a local `clang-format`/`taplo fmt
+  --check`/`ruff format --check` matches CI exactly.
 - **`extern "C"`** compatibility on headers that are still consumed by
   legacy C files.
 - **`const`-correctness** on pointer parameters that are not written to.


### PR DESCRIPTION
## Summary

PR-B of #166: a **build-free CI formatter gate**. Adds `.github/workflows/format.yaml` that fails when code is not formatted with the project's pinned formatters. Check-only — it never pushes formatting commits back (GPG-signing policy + fork-PR token constraints, per #166).

Depends on #177 (the formatter sweep), now merged — develop is formatter-clean, so this gate goes green immediately.

## What it does

On `push` / `pull_request` / `workflow_dispatch`, one fast job (no compile):

| Check | Tool | Pinned version | Scope / exclude |
|-------|------|----------------|-----------------|
| C/C++ | `clang-format --dry-run --Werror` | 21.1.6 (pip wheel) | all `*.c/*.h/*.cpp/*.hpp`; `src/core/tomlc99` + `util/` skipped via `.clang-format-ignore` |
| TOML | `taplo fmt --check` | 0.10.0 (release binary) | `taplo.toml` (excludes `.venv`/site-packages) |
| Python | `ruff format --check .` | 0.15.2 (pip wheel) | `ruff.toml` (ruff's built-in excludes) |

Same exclude list and same pinned versions as the #177 sweep, so a local run matches CI exactly. The taplo/ruff steps use `if: ${{ !cancelled() }}` so a PR sees all formatter failures at once.

`ruff check` (lint) is intentionally **not** included (separate concern, currently non-blocking — see #166).

## Type of change
- [x] CI / tooling (no functional change)

## Verification
- `format.yaml` YAML validated.
- Ran the **exact** gate commands locally against current `develop`: clang-format / taplo / ruff all exit 0 (green).
- Kept separate from `build.yaml` (the ~10-min regression job) so it stays fast.

## Follow-up (maintainer)
After this is green, make **`Formatter Check`** a required status check in the branch protection rule for `develop` (and `main`). Ordering matters — required *after* this merges, never before, or open PRs would break (already satisfied since #177 landed first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
