### PR TITLE
feat(rcv): let [positioning].signals drive raw-decoder code selection — GLONASS L2C/A in MADOCA-PPP RT (#187)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,7 @@ set(_UTEST_DIR ${CMAKE_SOURCE_DIR}/tests/utest)
 set(_UTEST_SOURCES
     t_atmos t_coord t_geoid t_gloeph t_ionex
     t_lambda t_matrix t_misc t_obsdef t_ppp t_preceph
-    t_rinex t_rinex4 t_time
+    t_rinex t_rinex4 t_sigcfg_decode t_time
     # t_tle excluded: tle_pos() implementation not yet in library
 )
 foreach(test IN LISTS _UTEST_SOURCES)

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -37,7 +37,9 @@ TOML section: `[positioning]`
 | `satellite_ephemeris` | enum | All | Satellite ephemeris source. SSR modes (`brdc+ssrapc`, `brdc+ssrcom`) are used for PPP and PPP-RTK. `brdc` · `precise` · `brdc+sbas` · `brdc+ssrapc` · `brdc+ssrcom` |
 | `systems` | string[] | All | GNSS constellations to use. Accepts a human-readable string list like `["GPS", "Galileo"]`. |
 | `excluded_sats` | string | All | Satellites to exclude. Space-separated PRN list (e.g., `G01 G02`). Prefix `+` to include only. |
-| `signals` | string[] | All | Explicit signal code list. Overrides default observation definition when set. e.g. `["G1C", "G2W", "E1C"]` |
+| `signals` | string[] | All | Explicit RINEX3-style signal code list (`{sys}{freq}{attr}`, e.g. `["G1C", "G2W", "R1C", "R2C", "E1C", "E7Q", "J1C", "J2L"]`). When set it is the **authoritative** signal selection: it overrides `frequency` / the `[signals]` presets, derives the number of frequencies, **and** selects which observation code occupies each band's slot during real-time raw decoding (so e.g. GLONASS L2C/A can be used as the iono-free 2nd frequency without the legacy `-RL2C` receiver option — see [#189](https://github.com/h-shiono/MRTKLIB/issues/189)). List **every** band you want, for every constellation you want to constrain — `signals = ["R2C"]` alone derives nf=1 (single-frequency). A constellation you omit entirely keeps its default signal selection. |
+
+> **Recommended surface.** `[positioning].signals` is the preferred way to select signals. The `[signals]` section (`gps`/`qzs`/`galileo`/`bds2`/`bds3` presets) and `frequency` are the older, coarser mechanism (no per-code control, and **no GLONASS entry**, which is why GLONASS L2 code selection requires `signals`). When `signals` is set it takes precedence.
 
 ### Frequency Index Mapping
 
@@ -270,6 +272,8 @@ TOML section: `[adaptive_filter]`
 ## Signal Selection
 
 TOML section: `[signals]`
+
+> **Legacy preset form.** These per-constellation presets are the older, coarser signal-selection surface (no per-code control, no GLONASS entry). Prefer [`[positioning].signals`](#positioning) for new configurations; when `signals` is set it overrides this section. GLONASS L2 code selection (e.g. L2C/A vs L2P) can only be expressed via `[positioning].signals`.
 
 | TOML Key | Type | Modes | Description |
 |:---------|:-----|:------|:------------|

--- a/include/mrtklib/mrtk_obs.h
+++ b/include/mrtklib/mrtk_obs.h
@@ -284,6 +284,29 @@ int mrtk_sigcfg_from_signals(const char** sigs, int nsig, mrtk_sigcfg_t* cfg, in
  */
 int mrtk_sigcfg_to_obsdef(const mrtk_sigcfg_t* cfg);
 
+/** @brief mrtk_sigcfg_freq_idx() sentinel: this constellation has no sigcfg
+ *         entry, so the caller should fall back to its default (-R/-G/...)
+ *         option logic. Distinct from -1 (drop) and from valid slot indices. */
+#define MRTK_SIGCFG_NOOPINION (-2)
+
+/**
+ * @brief Resolve the observation slot for a decoded (sys, code) from sigcfg.
+ *
+ * #189: lets `[positioning].signals` (sigcfg) drive raw-decoder code selection,
+ * so e.g. GLONASS L2C/A can be placed in the iono-free 2nd frequency without the
+ * legacy `-RL2C` receiver option. obsdef is band-level (cannot distinguish L2C
+ * from L2P); sigcfg carries the per-band preferred code, which this consults.
+ *
+ * @param[in] sys   Satellite system (SYS_???)
+ * @param[in] code  Observation code (CODE_???) just decoded
+ * @param[in] cfg   Per-constellation signal config array [MRTK_NSYS]
+ * @param[in] nex   Number of extra observation slots available (NEXOBS)
+ * @return main slot 0..NFREQ-1 (code selected for its band); -1 to drop (code
+ *         not selected, or its band not configured for this system);
+ *         MRTK_SIGCFG_NOOPINION if this system has no sigcfg entry.
+ */
+int mrtk_sigcfg_freq_idx(int sys, uint8_t code, const mrtk_sigcfg_t* cfg, int nex);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/mrtklib/mrtk_rcvraw.h
+++ b/include/mrtklib/mrtk_rcvraw.h
@@ -101,8 +101,10 @@ typedef struct {
     int outtype;                            /**< output message type */
     uint8_t buff[MAXRAWLEN];                /**< message buffer */
     char opt[256];                          /**< receiver dependent options */
-    int format;                             /**< receiver stream format */
-    void* rcv_data;                         /**< receiver dependent data */
+    mrtk_sigcfg_t sigcfg[MRTK_NSYS]; /**< #189: per-constellation signal config (drives decoder code selection) */
+    int sigcfg_set;                  /**< #189: 1 if sigcfg is configured (else fall back to opt/-Rxxx defaults) */
+    int format;                      /**< receiver stream format */
+    void* rcv_data;                  /**< receiver dependent data */
 } raw_t;
 
 /*============================================================================

--- a/src/data/mrtk_obs.c
+++ b/src/data/mrtk_obs.c
@@ -1269,3 +1269,40 @@ extern int mrtk_sigcfg_to_obsdef(const mrtk_sigcfg_t* cfg) {
     }
     return 0;
 }
+/* mrtk_sigcfg_freq_idx: sigcfg-driven obs slot for a decoded (sys,code) -------
+ * #189: see mrtk_obs.h. When a constellation is configured in sigcfg, the
+ * decoded code is kept only if it is the preferred code for one of the
+ * configured bands (placed at that band's obsdef slot); any other code — a
+ * non-preferred code on a configured band, or any code on a non-configured
+ * band — is dropped. A constellation with no sigcfg entry yields NOOPINION so
+ * the caller keeps its legacy (-R/-G/... option) behaviour.
+ *-----------------------------------------------------------------------------*/
+extern int mrtk_sigcfg_freq_idx(int sys, uint8_t code, const mrtk_sigcfg_t* cfg, int nex) {
+    int sys_idx = sys2sigcfg_idx(sys);
+    int fn, base_idx, i;
+    const mrtk_sigcfg_t* c;
+
+    (void)nex; /* non-selected codes are dropped, not retained as extra obs (phase 1) */
+
+    if (sys_idx < 0 || !cfg) {
+        return MRTK_SIGCFG_NOOPINION;
+    }
+    c = &cfg[sys_idx];
+    if (c->nsig <= 0) {
+        return MRTK_SIGCFG_NOOPINION; /* system not configured: fall back to defaults */
+    }
+
+    fn = code2freq_num(code); /* this code's band (by frequency number) */
+    for (i = 0; i < c->nsig; i++) {
+        if (mrtk_band_to_freq_num(sys, c->sig[i].band) != fn) {
+            continue; /* different band */
+        }
+        /* band is configured: accept only the preferred code (0 = auto/any) */
+        if (c->sig[i].preferred_code == 0 || c->sig[i].preferred_code == code) {
+            base_idx = code2freq_idx(sys, code);
+            return (base_idx >= 0 && base_idx < NFREQ) ? base_idx : -1;
+        }
+        return -1; /* a different code is preferred for this band */
+    }
+    return -1; /* band not configured for this (configured) system */
+}

--- a/src/data/mrtk_rcvraw.c
+++ b/src/data/mrtk_rcvraw.c
@@ -1700,6 +1700,8 @@ extern int init_raw(raw_t* raw, int format) {
         raw->buff[i] = 0;
     }
     raw->opt[0] = '\0';
+    memset(raw->sigcfg, 0, sizeof(raw->sigcfg)); /* #189: default = no sigcfg (legacy -R/-G path) */
+    raw->sigcfg_set = 0;
     raw->format = -1;
 
     raw->obs.data = NULL;

--- a/src/data/rcv/mrtk_rcv_septentrio.c
+++ b/src/data/rcv/mrtk_rcv_septentrio.c
@@ -281,13 +281,26 @@ static uint8_t sig_tbl[SBF_MAXSIG + 1][2] = {
     {SYS_QZS, CODE_L5Z}  /* 39: QZS L5S */
 };
 /* signal number to freq-index and code --------------------------------------*/
-static int sig2idx(int sat, int sig, const char* opt, uint8_t* code) {
+static int sig2idx(int sat, int sig, const raw_t* raw, uint8_t* code) {
+    const char* opt = raw->opt;
     int idx, sys = satsys(sat, NULL), nex = NEXOBS;
 
     if (sig < 0 || sig > SBF_MAXSIG || sig_tbl[sig][0] != sys) {
         return -1;
     }
     *code = sig_tbl[sig][1];
+
+    /* #189: when [positioning].signals (sigcfg) is configured, it is authoritative
+     * for per-band code selection (e.g. GLONASS L2C/A as the 2nd frequency). Fall
+     * through to the legacy -R/-G option logic only when this system has no sigcfg
+     * entry (NOOPINION). */
+    if (raw->sigcfg_set) {
+        int r = mrtk_sigcfg_freq_idx(sys, *code, raw->sigcfg, nex);
+        if (r != MRTK_SIGCFG_NOOPINION) {
+            return r;
+        }
+    }
+
     idx = code2freq_idx(sys, *code);
 
     /* resolve code priority in a freq-index */
@@ -431,7 +444,7 @@ static int decode_measepoch(raw_t* raw) {
         }
 
         /* Store Type-1 observation only if the signal is in obsdef */
-        if ((idx = sig2idx(sat, sig, raw->opt, &code)) >= 0) {
+        if ((idx = sig2idx(sat, sig, raw, &code)) >= 0) {
             if (P1 != 0.0) {
                 raw->obs.data[n].P[idx] = P1;
             }
@@ -471,7 +484,7 @@ static int decode_measepoch(raw_t* raw) {
                 trace(NULL, 3, "sbf measepoch ant error: sat=%d ant=%d\n", sat, ant);
                 continue;
             }
-            if ((idx = sig2idx(sat, sig, raw->opt, &code)) < 0) {
+            if ((idx = sig2idx(sat, sig, raw, &code)) < 0) {
                 trace(NULL, 3, "sbf measepoch sig error: sat=%d sig=%d\n", sat, sig);
                 continue;
             }

--- a/src/stream/mrtk_rtksvr.c
+++ b/src/stream/mrtk_rtksvr.c
@@ -1138,6 +1138,13 @@ extern int rtksvrstart(rtksvr_t* svr, int cycle, int buffsize, int* strs, char**
         strcpy(svr->raw[i].opt, rcvopts[i]);
         strcpy(svr->rtcm[i].opt, rcvopts[i]);
 
+        /* #189: propagate the configured signal selection to the raw decoder so
+         * `[positioning].signals` drives per-band code selection (e.g. GLONASS
+         * L2C/A as the 2nd frequency). Empty sigcfg leaves sigcfg_set=0 and the
+         * decoder keeps its legacy -R/-G option behaviour. */
+        memcpy(svr->raw[i].sigcfg, prcopt->sigcfg, sizeof(svr->raw[i].sigcfg));
+        svr->raw[i].sigcfg_set = prcopt->sigcfg_set;
+
         /* connect dgps corrections */
         svr->rtcm[i].dgps = svr->nav.dgps;
     }

--- a/tests/utest/t_sigcfg_decode.c
+++ b/tests/utest/t_sigcfg_decode.c
@@ -1,0 +1,60 @@
+/*------------------------------------------------------------------------------
+ * unit test : sigcfg-driven raw-decoder code selection (#189)
+ *
+ * Guards mrtk_sigcfg_freq_idx(), which lets [positioning].signals (sigcfg) drive
+ * which obs code occupies a band's slot during raw decoding — e.g. GLONASS L2C/A
+ * as the iono-free 2nd frequency without the legacy -RL2C receiver option.
+ * Uses explicit checks (not assert) so it is robust under -DNDEBUG.
+ *-----------------------------------------------------------------------------*/
+#include <stdio.h>
+
+#include "mrtklib/rtklib.h"
+
+static int fails = 0;
+
+#define CHECK(cond, msg)                 \
+    do {                                 \
+        if (!(cond)) {                   \
+            printf("FAIL: %s\n", (msg)); \
+            fails++;                     \
+        } else {                         \
+            printf("ok  : %s\n", (msg)); \
+        }                                \
+    } while (0)
+
+int main(void) {
+    /* full dual-frequency multi-GNSS list; GLONASS 2nd band = L2C/A (R2C) */
+    const char* sigs[] = {"G1C", "G2W", "R1C", "R2C", "E1C", "E7Q", "J1C", "J2L"};
+    mrtk_sigcfg_t cfg[MRTK_NSYS];
+    int nf = 0;
+
+    reset_obsdef();
+
+    CHECK(mrtk_sigcfg_from_signals(sigs, 8, cfg, &nf) == 0, "parse signals list");
+    CHECK(nf == 2, "derived nf == 2");
+
+    /* mirror the real flow: obsdef is rearranged from sigcfg before decoding */
+    CHECK(mrtk_sigcfg_to_obsdef(cfg) == 0, "apply sigcfg to obsdef");
+
+    /* GLONASS: L1 C/A -> slot 0; L2 C/A -> slot 1 (the #189 fix); L2P -> dropped */
+    CHECK(mrtk_sigcfg_freq_idx(SYS_GLO, CODE_L1C, cfg, NEXOBS) == 0, "GLO L1C/A -> main slot 0");
+    CHECK(mrtk_sigcfg_freq_idx(SYS_GLO, CODE_L2C, cfg, NEXOBS) == 1, "GLO L2C/A -> main slot 1 (R2C preferred)");
+    CHECK(mrtk_sigcfg_freq_idx(SYS_GLO, CODE_L2P, cfg, NEXOBS) == -1, "GLO L2P -> dropped (not the preferred R2 code)");
+
+    /* GPS: L2W selected (G2W) -> slot 1; L2L (2C-band, different code) -> dropped */
+    CHECK(mrtk_sigcfg_freq_idx(SYS_GPS, CODE_L2W, cfg, NEXOBS) == 1, "GPS L2W -> main slot 1 (G2W preferred)");
+    CHECK(mrtk_sigcfg_freq_idx(SYS_GPS, CODE_L2L, cfg, NEXOBS) == -1, "GPS L2L -> dropped (G2W preferred)");
+
+    /* a constellation absent from the list yields NOOPINION (caller keeps -R/-G defaults) */
+    CHECK(mrtk_sigcfg_freq_idx(SYS_CMP, CODE_L2I, cfg, NEXOBS) == MRTK_SIGCFG_NOOPINION,
+          "BDS not configured -> NOOPINION (legacy fallback)");
+
+    reset_obsdef();
+
+    if (fails) {
+        printf("\n%d check(s) FAILED\n", fails);
+        return 1;
+    }
+    printf("\nall sigcfg-decode #189 checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Closes #187. Makes `[positioning].signals` (sigcfg) the authoritative signal-selection surface and lets it drive **raw-decoder code selection**, so GLONASS L2C/A can be placed in the iono-free 2nd frequency without the legacy `-RL2C` receiver option.

### Background

GLONASS was never used in MADOCA-PPP real-time on a **mosaic-CLAS** rover because GLONASS came out single-frequency (L1 C/A only) → no iono-free pair (#187). Root cause: mosaic-CLAS outputs GLONASS **L2C/A** (not L2P); the Septentrio decoder routes L2C/A to an extra obs slot unless `-RL2C` is set; but rtkrcv hardcodes the per-stream receiver-option string to empty, so `-RL2C` was unreachable in real time.

obsdef is **band-level** and cannot distinguish L2C from L2P; the disambiguation lived only in scattered `-R/-G` decoder flags. sigcfg already parses a per-band **preferred code** (e.g. `R2C` → GLONASS band 2, code L2C) — it was just unused. This PR consumes it.

## Change

- **`raw_t`** gains `sigcfg[MRTK_NSYS]` + `sigcfg_set`; `rtksvrstart()` copies them from `prcopt` next to the existing `opt` copy.
- **`mrtk_sigcfg_freq_idx()`** (new, `src/data/mrtk_obs.c`): given a decoded `(sys, code)`, returns the main slot if the code is the preferred code for one of the configured bands, `-1` to drop a non-selected code, or `MRTK_SIGCFG_NOOPINION` if the constellation has no sigcfg entry (→ caller keeps its legacy behaviour).
- **Septentrio `sig2idx()`** consults the helper first when `sigcfg_set`; otherwise the existing `-R/-G` logic runs unchanged (backward compatible).
- **`tests/utest/t_sigcfg_decode.c`** (new, `utest_t_sigcfg_decode`): guards the helper — GLONASS L2C/A → 2nd slot, L2P → dropped, unconfigured system → NOOPINION, GPS L2W vs L2L. Env-independent.
- **Docs** (`config-options.md`): `signals` is the recommended, authoritative surface (overrides `frequency`/`[signals]` presets, derives nf, drives decoder code selection); the `[signals]` preset section is marked legacy (no per-code control, no GLONASS). Notes that `signals` must list every wanted band (`["R2C"]` alone ⇒ nf=1).

### Usage

```toml
[positioning]
signals = ["G1C", "G2W", "R1C", "R2C", "E1C", "E7Q", "J1C", "J2L"]  # nf=2; GLONASS 2nd band = L2C/A
```

## Scope

**Phase 1: Septentrio (SBF) only** — which covers the mosaic-CLAS case in #187. `novatel`/`javad`/`ublox`/`binex`, the RTCM3 obs path, and `convbin` remain on the legacy `-R/-G` path; extending the sigcfg-driven helper to them is **Phase 2 (#189)**. The `-R/-G` options are retained as the fallback when `signals` is unset.

## Testing

Full ctest suite: only the two documented pre-existing failures (`rtkrcv_rt` headless replay, `madocalib_pppar_ion_check` LAPACK tolerance); **no new failures**. `utest_t_sigcfg_decode` passes (9/9). `rtkrcv_rt_clas` / `rtkrcv_rt_clas_2ch` and all madocalib/igs/ppp/vrs tests pass. When `signals` is unset the decoder path is bit-identical to before. clang-format 21.1.6 clean; no tolerance changes.

## Related

- #187 (GLONASS single-frequency on mosaic-CLAS — fixed here)
- #189 (Phase 2: remaining decoders / RTCM3 obs / convbin)
- #184 / #185 / #186 (real-time signal-selection series)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
