### PR TITLE
docs(citation): Zenodo DOI badge, citation section, .zenodo.json + CITATION.cff

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,35 @@
+{
+  "upload_type": "software",
+  "access_right": "open",
+  "license": "bsd-2-clause",
+  "title": "MRTKLIB: Modernized RTKLIB for Next-Generation GNSS",
+  "description": "A modernized, thread-safe, modularized C11 library for standard and precise GNSS positioning (PPP, PPP-AR, PPP-RTK with QZSS CLAS/MADOCA), built on RTKLIB.",
+  "creators": [
+    {
+      "name": "Shiono, Hayato",
+      "orcid": "0009-0005-3547-4198"
+    }
+  ],
+  "keywords": [
+    "GNSS",
+    "GPS",
+    "RTKLIB",
+    "QZSS",
+    "CLAS",
+    "MADOCA",
+    "PPP",
+    "PPP-RTK"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/h-shiono/MRTKLIB",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://www.rtklib.com/",
+      "relation": "isDerivedFrom",
+      "scheme": "url"
+    }
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,15 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using these metadata."
+title: "MRTKLIB: Modernized RTKLIB for Next-Generation GNSS"
+type: software
+authors:
+  - family-names: Shiono
+    given-names: Hayato
+    orcid: "https://orcid.org/0009-0005-3547-4198"
+license: BSD-2-Clause
+repository-code: "https://github.com/h-shiono/MRTKLIB"
+url: "https://github.com/h-shiono/MRTKLIB"
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.20373746
+    description: "Concept DOI (all versions)"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License](https://img.shields.io/badge/License-BSD_2--Clause-blue.svg)](LICENSE)
 [![Build](https://img.shields.io/badge/build-CMake-success.svg)]()
 [![C11](https://img.shields.io/badge/standard-C11-blue.svg)]()
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20373746.svg)](https://doi.org/10.5281/zenodo.20373746)
 
 **MRTKLIB** is a completely modernized, thread-safe, and modularized C11 library for standard and precise GNSS positioning.
 
@@ -142,6 +143,25 @@ The codebase is fully documented using Doxygen. To generate the API reference an
 cmake --build build --target doc
 ```
 Documentation will be generated in `build/doc/html/index.html`.
+
+## 📚 How to Cite
+
+If you use MRTKLIB in your research or product, please cite it via its archived
+release on [Zenodo](https://zenodo.org/). You can cite **all versions** by using
+the concept DOI `10.5281/zenodo.20373746`; Zenodo also mints a version-specific
+DOI for each individual release.
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20373746.svg)](https://doi.org/10.5281/zenodo.20373746)
+
+```bibtex
+@software{mrtklib,
+  author    = {Shiono, Hayato},
+  title     = {{MRTKLIB: Modernized RTKLIB for Next-Generation GNSS}},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.20373746},
+  url       = {https://doi.org/10.5281/zenodo.20373746}
+}
+```
 
 ## 📄 License & Attributions
 MRTKLIB is distributed under the BSD 2-Clause License.


### PR DESCRIPTION
## Summary

Zenodo now mints a DOI for MRTKLIB (concept / all-versions DOI `10.5281/zenodo.20373746`). This PR adds the citation surface so users can cite the library and so the GitHub–Zenodo integration uses curated metadata on future releases.

## Changes

- **README**: DOI badge in the top badge row + a **📚 How to Cite** section (concept DOI explanation, Zenodo badge, BibTeX entry).
- **`.zenodo.json`**: metadata the GitHub–Zenodo integration applies on the *next* release — title, description, creator + ORCID, `license: bsd-2-clause` (Zenodo's lowercase vocabulary), keywords, related identifiers (GitHub repo, RTKLIB `isDerivedFrom`). The existing concept DOI is untouched.
- **`CITATION.cff`**: enables GitHub's native "Cite this repository" widget and machine-readable citation tooling, complementing `.zenodo.json`. Points at the concept DOI; `version`/`date-released` omitted to avoid per-release churn.

## Notes

- No code / positioning change — docs & metadata only.
- Not covered by the formatter CI gate (#166), which targets C/C++/TOML/Python (Markdown, JSON, YAML are out of scope). `.zenodo.json` validated as JSON; `CITATION.cff` validated as YAML (cff-version 1.2.0).
- ORCID checksum (MOD 11-2) verified valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)