### PR TITLE
Added tentative workaround code to the issue of MADOCA-PPP not using satellites other than GPS.

### DIFF
--- a/src/pos/mrtk_rtkpos.c
+++ b/src/pos/mrtk_rtkpos.c
@@ -2326,6 +2326,8 @@ static void signal_sel_ppp(obsd_t* pppobs, const nav_t* nav, const prcopt_t* opt
             case SYS_GPS:
                 if (opt->pppsig[0] == 1) { /* L1/L5 */
                     sigtype = 2;
+                } else if (opt->pppsig[0] == 2) { /* L1C/L2C */
+                    sigtype = 1;
                 }
                 break;
             case SYS_GAL:

--- a/src/pos/mrtk_rtkpos.c
+++ b/src/pos/mrtk_rtkpos.c
@@ -103,10 +103,10 @@ extern int miono_get_corr(const double* rr, nav_t* nav);
 #define NX(opt) (NR(opt) + NB(opt))
 
 /* state variable index */
-#define II(s, opt) (NP(opt) + (s) - 1)                     /* ionos (s:satellite no) */
+#define II(s, opt) (NP(opt) + (s)-1)                       /* ionos (s:satellite no) */
 #define IT(r, opt) (NP(opt) + NI(opt) + NT(opt) / 2 * (r)) /* tropos (r:0=rov,1:ref) */
 #define IL(f, opt) (NP(opt) + NI(opt) + NT(opt) + (f))     /* receiver h/w bias */
-#define IB(s, f, opt) (NR(opt) + MAXSAT * (f) + (s) - 1)   /* phase bias (s:satno,f:freq) */
+#define IB(s, f, opt) (NR(opt) + MAXSAT * (f) + (s)-1)     /* phase bias (s:satno,f:freq) */
 
 /* polynomial coefficients for adaptive AR ratio threshold based on sat-pair count
    (fitted to LAMBDA reliability curves from TU Delft; valid for 1–50 pairs) */
@@ -2269,6 +2269,142 @@ extern void rtkfree(rtk_t* rtk) {
     rtk->Pa = NULL;
 }
 
+/* signal selection for PPP --------------------------------------------------*/
+static void signal_sel_ppp(obsd_t* pppobs, const nav_t* nav, const prcopt_t* opt, int ns) {
+    char sattype[MAXANT], satid[8], *tstr = time_str(pppobs->time, 3);
+    int i, j, sigtype, sys;
+
+    for (i = 0; i < ns; i++) {
+        sys = satsys(pppobs->sat, NULL);
+        sigtype = 0; /* 0:GPS=L1C/A-L2P, GLO=G1-G2, GAL=E1-E5a, QZS=L1C-L5, BDS=B1_2-B3 */
+
+#if 0
+        /* original code from MALIB */
+        strcpy(sattype, nav->pcvs[pppobs->sat - 1].type);
+        for (j = strlen(sattype) - 1; j > 0; j--) {
+            if (sattype[j] != ' ') {
+                break;
+            }
+            sattype[j] = '\0'; /* delete tail blank */
+        }
+        if (0 == strcmp(sattype, "BLOCK IIR-M")) {
+            sigtype = opt->pppsig[0]; /* 1:L1C/A-L2C */
+        } else if (0 == strcmp(sattype, "BLOCK IIF")) {
+            sigtype = opt->pppsig[1]; /* 1:L1C/A-L2C, 2:L1C/A-L5 */
+        } else if (0 == strcmp(sattype, "BLOCK IIIA")) {
+            sigtype = opt->pppsig[2];
+        } else if (0 == strcmp(sattype, "QZSS")) {
+            sigtype = opt->pppsig[3]; /* 1:L1C/A-L2C */
+        } else if (0 == strcmp(sattype, "QZSS-2G")) {
+            sigtype = opt->pppsig[3];
+        } else if (0 == strcmp(sattype, "QZSS-2I")) {
+            sigtype = opt->pppsig[3];
+        } else if (0 == strcmp(sattype, "QZSS-2A")) {
+            sigtype = opt->pppsig[3];
+        } else if (0 == strcmp(sattype, "BEIDOU-3G-CAST")) {
+            sigtype = opt->pppsig[4]; /* 1:B1-B2a */
+        } else if (0 == strcmp(sattype, "BEIDOU-3I")) {
+            sigtype = opt->pppsig[4];
+        } else if (0 == strcmp(sattype, "BEIDOU-3M-CAST")) {
+            sigtype = opt->pppsig[4];
+        } else if (0 == strcmp(sattype, "BEIDOU-3M-SECM")) {
+            sigtype = opt->pppsig[4];
+        } else if (0 == strcmp(sattype, "BEIDOU-3SI-CAST")) {
+            sigtype = opt->pppsig[4];
+        } else if (0 == strcmp(sattype, "BEIDOU-3SI-SECM")) {
+            sigtype = opt->pppsig[4];
+        } else if (0 == strcmp(sattype, "BEIDOU-3SM-CAST")) {
+            sigtype = opt->pppsig[4];
+        } else if (0 == strcmp(sattype, "GALILEO-1")) {
+            sigtype = opt->pppsig[5];
+        } else if (0 == strcmp(sattype, "GALILEO-2")) {
+            sigtype = opt->pppsig[5];
+        }
+#else
+        /* tentative workaround */
+        switch (sys) {
+            case SYS_GPS:
+                if (opt->pppsig[0] == 1) { /* L1/L5 */
+                    sigtype = 2;
+                }
+                break;
+            case SYS_GAL:
+                if (opt->pppsig[2] == 1) { /* E1/E5b */
+                    sigtype = 1;
+                }
+                break;
+            case SYS_QZS:
+                if (opt->pppsig[1] == 1) { /* L1/L2 */
+                    sigtype = 1;
+                }
+                break;
+            case SYS_CMP:
+                if (opt->pppsig[4] == 1) { /* 1:B1I/B2a */
+                    sigtype = 1;
+                }
+                break;
+        }
+#endif
+
+        switch (sys) {
+            case SYS_GPS:
+                signal_replace(pppobs, 0, '1', "C");
+                if (sigtype == 0) {                            /* L1C/A-L2P */
+                    signal_replace(pppobs, 1, '2', "PYWCMND"); /* Note, codepries="PYWCMNDLXS" */
+                } else if (sigtype == 1) {                     /* L1C/A-L2C */
+                    signal_replace(pppobs, 1, '2', "LXS");
+                } else if (sigtype == 2) { /* L1C/A-L5 */
+                    signal_replace(pppobs, 1, '5', "QXI");
+                }
+                break;
+            case SYS_GLO:
+                signal_replace(pppobs, 0, '1', "CP");
+                signal_replace(pppobs, 1, '2', "PC");
+                break;
+            case SYS_GAL:
+                if (sigtype == 0) { /* E1-E5a */
+                    signal_replace(pppobs, 0, '1', "CBX");
+                    signal_replace(pppobs, 1, '5', "QXI");
+                } else if (sigtype == 1) { /* E1-E5b */
+                    signal_replace(pppobs, 0, '1', "CBX");
+                    signal_replace(pppobs, 1, '7', "QXI");
+                }
+                break;
+            case SYS_QZS:
+                if (sigtype == 0) { /* L1C-L5 */
+                    signal_replace(pppobs, 0, '1', "LXS");
+                    signal_replace(pppobs, 1, '5', "QXI");
+                } else if (sigtype == 1) { /* L1C/A-L2C */
+                    signal_replace(pppobs, 0, '1', "C");
+                    signal_replace(pppobs, 1, '2', "LXS");
+                } else if (sigtype == 2) { /* L1C/B-L5 */
+                    signal_replace(pppobs, 0, '1', "E");
+                    signal_replace(pppobs, 1, '5', "QXI");
+                } else if (sigtype == 10) { /* L1C/AorB-L5 */
+                    signal_replace(pppobs, 0, '1', "CE");
+                    signal_replace(pppobs, 1, '5', "QXI");
+                }
+                break;
+            case SYS_CMP:
+                if (sigtype == 0) { /* B1-B3 */
+                    signal_replace(pppobs, 0, '2', "QXI");
+                    signal_replace(pppobs, 1, '6', "QXI");
+                } else if (sigtype == 1) { /* B1C-B2a */
+                    signal_replace(pppobs, 0, '1', "PXD");
+                    signal_replace(pppobs, 1, '5', "PXD");
+                }
+                break;
+        }
+        satno2id(pppobs->sat, satid);
+        trace(NULL, 3,
+              "signal_sel_ppp %s %s %-18s code=%2d,%2d P=%13.3f,%13.3f L=%13.3f,%13.3f LLI=%d,%d "
+              "SNR=%6.2f,%6.2f\n",
+              tstr, satid, sattype, pppobs->code[0], pppobs->code[1], pppobs->P[0], pppobs->P[1], pppobs->L[0],
+              pppobs->L[1], pppobs->LLI[0], pppobs->LLI[1], pppobs->SNR[0] * 0.001, pppobs->SNR[1] * 0.001);
+        pppobs++;
+    }
+}
+
 /* update satellite code bias ------------------------------------------------*/
 static void udsatcb(gtime_t gt, nav_t* nav, osb_t* biaosb, const prcopt_t* popt) {
     int i, j, sys, udcnt = 0, ssrcode = CODE_NONE;
@@ -2791,11 +2927,24 @@ extern int rtkpos(mrtk_ctx_t* ctx, rtk_t* rtk, const obsd_t* obs, int n, nav_t* 
     }
     /* precise point positioning */
     if (opt->mode >= PMODE_PPP_KINEMA) {
+#if 0
         miono_get_corr(rtk->sol.rr, nav);
         trace(ctx, 4, "obs=\n");
         traceobs(ctx, 4, obs, n);
         pppos(ctx, rtk, obs, nu, nav);
         outsolstat(rtk);
+#else
+        /* tentative workaround */
+        static obsd_t pppobs[MAXOBS];
+        memcpy(pppobs, obs, sizeof(obsd_t) * nu);
+        signal_sel_ppp(pppobs, nav, opt, nu);
+        pntpos(ctx, pppobs, nu, nav, &rtk->opt, &rtk->sol, NULL, rtk->ssat, msg);
+        miono_get_corr(rtk->sol.rr, nav);
+        trace(ctx, 4, "obs=\n");
+        traceobs(ctx, 4, pppobs, n);
+        pppos(ctx, rtk, pppobs, nu, nav);
+        outsolstat(rtk);
+#endif
         return 1;
     }
     trace(ctx, 4, "obs=\n");


### PR DESCRIPTION
<!--
Thanks for contributing to MRTKLIB. Please fill in the sections below.
Delete any section that does not apply.
-->

## Summary

受信機と設定にもよりますが、私の環境で MADOCA-PPP を試したところ、
GPS以外の衛星が使われず、それを回避するための暫定的なコードを追加しました。
`src/pos/mrtk_rtkpos.c`だけを変更しています。

GalileoとQzss、Glonassについて、pntpos の際に P2 に値がセットされていないことで
pntposの処理が最後まで至らず、それが起因して ppp_res の中で信号が選択されていないようでした。
そこで、ppposの前に、signal_sel_pppとpntposを挟みました。

signal_sel_pppは、MALIBのコードから持ってきましたが、
MRTKLIBには取り込まれていないことからすると、
本来の信号選択のスキームではないのかと思います。
今回のコードは暫定ですので適宜修正して頂けましたら幸いです。

参考までに、私が使った `rtkrcv.toml` を添付致します。（pathのところだけ伏せています）
[rtkrcv.test.toml.txt](https://github.com/user-attachments/files/28343263/rtkrcv.test.toml.txt)

## Type of change

- [x] ~~Bug fix (non-breaking)~~ Request for fix

## Testing

97% tests passed, 2 tests failed out of 79

Label Time Summary:
absolute      =   0.60 sec*proc (7 tests)
claslib       = 891.46 sec*proc (27 tests)
iflc          =   0.47 sec*proc (4 tests)
igs           =   2.65 sec*proc (16 tests)
igsrts        =   0.27 sec*proc (4 tests)
madocalib     =   5.31 sec*proc (12 tests)
ppp           =   3.34 sec*proc (18 tests)
ppp-rtk       =  75.39 sec*proc (11 tests)
pppar         =   5.75 sec*proc (11 tests)
realtime      = 753.05 sec*proc (3 tests)
recvbias      =   1.01 sec*proc (2 tests)
regression    = 912.37 sec*proc (51 tests)
scatter       =   0.26 sec*proc (2 tests)
spp           =   1.53 sec*proc (2 tests)
tier3         =   0.26 sec*proc (2 tests)
utest         =   4.30 sec*proc (16 tests)
vrs           =  71.43 sec*proc (9 tests)

Total Test time (real) = 917.76 sec

The following tests FAILED:
	 24 - rtkrcv_rt (Failed)                                realtime regression
	 75 - igs_iflc_ppp_check (Failed)                       absolute iflc igs ppp
Errors while running CTest

## Positioning regression check

<!--
For changes that touch the positioning pipeline (PPP, RTK, PPP-RTK, VRS-RTK,
SPP, CLAS, MADOCA, RTCM decoding, etc.), confirm that Fix rate and accuracy
on the relevant reference dataset did not regress. State the dataset and
the observed numbers.
-->

- [ ] Not applicable (change does not affect the positioning pipeline)
- [ ] Regression check performed; dataset and results:

## Checklist

- [ ] I have read the coding standards in `CLAUDE.md`
- [ ] Doxygen comments added/updated for new or changed public functions
- [ ] `.clang-format` applied (or diff is formatting-clean)
- [ ] No unrelated changes included in this PR
