### PR TITLE
fix(rtkrcv): apply PPP signal selection in real-time path (#184)

### DIFF
--- a/apps/rtkrcv/rtkrcv.c
+++ b/apps/rtkrcv/rtkrcv.c
@@ -532,11 +532,14 @@ static int startsvr(vt_t* vt) {
     }
 
     /* #184: apply PPP signal selection in the real-time path, mirroring the
-     * post-processing path (rnx2rtkp.c). Without this, the obsdef tables keep
-     * their defaults and the madocalib PPP engine only forms iono-free pairs
-     * for GPS, silently dropping Galileo/QZSS/GLONASS/BeiDou. As in post, IGS
+     * post-processing path (rnx2rtkp.c). apply_pppsig() reshapes the obsdef
+     * tables (GPS/QZS/GAL/BDS) that every receiver decoder consults via
+     * code2freq_idx(); without it a non-GPS 2nd band that differs from the
+     * default slot (e.g. GAL E5b, BDS B2I) is never mapped, so the madocalib
+     * PPP engine can only form the iono-free pair for GPS. As in post, IGS
      * precise-product PPP skips it (#135) so the receiver's actual 2nd band
-     * survives. */
+     * survives. (GLONASS is unaffected: apply_pppsig() does not touch it and
+     * its default G1/G2 obsdef already maps correctly.) */
     if (prcopt.correction != CORR_IGS) {
         apply_pppsig(prcopt.pppsig);
     }

--- a/apps/rtkrcv/rtkrcv.c
+++ b/apps/rtkrcv/rtkrcv.c
@@ -531,6 +531,16 @@ static int startsvr(vt_t* vt) {
         }
     }
 
+    /* #184: apply PPP signal selection in the real-time path, mirroring the
+     * post-processing path (rnx2rtkp.c). Without this, the obsdef tables keep
+     * their defaults and the madocalib PPP engine only forms iono-free pairs
+     * for GPS, silently dropping Galileo/QZSS/GLONASS/BeiDou. As in post, IGS
+     * precise-product PPP skips it (#135) so the receiver's actual 2nd band
+     * survives. */
+    if (prcopt.correction != CORR_IGS) {
+        apply_pppsig(prcopt.pppsig);
+    }
+
     /* read start commads from command files */
     for (i = 0; i < 3; i++) {
         if (!*rcvcmds[i]) {


### PR DESCRIPTION
## Summary

Fixes #184. MADOCA-PPP in the real-time path (`mrtk run` / rtkrcv) only used GPS satellites; the non-GPS 2nd band was silently dropped. Reported by an external contributor in #183 (tentative workaround), reproduced and root-caused here.

> [!IMPORTANT]
> This fix covers the systems `apply_pppsig()` reshapes — **Galileo / QZSS / BeiDou**. **GLONASS is _not_ addressed**: `apply_pppsig()` does not touch it and its default G1/G2 obsdef already maps correctly, so a GLONASS-unused symptom (mentioned in #183/#184) has a different cause and needs separate investigation. A second, restart-related state-leak in the obsdef tables is tracked in #186.

The post-processing path ([`apps/rnx2rtkp/rnx2rtkp.c:314`](../blob/develop/apps/rnx2rtkp/rnx2rtkp.c#L314)) calls `apply_pppsig(prcopt.pppsig)` after `resolve_correction()`, but the real-time path in `startsvr()` never did. As a result the obsdef tables kept their multi-band defaults, and every receiver decoder's `code2freq_idx()` (which reads those tables via `freq_num2freq_idx()`) failed to map the non-GPS 2nd band into a frequency slot — so `P[1]` was never set for non-GPS and the madocalib PPP engine could not form the iono-free pair.

## Change

One file, `apps/rtkrcv/rtkrcv.c`. In `startsvr()`, after `resolve_correction()` succeeds, mirror the post path:

```c
if (prcopt.correction != CORR_IGS) {
    apply_pppsig(prcopt.pppsig);
}
```

The `CORR_IGS` skip matches post (#135): IGS precise-product PPP must keep the receiver's actual 2nd band (e.g. GAL E5b / BDS B2I on u-blox F9P) rather than have the obsdef table reshaped.

## Why not the #183 approach

The contributor's tentative patch added a third, MALIB-derived signal-selection scheme (per-epoch `signal_replace()` on a copy of the obs) inside the shared `PMODE_PPP_KINEMA` branch of `rtkpos()`. That path is common to **all** PPP modes, so it degraded IGS IFLC PPP (`igs_iflc_ppp_check` failed in the contributor's own CTest run) and introduced a `pppsig[]` value semantics that disagreed with `apply_pppsig()`. This PR instead reuses the existing, proven signal-selection mechanism and keeps post/real-time behaviour symmetric.

## Testing

Full suite on this machine: **77 passed / 2 failed (out of 79)** — the two failures are the documented pre-existing ones and are unchanged by this PR:

- `rtkrcv_rt` — known headless RT-replay env failure (`output=0`; excluded in CI)
- `madocalib_pppar_ion_check` — known LAPACK-vs-reference drift (3D RMS 1.62 cm vs 0.5 cm tol; Fix-rate delta +0.00%)

No new failures. In particular:
- `igs_iflc_ppp_check` — **PASS** (the test the #183 approach regressed)
- `rtkrcv_rt_clas`, `rtkrcv_rt_clas_2ch` — **PASS** (CLAS real-time unaffected by the now-symmetric `apply_pppsig` call)
- All IGS-product PPP / PPP-AR post-processing tests — PASS

No test tolerances were changed.

## Positioning regression check

- [x] Regression check performed; dataset and results: full ctest regression suite, no new failures, no tolerance changes (see Testing).

> [!NOTE]
> **End-to-end positive confirmation is still pending.** The fix is verified to be regression-free across the suite, and the root cause is mechanistically confirmed (obsdef → `code2freq_idx` → slot assignment) and symmetric with the proven post path. However, the only multi-GNSS MADOCA real-time test (`rtkrcv_rt`) fails on this machine for an unrelated environment reason (`output=0`), so the "non-GPS now used" outcome could not be observed locally. @hitoshimukai — could you verify on your environment (the receiver/data where the GPS-only behaviour reproduced)? Confirmation that Galileo/QZSS (and BeiDou, if present) are now used would close the loop. GLONASS is out of scope here (see the IMPORTANT note above).

## Checklist

- [x] I have read the coding standards in `CLAUDE.md`
- [x] Doxygen comments added/updated for new or changed public functions (n/a — no new public function; a guarded call with an explanatory comment)
- [x] `.clang-format` applied (clang-format 21.1.6 clean)
- [x] No unrelated changes included in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
