### PR TITLE
fix(nav): make obsdef signal selection idempotent across rtkrcv restarts (#186)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,7 @@ enable_testing()
 set(_UTEST_DIR ${CMAKE_SOURCE_DIR}/tests/utest)
 set(_UTEST_SOURCES
     t_atmos t_coord t_geoid t_gloeph t_ionex
-    t_lambda t_matrix t_misc t_ppp t_preceph
+    t_lambda t_matrix t_misc t_obsdef t_ppp t_preceph
     t_rinex t_rinex4 t_time
     # t_tle excluded: tle_pos() implementation not yet in library
 )

--- a/apps/rtkrcv/rtkrcv.c
+++ b/apps/rtkrcv/rtkrcv.c
@@ -539,9 +539,18 @@ static int startsvr(vt_t* vt) {
      * PPP engine can only form the iono-free pair for GPS. As in post, IGS
      * precise-product PPP skips it (#135) so the receiver's actual 2nd band
      * survives. (GLONASS is unaffected: apply_pppsig() does not touch it and
-     * its default G1/G2 obsdef already maps correctly.) */
-    if (prcopt.correction != CORR_IGS) {
-        apply_pppsig(prcopt.pppsig);
+     * its default G1/G2 obsdef already maps correctly.)
+     *
+     * #186: reset to the pristine defaults first so a restart (the rtkrcv shell
+     * can `load` a new config and `restart` in the same process) that changes
+     * the correction or signal selection — including switching to correction=igs,
+     * which skips apply_pppsig — cannot inherit a previously trimmed obsdef.
+     * sigcfg-configured obsdef (pos1-signals) is left untouched. */
+    if (!prcopt.sigcfg_set) {
+        reset_obsdef();
+        if (prcopt.correction != CORR_IGS) {
+            apply_pppsig(prcopt.pppsig);
+        }
     }
 
     /* read start commads from command files */

--- a/include/mrtklib/mrtk_nav.h
+++ b/include/mrtklib/mrtk_nav.h
@@ -551,6 +551,14 @@ int freq_idx2ant_idx(int sys, int freq_idx);
 void set_obsdef(int sys, const int* freq_nums);
 
 /**
+ * @brief Reset all obsdef tables to their pristine default frequency layout.
+ * @note #186: restores the full multi-band tables so a repeated/changed signal
+ *       selection (e.g. an rtkrcv restart, or switching to correction=igs which
+ *       skips apply_pppsig()) does not inherit a previously trimmed layout.
+ */
+void reset_obsdef(void);
+
+/**
  * @brief Apply PPP signal selection options to obsdef tables.
  * @param[in] pppsig  Signal selection array [5]: GPS,QZS,GAL,BDS2,BDS3
  */

--- a/src/data/mrtk_nav.c
+++ b/src/data/mrtk_nav.c
@@ -275,6 +275,78 @@ static obsdef_t* get_obsdef(int sys) {
             return NULL;
     }
 }
+/* pristine default snapshots of the obsdef tables ----------------------------
+ * #186: set_obsdef() rewrites the working tables in place, zeroing the bands
+ * not in the selected pair. Without a pristine reference, signal selection is
+ * not idempotent across rtkrcv restarts — a band trimmed by one selection
+ * cannot be restored by a later one, and switching to correction=igs (which
+ * skips apply_pppsig) leaves the tables trimmed. We snapshot the default tables
+ * on first use, before any mutation, so set_obsdef() / reset_obsdef() can always
+ * rebuild from them. The working-table initialisers above stay the single
+ * source of truth for the default values.
+ *---------------------------------------------------------------------------*/
+static obsdef_t obsdef_GPS_def[MAXFREQ], obsdef_GLO_def[MAXFREQ], obsdef_GAL_def[MAXFREQ], obsdef_QZS_def[MAXFREQ],
+    obsdef_SBS_def[MAXFREQ], obsdef_BDS_def[MAXFREQ], obsdef_BD2_def[MAXFREQ], obsdef_IRN_def[MAXFREQ];
+static int obsdef_defaults_saved = 0;
+
+/* helper: select pristine-default obsdef table by system (mirrors get_obsdef) */
+static obsdef_t* get_obsdef_default(int sys) {
+    switch (sys) {
+        case SYS_GPS:
+            return obsdef_GPS_def;
+        case SYS_GLO:
+            return obsdef_GLO_def;
+        case SYS_GAL:
+            return obsdef_GAL_def;
+        case SYS_QZS:
+            return obsdef_QZS_def;
+        case SYS_SBS:
+            return obsdef_SBS_def;
+        case SYS_CMP:
+            return obsdef_BDS_def;
+        case SYS_BD2:
+            return obsdef_BD2_def;
+        case SYS_IRN:
+            return obsdef_IRN_def;
+        default:
+            return NULL;
+    }
+}
+
+/* capture the pristine default tables on first use (before any mutation) */
+static void save_obsdef_defaults(void) {
+    if (obsdef_defaults_saved) {
+        return;
+    }
+    memcpy(obsdef_GPS_def, obsdef_GPS, sizeof(obsdef_GPS));
+    memcpy(obsdef_GLO_def, obsdef_GLO, sizeof(obsdef_GLO));
+    memcpy(obsdef_GAL_def, obsdef_GAL, sizeof(obsdef_GAL));
+    memcpy(obsdef_QZS_def, obsdef_QZS, sizeof(obsdef_QZS));
+    memcpy(obsdef_SBS_def, obsdef_SBS, sizeof(obsdef_SBS));
+    memcpy(obsdef_BDS_def, obsdef_BDS, sizeof(obsdef_BDS));
+    memcpy(obsdef_BD2_def, obsdef_BD2, sizeof(obsdef_BD2));
+    memcpy(obsdef_IRN_def, obsdef_IRN, sizeof(obsdef_IRN));
+    obsdef_defaults_saved = 1;
+}
+
+/* reset obsdef tables to their pristine defaults -----------------------------
+ * #186: restore the full multi-band tables, e.g. before re-applying signal
+ * selection on an rtkrcv restart, or when switching to correction=igs (which
+ * skips apply_pppsig and must see the receiver's actual bands, #135).
+ * return : none
+ *-----------------------------------------------------------------------------*/
+extern void reset_obsdef(void) {
+    save_obsdef_defaults();
+    memcpy(obsdef_GPS, obsdef_GPS_def, sizeof(obsdef_GPS));
+    memcpy(obsdef_GLO, obsdef_GLO_def, sizeof(obsdef_GLO));
+    memcpy(obsdef_GAL, obsdef_GAL_def, sizeof(obsdef_GAL));
+    memcpy(obsdef_QZS, obsdef_QZS_def, sizeof(obsdef_QZS));
+    memcpy(obsdef_SBS, obsdef_SBS_def, sizeof(obsdef_SBS));
+    memcpy(obsdef_BDS, obsdef_BDS_def, sizeof(obsdef_BDS));
+    memcpy(obsdef_BD2, obsdef_BD2_def, sizeof(obsdef_BD2));
+    memcpy(obsdef_IRN, obsdef_IRN_def, sizeof(obsdef_IRN));
+}
+
 /* set observation definition by frequency number array -----------------------
  * rearrange obsdef table so that freq_nums[0..MAXFREQ-1] appear at indices
  * 0,1,2,... — used to apply pos2-sig* signal selection options.
@@ -283,30 +355,34 @@ static obsdef_t* get_obsdef(int sys) {
  * return : none
  *-----------------------------------------------------------------------------*/
 extern void set_obsdef(int sys, const int* freq_nums) {
-    obsdef_t obsdef_tmp[MAXFREQ] = {{0}};
     obsdef_t* obsdef;
+    const obsdef_t* def;
     obsdef_t obsdef0 = {0};
     int i, j;
 
-    if (!(obsdef = get_obsdef(sys))) {
+    save_obsdef_defaults();
+
+    if (!(obsdef = get_obsdef(sys)) || !(def = get_obsdef_default(sys))) {
         return;
     }
-
+    /* #186: rebuild from the pristine defaults (not the current table) so a band
+       trimmed by a previous selection can still be restored — idempotent. On the
+       first call the defaults equal the current table, so the result is
+       bit-identical to the historical in-place behaviour. */
     for (i = 0; i < MAXFREQ; i++) {
-        obsdef_tmp[i] = obsdef[i];
         obsdef[i] = obsdef0;
     }
     for (i = 0; i < MAXFREQ; i++) {
         for (j = 0; j < MAXFREQ; j++) {
-            if (obsdef_tmp[j].freq_num == freq_nums[i]) {
+            if (def[j].freq_num == freq_nums[i]) {
                 break;
             }
         }
         if (j == MAXFREQ) {
             continue;
         }
-        obsdef[i].freq_num = obsdef_tmp[j].freq_num;
-        obsdef[i].freq_hz = obsdef_tmp[j].freq_hz;
+        obsdef[i].freq_num = def[j].freq_num;
+        obsdef[i].freq_hz = def[j].freq_hz;
     }
 }
 /* apply PPP signal selection options to obsdef tables -----------------------

--- a/tests/utest/t_obsdef.c
+++ b/tests/utest/t_obsdef.c
@@ -1,0 +1,73 @@
+/*------------------------------------------------------------------------------
+ * unit test : obsdef signal-selection idempotency and reset (#186)
+ *
+ * apply_pppsig()/set_obsdef() rewrite the global obsdef tables in place. This
+ * test guards that:
+ *   - selection rebuilds from the pristine defaults, so switching the selected
+ *     2nd band restores a band a previous selection had trimmed (idempotency);
+ *   - reset_obsdef() returns the tables to their full multi-band defaults.
+ * Before the #186 fix, a band zeroed by one selection could not be recovered by
+ * the next (it stayed 0), which corrupts code2freq_idx() slot mapping after an
+ * rtkrcv restart. Uses explicit checks (not assert) so it is robust under
+ * -DNDEBUG.
+ *-----------------------------------------------------------------------------*/
+#include <stdio.h>
+
+#include "mrtklib/rtklib.h"
+
+static int fails = 0;
+
+#define CHECK(cond, msg)                 \
+    do {                                 \
+        if (!(cond)) {                   \
+            printf("FAIL: %s\n", (msg)); \
+            fails++;                     \
+        } else {                         \
+            printf("ok  : %s\n", (msg)); \
+        }                                \
+    } while (0)
+
+static int gal(int idx) { return freq_idx2freq_num(SYS_GAL, idx); }
+static int gps(int idx) { return freq_idx2freq_num(SYS_GPS, idx); }
+
+int main(void) {
+    int pppsig[5];
+
+    /* 1. pristine defaults (the first reset_obsdef snapshots them) */
+    reset_obsdef();
+    CHECK(gal(0) == 1 && gal(1) == 5 && gal(2) == 7 && gal(3) == 6 && gal(4) == 8, "GAL pristine = E1,E5a,E5b,E6,E5ab");
+    CHECK(gps(0) == 1 && gps(1) == 2 && gps(2) == 5, "GPS pristine = L1,L2,L5");
+
+    /* 2. select GAL E1-E5b (pppsig[2]=1) and GPS L1-L5 (pppsig[0]=1) */
+    pppsig[0] = 1;
+    pppsig[1] = 0;
+    pppsig[2] = 1;
+    pppsig[3] = 0;
+    pppsig[4] = 0;
+    apply_pppsig(pppsig);
+    CHECK(gal(0) == 1 && gal(1) == 7 && gal(2) == 0, "GAL E1-E5b: idx1=E5b(7), idx2 trimmed");
+    CHECK(gps(0) == 1 && gps(1) == 5 && gps(2) == 0, "GPS L1-L5: idx1=L5(5), idx2 trimmed");
+
+    /* 3. #186 idempotency: switch GAL to E1-E5a and GPS to L1-L2 from the trimmed
+     *    state. The restored band must reappear (not stay 0). */
+    pppsig[0] = 0;
+    pppsig[2] = 0;
+    apply_pppsig(pppsig);
+    CHECK(gal(1) == 5, "GAL E1-E5a after E1-E5b: idx1 restored to E5a(5), not 0");
+    CHECK(gps(1) == 2, "GPS L1-L2 after L1-L5: idx1 restored to L2(2), not 0");
+
+    /* 4. reset_obsdef() restores the full multi-band defaults from any state */
+    pppsig[0] = 1;
+    pppsig[2] = 1;
+    apply_pppsig(pppsig); /* leave tables trimmed */
+    reset_obsdef();
+    CHECK(gal(1) == 5 && gal(2) == 7 && gal(3) == 6 && gal(4) == 8, "reset_obsdef restores GAL E5a/E5b/E6/E5ab");
+    CHECK(gps(2) == 5, "reset_obsdef restores GPS L5");
+
+    if (fails) {
+        printf("\n%d check(s) FAILED\n", fails);
+        return 1;
+    }
+    printf("\nall obsdef #186 checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes #186. `set_obsdef()` rewrote the module-static obsdef tables in place (zeroing the bands not in the selected pair), with no way to restore them. Because `set_obsdef()` rearranged from the *current* (possibly already-trimmed) table, a band trimmed by one selection could never be recovered by a later one. In `rtkrcv` the shell can `load` a new config and `restart` in the same process, so a restart that changed the correction source or signal selection inherited a corrupted obsdef → silent frequency-slot mismapping in `code2freq_idx()` for the second and later runs.

Found by Copilot review on #185.

## Change

**`src/data/mrtk_nav.c` — make obsdef configuration idempotent (root fix):**
- Snapshot the pristine default tables on first use, *before* any mutation (`save_obsdef_defaults()`); the working-table initialisers remain the single source of truth for the defaults.
- `set_obsdef()` now rebuilds the working table from the pristine snapshot instead of from the current (possibly trimmed) table. On the first/single call the snapshot equals the current table, so the result is **bit-identical to the historical in-place behaviour** — only repeated/changed selections within one process differ (the bug case).
- Added `reset_obsdef()` to restore all tables to their defaults.

**`apps/rtkrcv/rtkrcv.c` — reset before (re)applying selection in `startsvr()`:**
- Call `reset_obsdef()` before the guarded `apply_pppsig()` so a restart that switches to `correction=igs` (which skips `apply_pppsig`, #135) returns to the full multi-band defaults instead of staying trimmed.
- Wrapped in `if (!prcopt.sigcfg_set)` so an explicit `pos1-signals` (sigcfg) layout is left untouched. No bundled config sets sigcfg, so this is a no-op for all current configs/tests.

**`tests/utest/t_obsdef.c` (new) — `utest_t_obsdef`:**
- Directly guards #186 without needing the env-flaky `rtkrcv_rt` restart path: verifies (1) pristine defaults, (2) trimming on selection, (3) **idempotency** — switching the selected 2nd band restores a band a previous selection trimmed (this check returns 0 on the old code → would fail), (4) `reset_obsdef()` restores the full multi-band tables. Uses explicit checks (not `assert`) so it is robust under `-DNDEBUG`.

## Why this is low-risk

`set_obsdef()` is bit-identical for the first/single call (every fresh-process run: all post-processing tests, and the single-start RT tests). Only repeated calls within one process change — which is exactly the restart bug. The full ctest suite is the regression guard.

## Testing

Full ctest suite (80 tests): **78 pass**, only the two documented pre-existing failures remain — `rtkrcv_rt` (headless RT replay, output=0, CI-excluded) and `madocalib_pppar_ion_check` (LAPACK-vs-reference ~1.6 cm vs 0.5 cm tolerance). No new failures.

- `utest_t_obsdef`: **PASS** (8/8 checks) — new guard for this fix.
- `rtkrcv_rt_clas` / `rtkrcv_rt_clas_2ch`: **PASS** (the obsdef/apply_pppsig RT path this change touches).
- All madocalib / igs / ppp / pppar / vrs tests: PASS.
- clang-format 21.1.6 clean. No test tolerances changed.

## Related

- #185 (the RT `apply_pppsig` fix this follows up), #184, #135 (CORR_IGS skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
