### PR TITLE
Release v0.6.12 — real-time MADOCA-PPP multi-GNSS signal selection

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,35 @@
+{
+  "upload_type": "software",
+  "access_right": "open",
+  "license": "bsd-2-clause",
+  "title": "MRTKLIB: Modernized RTKLIB for Next-Generation GNSS",
+  "description": "A modernized, thread-safe, modularized C11 library for standard and precise GNSS positioning (PPP, PPP-AR, PPP-RTK with QZSS CLAS/MADOCA), built on RTKLIB.",
+  "creators": [
+    {
+      "name": "Shiono, Hayato",
+      "orcid": "0009-0005-3547-4198"
+    }
+  ],
+  "keywords": [
+    "GNSS",
+    "GPS",
+    "RTKLIB",
+    "QZSS",
+    "CLAS",
+    "MADOCA",
+    "PPP",
+    "PPP-RTK"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/h-shiono/MRTKLIB",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://www.rtklib.com/",
+      "relation": "isDerivedFrom",
+      "scheme": "url"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,70 @@ All notable changes to MRTKLIB are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.6.12] - 2026-06-03
+
+**Real-time MADOCA-PPP multi-GNSS signal selection.** Brings the real-time
+(`mrtk run`) path up to parity with post-processing for non-GPS constellations:
+Galileo and QZSS are now used, GLONASS L2C/A can be selected, and the obsdef
+signal tables survive in-process restarts. **This is a positioning change** for
+real-time MADOCA-PPP (more constellations enter the solution); post-processing
+outputs are unchanged.
+
+### Added
+
+- **Non-GPS signals in real-time MADOCA-PPP** ([#184](https://github.com/h-shiono/MRTKLIB/issues/184),
+  PR #185) — `rtkrcv` now applies the configured PPP signal selection
+  (`apply_pppsig()`) at server start, mirroring the post-processing path. Without
+  it the obsdef tables kept their defaults and the engine could only form the
+  iono-free pair for GPS, silently dropping Galileo/QZSS/BeiDou. IGS-product PPP
+  still skips it (#135) so the receiver's actual 2nd band survives.
+- **`[positioning].signals` drives raw-decoder code selection**
+  ([#187](https://github.com/h-shiono/MRTKLIB/issues/187), PR #190) — the
+  signal list is now authoritative for which observation code occupies each
+  band's slot during decoding, so e.g. **GLONASS L2C/A** can be used as the
+  iono-free 2nd frequency on an L2C/A-only receiver (Septentrio mosaic-CLAS)
+  without the legacy `-RL2C` option. New `mrtk_sigcfg_freq_idx()` helper;
+  `raw_t` carries the resolved `sigcfg`. **Phase 1 covers the Septentrio (SBF)
+  decoder**; other decoders, the RTCM3 obs path and `convbin` follow in
+  [#189](https://github.com/h-shiono/MRTKLIB/issues/189). The `-R/-G` receiver
+  options are retained as the fallback when `signals` is unset.
+- **Unit tests** — `utest_t_obsdef` (obsdef idempotency/reset) and
+  `utest_t_sigcfg_decode` (sigcfg-driven per-code slotting), both env-independent.
+
+### Changed
+
+- **obsdef signal selection is idempotent across `rtkrcv` restarts**
+  ([#186](https://github.com/h-shiono/MRTKLIB/issues/186), PR #188) —
+  `set_obsdef()` now rebuilds from a pristine default snapshot instead of mutating
+  in place, and a new `reset_obsdef()` is applied before re-selecting signals at
+  server start. A `load`+`restart` that changes the correction source or signal
+  selection (including switching to `correction = "igs"`, which skips
+  `apply_pppsig()`) can no longer inherit a trimmed obsdef. Bit-identical on the
+  first/single configuration.
+- **Docs** — `[positioning].signals` is documented as the recommended,
+  authoritative signal-selection surface (overrides `frequency` / the `[signals]`
+  presets, derives the frequency count, and drives decoder code selection). The
+  `[signals]` preset section is marked **legacy** (coarse, no per-code control,
+  no GLONASS entry). List every band you want — `signals = ["R2C"]` alone derives
+  a single frequency.
+
+### Fixed
+
+- **`init_raw()` initializes the new `raw_t.sigcfg`/`sigcfg_set` fields**
+  (PR #190 review) — `init_raw()` sets members individually, so the
+  `malloc()`+`init_raw()` paths (stream converter, `convbin`) could otherwise
+  evaluate the sigcfg-driven branch on uninitialized state. Defaults to the
+  legacy path.
+
+### Known limitations
+
+- Decoder code-selection from `[positioning].signals` is **Septentrio/SBF only**
+  in this release; the remaining decoders, RTCM3 observations and `convbin` are
+  tracked in [#189](https://github.com/h-shiono/MRTKLIB/issues/189) (Phase 2).
+- GLONASS in MADOCA-PPP requires dual-frequency observations (G1 + G2). On a
+  GLONASS-L2C/A receiver, list `"R2C"` in `[positioning].signals`; an L2P-capable
+  receiver works out-of-the-box.
+
 ## [v0.6.11] - 2026-05-25
 
 **Tooling / developer experience** — no positioning change; all binaries and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,15 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using these metadata."
+title: "MRTKLIB: Modernized RTKLIB for Next-Generation GNSS"
+type: software
+authors:
+  - family-names: Shiono
+    given-names: Hayato
+    orcid: "https://orcid.org/0009-0005-3547-4198"
+license: BSD-2-Clause
+repository-code: "https://github.com/h-shiono/MRTKLIB"
+url: "https://github.com/h-shiono/MRTKLIB"
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.20373746
+    description: "Concept DOI (all versions)"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(MRTKLIB VERSION 0.6.11 LANGUAGES C)
+project(MRTKLIB VERSION 0.6.12 LANGUAGES C)
 
 # ── Version header generation ─────────────────────────────────────────────────
 set(MRTKLIB_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,7 @@ set(_UTEST_DIR ${CMAKE_SOURCE_DIR}/tests/utest)
 set(_UTEST_SOURCES
     t_atmos t_coord t_geoid t_gloeph t_ionex
     t_lambda t_matrix t_misc t_obsdef t_ppp t_preceph
-    t_rinex t_rinex4 t_time
+    t_rinex t_rinex4 t_sigcfg_decode t_time
     # t_tle excluded: tle_pos() implementation not yet in library
 )
 foreach(test IN LISTS _UTEST_SOURCES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,7 @@ enable_testing()
 set(_UTEST_DIR ${CMAKE_SOURCE_DIR}/tests/utest)
 set(_UTEST_SOURCES
     t_atmos t_coord t_geoid t_gloeph t_ionex
-    t_lambda t_matrix t_misc t_ppp t_preceph
+    t_lambda t_matrix t_misc t_obsdef t_ppp t_preceph
     t_rinex t_rinex4 t_time
     # t_tle excluded: tle_pos() implementation not yet in library
 )

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ is in the [CHANGELOG](CHANGELOG.md) and [release notes](docs/releases/):
 |-----|-------|
 | **v0.4.x** | demo5 RTK / PPP-RTK algorithm port (PAR, `detslp_dop` / `detslp_code`, full-constellation `varerr`, false-fix fixes); real-time CLAS PPP-RTK (1ch / 2ch) |
 | **v0.5.x** | TOML configuration; code-quality sweeps (`clang-format`, mandatory braces); signals restructuring; RINEX 4.00 CNAV; `convbin` / `str2str` ports |
-| **v0.6.x** | Unified `mrtk` CLI; NTRIP v2; `mrtk cssr2rtcm3` (CSSR→RTCM3); IGS-products float / RTS / integer PPP-AR (the `correction` axis); SPP accuracy; formatter CI gate; GSDC smartphone benchmark |
+| **v0.6.x** | Unified `mrtk` CLI; NTRIP v2; `mrtk cssr2rtcm3` (CSSR→RTCM3); IGS-products float / RTS / integer PPP-AR (the `correction` axis); SPP accuracy; formatter CI gate; GSDC smartphone benchmark; real-time MADOCA-PPP multi-GNSS signal selection |
 
-**Latest — v0.6.11:** developer experience / tooling (no positioning change — outputs bit-identical to v0.6.10) — enforced formatter CI gate + repo-wide format baseline ([#166](https://github.com/h-shiono/MRTKLIB/issues/166)), GSDC-2023 smartphone SPP benchmark ([#165](https://github.com/h-shiono/MRTKLIB/issues/165)), and faster network-free regression CI
+**Latest — v0.6.12:** real-time MADOCA-PPP multi-GNSS signal selection — Galileo / QZSS now used in `mrtk run` ([#184](https://github.com/h-shiono/MRTKLIB/issues/184)), GLONASS L2C/A selectable via `[positioning].signals` on Septentrio/SBF ([#187](https://github.com/h-shiono/MRTKLIB/issues/187)), and obsdef signal tables made idempotent across `rtkrcv` restarts ([#186](https://github.com/h-shiono/MRTKLIB/issues/186)). Real-time positioning change; post-processing outputs unchanged.
 
-**Next:** tuned SPP P5/P6 (clock-jump + position EKF) on the GSDC smartphone benchmark ([#165](https://github.com/h-shiono/MRTKLIB/issues/165)); Doxygen docstring coverage
+**Next:** extend `signals`-driven decoder code selection to the remaining decoders / RTCM3 / `convbin` ([#189](https://github.com/h-shiono/MRTKLIB/issues/189)); tuned SPP P5/P6 (clock-jump + position EKF) on the GSDC smartphone benchmark ([#165](https://github.com/h-shiono/MRTKLIB/issues/165))
 
 > [!NOTE]
 > demo5 algorithm improvements are adapted from **[demo5 RTKLIB](https://github.com/rtklibexplorer/RTKLIB)**

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License](https://img.shields.io/badge/License-BSD_2--Clause-blue.svg)](LICENSE)
 [![Build](https://img.shields.io/badge/build-CMake-success.svg)]()
 [![C11](https://img.shields.io/badge/standard-C11-blue.svg)]()
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20373746.svg)](https://doi.org/10.5281/zenodo.20373746)
 
 **MRTKLIB** is a completely modernized, thread-safe, and modularized C11 library for standard and precise GNSS positioning.
 
@@ -142,6 +143,25 @@ The codebase is fully documented using Doxygen. To generate the API reference an
 cmake --build build --target doc
 ```
 Documentation will be generated in `build/doc/html/index.html`.
+
+## 📚 How to Cite
+
+If you use MRTKLIB in your research or product, please cite it via its archived
+release on [Zenodo](https://zenodo.org/). You can cite **all versions** by using
+the concept DOI `10.5281/zenodo.20373746`; Zenodo also mints a version-specific
+DOI for each individual release.
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20373746.svg)](https://doi.org/10.5281/zenodo.20373746)
+
+```bibtex
+@software{mrtklib,
+  author    = {Shiono, Hayato},
+  title     = {{MRTKLIB: Modernized RTKLIB for Next-Generation GNSS}},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.20373746},
+  url       = {https://doi.org/10.5281/zenodo.20373746}
+}
+```
 
 ## 📄 License & Attributions
 MRTKLIB is distributed under the BSD 2-Clause License.

--- a/apps/rtkrcv/rtkrcv.c
+++ b/apps/rtkrcv/rtkrcv.c
@@ -532,11 +532,14 @@ static int startsvr(vt_t* vt) {
     }
 
     /* #184: apply PPP signal selection in the real-time path, mirroring the
-     * post-processing path (rnx2rtkp.c). Without this, the obsdef tables keep
-     * their defaults and the madocalib PPP engine only forms iono-free pairs
-     * for GPS, silently dropping Galileo/QZSS/GLONASS/BeiDou. As in post, IGS
+     * post-processing path (rnx2rtkp.c). apply_pppsig() reshapes the obsdef
+     * tables (GPS/QZS/GAL/BDS) that every receiver decoder consults via
+     * code2freq_idx(); without it a non-GPS 2nd band that differs from the
+     * default slot (e.g. GAL E5b, BDS B2I) is never mapped, so the madocalib
+     * PPP engine can only form the iono-free pair for GPS. As in post, IGS
      * precise-product PPP skips it (#135) so the receiver's actual 2nd band
-     * survives. */
+     * survives. (GLONASS is unaffected: apply_pppsig() does not touch it and
+     * its default G1/G2 obsdef already maps correctly.) */
     if (prcopt.correction != CORR_IGS) {
         apply_pppsig(prcopt.pppsig);
     }

--- a/apps/rtkrcv/rtkrcv.c
+++ b/apps/rtkrcv/rtkrcv.c
@@ -539,9 +539,18 @@ static int startsvr(vt_t* vt) {
      * PPP engine can only form the iono-free pair for GPS. As in post, IGS
      * precise-product PPP skips it (#135) so the receiver's actual 2nd band
      * survives. (GLONASS is unaffected: apply_pppsig() does not touch it and
-     * its default G1/G2 obsdef already maps correctly.) */
-    if (prcopt.correction != CORR_IGS) {
-        apply_pppsig(prcopt.pppsig);
+     * its default G1/G2 obsdef already maps correctly.)
+     *
+     * #186: reset to the pristine defaults first so a restart (the rtkrcv shell
+     * can `load` a new config and `restart` in the same process) that changes
+     * the correction or signal selection — including switching to correction=igs,
+     * which skips apply_pppsig — cannot inherit a previously trimmed obsdef.
+     * sigcfg-configured obsdef (pos1-signals) is left untouched. */
+    if (!prcopt.sigcfg_set) {
+        reset_obsdef();
+        if (prcopt.correction != CORR_IGS) {
+            apply_pppsig(prcopt.pppsig);
+        }
     }
 
     /* read start commads from command files */

--- a/apps/rtkrcv/rtkrcv.c
+++ b/apps/rtkrcv/rtkrcv.c
@@ -531,6 +531,16 @@ static int startsvr(vt_t* vt) {
         }
     }
 
+    /* #184: apply PPP signal selection in the real-time path, mirroring the
+     * post-processing path (rnx2rtkp.c). Without this, the obsdef tables keep
+     * their defaults and the madocalib PPP engine only forms iono-free pairs
+     * for GPS, silently dropping Galileo/QZSS/GLONASS/BeiDou. As in post, IGS
+     * precise-product PPP skips it (#135) so the receiver's actual 2nd band
+     * survives. */
+    if (prcopt.correction != CORR_IGS) {
+        apply_pppsig(prcopt.pppsig);
+    }
+
     /* read start commads from command files */
     for (i = 0; i < 3; i++) {
         if (!*rcvcmds[i]) {

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -37,7 +37,9 @@ TOML section: `[positioning]`
 | `satellite_ephemeris` | enum | All | Satellite ephemeris source. SSR modes (`brdc+ssrapc`, `brdc+ssrcom`) are used for PPP and PPP-RTK. `brdc` · `precise` · `brdc+sbas` · `brdc+ssrapc` · `brdc+ssrcom` |
 | `systems` | string[] | All | GNSS constellations to use. Accepts a human-readable string list like `["GPS", "Galileo"]`. |
 | `excluded_sats` | string | All | Satellites to exclude. Space-separated PRN list (e.g., `G01 G02`). Prefix `+` to include only. |
-| `signals` | string[] | All | Explicit signal code list. Overrides default observation definition when set. e.g. `["G1C", "G2W", "E1C"]` |
+| `signals` | string[] | All | Explicit RINEX3-style signal code list (`{sys}{freq}{attr}`, e.g. `["G1C", "G2W", "R1C", "R2C", "E1C", "E7Q", "J1C", "J2L"]`). When set it is the **authoritative** signal selection: it overrides `frequency` / the `[signals]` presets, derives the number of frequencies, **and** selects which observation code occupies each band's slot during real-time raw decoding (so e.g. GLONASS L2C/A can be used as the iono-free 2nd frequency without the legacy `-RL2C` receiver option — see [#189](https://github.com/h-shiono/MRTKLIB/issues/189)). List **every** band you want, for every constellation you want to constrain — `signals = ["R2C"]` alone derives nf=1 (single-frequency). A constellation you omit entirely keeps its default signal selection. |
+
+> **Recommended surface.** `[positioning].signals` is the preferred way to select signals. The `[signals]` section (`gps`/`qzs`/`galileo`/`bds2`/`bds3` presets) and `frequency` are the older, coarser mechanism (no per-code control, and **no GLONASS entry**, which is why GLONASS L2 code selection requires `signals`). When `signals` is set it takes precedence.
 
 ### Frequency Index Mapping
 
@@ -270,6 +272,8 @@ TOML section: `[adaptive_filter]`
 ## Signal Selection
 
 TOML section: `[signals]`
+
+> **Legacy preset form.** These per-constellation presets are the older, coarser signal-selection surface (no per-code control, no GLONASS entry). Prefer [`[positioning].signals`](#positioning) for new configurations; when `signals` is set it overrides this section. GLONASS L2 code selection (e.g. L2C/A vs L2P) can only be expressed via `[positioning].signals`.
 
 | TOML Key | Type | Modes | Description |
 |:---------|:-----|:------|:------------|

--- a/docs/releases/release-notes-v0.6.12.md
+++ b/docs/releases/release-notes-v0.6.12.md
@@ -1,0 +1,124 @@
+# Release Notes — v0.6.12
+
+## Real-time MADOCA-PPP multi-GNSS signal selection
+
+**Release date:** 2026-06-03
+**Type:** Positioning feature — real-time MADOCA-PPP now uses non-GPS constellations (post-processing outputs unchanged)
+**Branch:** `release/v0.6.12`
+
+---
+
+### Overview
+
+v0.6.12 brings the **real-time** (`mrtk run`) MADOCA-PPP path up to parity with
+post-processing for non-GPS constellations. Before this release, real-time
+MADOCA-PPP effectively produced a GPS-only solution; this release makes
+Galileo and QZSS usable, lets GLONASS L2C/A be selected as the iono-free 2nd
+frequency, and hardens the signal-selection tables against in-process restarts.
+
+It bundles four issues, originally surfaced by an external bug report
+([#183](https://github.com/h-shiono/MRTKLIB/pull/183), thanks @hitoshimukai):
+
+1. **Non-GPS signals in real time** — Galileo / QZSS ([#184](https://github.com/h-shiono/MRTKLIB/issues/184), PR #185)
+2. **obsdef idempotency across restarts** ([#186](https://github.com/h-shiono/MRTKLIB/issues/186), PR #188)
+3. **GLONASS L2C/A via `[positioning].signals`** ([#187](https://github.com/h-shiono/MRTKLIB/issues/187), PR #190)
+4. **Docs**: `signals` positioned as the authoritative signal-selection surface
+
+> **Positioning impact.** Real-time MADOCA-PPP solutions now include more
+> constellations, so outputs differ from v0.6.11 (more satellites in the filter).
+> Post-processing (`mrtk post`) is unchanged.
+
+---
+
+### 1. Non-GPS signals in real-time MADOCA-PPP (#184, PR #185)
+
+The post-processing entry point calls `apply_pppsig()` after resolving the
+correction source, but the real-time server (`startsvr()`) never did. As a
+result the obsdef tables — consulted by every receiver decoder via
+`code2freq_idx()` — kept their defaults, the non-GPS 2nd band was not mapped into
+a frequency slot, and the madocalib PPP engine could only form the iono-free pair
+for GPS.
+
+`rtkrcv` now applies the configured PPP signal selection at server start,
+mirroring `mrtk post`. IGS precise-product PPP keeps skipping it (#135) so a
+receiver's actual 2nd band (e.g. GAL E5b / BDS B2I on a u-blox F9P) survives.
+Galileo and QZSS are now used in real-time MADOCA-PPP, confirmed by the reporter.
+
+### 2. obsdef idempotency across rtkrcv restarts (#186, PR #188)
+
+`set_obsdef()` rewrote the global obsdef tables in place (zeroing bands not in
+the selected pair), with no way to restore them — so a band trimmed by one
+selection could not be recovered by the next. In the `rtkrcv` shell a
+`load`+`restart` that changed the correction source or signal selection inherited
+a corrupted obsdef, mis-mapping frequency slots in later runs.
+
+`set_obsdef()` now rebuilds from a pristine default snapshot (captured before any
+mutation), and a new `reset_obsdef()` is applied before re-selecting signals at
+server start. The result is **bit-identical** to the previous behaviour on the
+first/single configuration; only repeated/changed selections within one process
+differ (the bug case). Guarded by `utest_t_obsdef`.
+
+### 3. GLONASS L2C/A via `[positioning].signals` (#187, PR #190)
+
+GLONASS was unused on a Septentrio **mosaic-CLAS** rover because the observations
+came out single-frequency (L1 C/A only) — no iono-free pair. mosaic-CLAS outputs
+GLONASS **L2C/A** (not L2P); the SBF decoder routes L2C/A to an extra observation
+slot unless the legacy `-RL2C` option is set, and `rtkrcv` had no way to pass it.
+
+`obsdef` is band-level and cannot distinguish L2C from L2P, but the signal config
+parsed from `[positioning].signals` already carries a per-band **preferred code**.
+This release consumes it: a new `mrtk_sigcfg_freq_idx()` helper resolves the
+observation slot from sigcfg, and `raw_t` carries the configured `sigcfg`. With
+
+```toml
+[positioning]
+signals = ["G1C", "G2W", "R1C", "R2C", "E1C", "E7Q", "J1C", "J2L"]  # nf=2; GLONASS 2nd band = L2C/A
+```
+
+GLONASS L2C/A is placed in the iono-free 2nd frequency with no `-RL2C`. Guarded by
+`utest_t_sigcfg_decode`.
+
+**Phase 1 covers the Septentrio (SBF) decoder** — which is the mosaic-CLAS case.
+The remaining decoders (NovAtel / JAVAD / u-blox / BINEX), the RTCM3 observation
+path and `convbin` are tracked in
+[#189](https://github.com/h-shiono/MRTKLIB/issues/189) (Phase 2). The `-R/-G`
+receiver options remain as the fallback when `signals` is unset, so existing
+configurations are unaffected.
+
+### 4. `signals` is now the recommended signal-selection surface
+
+`[positioning].signals` (RINEX3-style tokens, e.g. `"R2C"`) is the authoritative
+way to select signals: it overrides `frequency` and the `[signals]` presets,
+derives the number of frequencies, **and** drives decoder code selection. List
+every band you want — `signals = ["R2C"]` alone derives a single frequency. The
+`[signals]` preset section (`gps`/`qzs`/`galileo`/`bds2`/`bds3`) is now documented
+as **legacy**: coarse, no per-code control, and **no GLONASS entry** (which is why
+GLONASS L2 code selection requires `signals`). See
+[Configuration Options](../reference/config-options.md).
+
+---
+
+### Compatibility & migration
+
+- **Real-time MADOCA-PPP users**: no config change is required to gain Galileo /
+  QZSS. To use GLONASS on an L2C/A-only receiver, switch from the `[signals]`
+  presets / `frequency` to a full `[positioning].signals` list that includes
+  `"R2C"` (see §3). An L2P-capable receiver works without any change.
+- **Everyone else**: when `[positioning].signals` is unset, signal selection and
+  raw decoding are unchanged (legacy `-R/-G` path); post-processing is unchanged.
+
+### Tests
+
+Full `ctest` regression: only the two documented pre-existing environment/numerical
+failures (`rtkrcv_rt` headless replay, `madocalib_pppar_ion_check` LAPACK
+tolerance); no new failures. Two new env-independent unit tests added
+(`utest_t_obsdef`, `utest_t_sigcfg_decode`). clang-format 21.1.6 clean; no test
+tolerances changed.
+
+### Issues / PRs
+
+- [#184](https://github.com/h-shiono/MRTKLIB/issues/184) / PR #185 — non-GPS signals in real-time MADOCA-PPP
+- [#186](https://github.com/h-shiono/MRTKLIB/issues/186) / PR #188 — obsdef idempotency across restarts
+- [#187](https://github.com/h-shiono/MRTKLIB/issues/187) / PR #190 — GLONASS L2C/A via `[positioning].signals`
+- [#189](https://github.com/h-shiono/MRTKLIB/issues/189) — Phase 2 (remaining decoders / RTCM3 / convbin), open
+- [#183](https://github.com/h-shiono/MRTKLIB/pull/183) — originating external report (thanks @hitoshimukai)

--- a/include/mrtklib/mrtk_nav.h
+++ b/include/mrtklib/mrtk_nav.h
@@ -551,6 +551,14 @@ int freq_idx2ant_idx(int sys, int freq_idx);
 void set_obsdef(int sys, const int* freq_nums);
 
 /**
+ * @brief Reset all obsdef tables to their pristine default frequency layout.
+ * @note #186: restores the full multi-band tables so a repeated/changed signal
+ *       selection (e.g. an rtkrcv restart, or switching to correction=igs which
+ *       skips apply_pppsig()) does not inherit a previously trimmed layout.
+ */
+void reset_obsdef(void);
+
+/**
  * @brief Apply PPP signal selection options to obsdef tables.
  * @param[in] pppsig  Signal selection array [5]: GPS,QZS,GAL,BDS2,BDS3
  */

--- a/include/mrtklib/mrtk_obs.h
+++ b/include/mrtklib/mrtk_obs.h
@@ -284,6 +284,29 @@ int mrtk_sigcfg_from_signals(const char** sigs, int nsig, mrtk_sigcfg_t* cfg, in
  */
 int mrtk_sigcfg_to_obsdef(const mrtk_sigcfg_t* cfg);
 
+/** @brief mrtk_sigcfg_freq_idx() sentinel: this constellation has no sigcfg
+ *         entry, so the caller should fall back to its default (-R/-G/...)
+ *         option logic. Distinct from -1 (drop) and from valid slot indices. */
+#define MRTK_SIGCFG_NOOPINION (-2)
+
+/**
+ * @brief Resolve the observation slot for a decoded (sys, code) from sigcfg.
+ *
+ * #189: lets `[positioning].signals` (sigcfg) drive raw-decoder code selection,
+ * so e.g. GLONASS L2C/A can be placed in the iono-free 2nd frequency without the
+ * legacy `-RL2C` receiver option. obsdef is band-level (cannot distinguish L2C
+ * from L2P); sigcfg carries the per-band preferred code, which this consults.
+ *
+ * @param[in] sys   Satellite system (SYS_???)
+ * @param[in] code  Observation code (CODE_???) just decoded
+ * @param[in] cfg   Per-constellation signal config array [MRTK_NSYS]
+ * @param[in] nex   Number of extra observation slots available (NEXOBS)
+ * @return main slot 0..NFREQ-1 (code selected for its band); -1 to drop (code
+ *         not selected, or its band not configured for this system);
+ *         MRTK_SIGCFG_NOOPINION if this system has no sigcfg entry.
+ */
+int mrtk_sigcfg_freq_idx(int sys, uint8_t code, const mrtk_sigcfg_t* cfg, int nex);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/mrtklib/mrtk_rcvraw.h
+++ b/include/mrtklib/mrtk_rcvraw.h
@@ -101,8 +101,10 @@ typedef struct {
     int outtype;                            /**< output message type */
     uint8_t buff[MAXRAWLEN];                /**< message buffer */
     char opt[256];                          /**< receiver dependent options */
-    int format;                             /**< receiver stream format */
-    void* rcv_data;                         /**< receiver dependent data */
+    mrtk_sigcfg_t sigcfg[MRTK_NSYS]; /**< #189: per-constellation signal config (drives decoder code selection) */
+    int sigcfg_set;                  /**< #189: 1 if sigcfg is configured (else fall back to opt/-Rxxx defaults) */
+    int format;                      /**< receiver stream format */
+    void* rcv_data;                  /**< receiver dependent data */
 } raw_t;
 
 /*============================================================================

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,8 @@ nav:
     - Positioning Configuration Model: design/configuration.md
   - Releases:
     - Changelog: releases/changelog.md
+    - v0.6.12: releases/release-notes-v0.6.12.md
+    - v0.6.11: releases/release-notes-v0.6.11.md
     - v0.6.10: releases/release-notes-v0.6.10.md
     - v0.6.9: releases/release-notes-v0.6.9.md
     - v0.6.8: releases/release-notes-v0.6.8.md

--- a/src/data/mrtk_nav.c
+++ b/src/data/mrtk_nav.c
@@ -275,6 +275,78 @@ static obsdef_t* get_obsdef(int sys) {
             return NULL;
     }
 }
+/* pristine default snapshots of the obsdef tables ----------------------------
+ * #186: set_obsdef() rewrites the working tables in place, zeroing the bands
+ * not in the selected pair. Without a pristine reference, signal selection is
+ * not idempotent across rtkrcv restarts — a band trimmed by one selection
+ * cannot be restored by a later one, and switching to correction=igs (which
+ * skips apply_pppsig) leaves the tables trimmed. We snapshot the default tables
+ * on first use, before any mutation, so set_obsdef() / reset_obsdef() can always
+ * rebuild from them. The working-table initialisers above stay the single
+ * source of truth for the default values.
+ *---------------------------------------------------------------------------*/
+static obsdef_t obsdef_GPS_def[MAXFREQ], obsdef_GLO_def[MAXFREQ], obsdef_GAL_def[MAXFREQ], obsdef_QZS_def[MAXFREQ],
+    obsdef_SBS_def[MAXFREQ], obsdef_BDS_def[MAXFREQ], obsdef_BD2_def[MAXFREQ], obsdef_IRN_def[MAXFREQ];
+static int obsdef_defaults_saved = 0;
+
+/* helper: select pristine-default obsdef table by system (mirrors get_obsdef) */
+static obsdef_t* get_obsdef_default(int sys) {
+    switch (sys) {
+        case SYS_GPS:
+            return obsdef_GPS_def;
+        case SYS_GLO:
+            return obsdef_GLO_def;
+        case SYS_GAL:
+            return obsdef_GAL_def;
+        case SYS_QZS:
+            return obsdef_QZS_def;
+        case SYS_SBS:
+            return obsdef_SBS_def;
+        case SYS_CMP:
+            return obsdef_BDS_def;
+        case SYS_BD2:
+            return obsdef_BD2_def;
+        case SYS_IRN:
+            return obsdef_IRN_def;
+        default:
+            return NULL;
+    }
+}
+
+/* capture the pristine default tables on first use (before any mutation) */
+static void save_obsdef_defaults(void) {
+    if (obsdef_defaults_saved) {
+        return;
+    }
+    memcpy(obsdef_GPS_def, obsdef_GPS, sizeof(obsdef_GPS));
+    memcpy(obsdef_GLO_def, obsdef_GLO, sizeof(obsdef_GLO));
+    memcpy(obsdef_GAL_def, obsdef_GAL, sizeof(obsdef_GAL));
+    memcpy(obsdef_QZS_def, obsdef_QZS, sizeof(obsdef_QZS));
+    memcpy(obsdef_SBS_def, obsdef_SBS, sizeof(obsdef_SBS));
+    memcpy(obsdef_BDS_def, obsdef_BDS, sizeof(obsdef_BDS));
+    memcpy(obsdef_BD2_def, obsdef_BD2, sizeof(obsdef_BD2));
+    memcpy(obsdef_IRN_def, obsdef_IRN, sizeof(obsdef_IRN));
+    obsdef_defaults_saved = 1;
+}
+
+/* reset obsdef tables to their pristine defaults -----------------------------
+ * #186: restore the full multi-band tables, e.g. before re-applying signal
+ * selection on an rtkrcv restart, or when switching to correction=igs (which
+ * skips apply_pppsig and must see the receiver's actual bands, #135).
+ * return : none
+ *-----------------------------------------------------------------------------*/
+extern void reset_obsdef(void) {
+    save_obsdef_defaults();
+    memcpy(obsdef_GPS, obsdef_GPS_def, sizeof(obsdef_GPS));
+    memcpy(obsdef_GLO, obsdef_GLO_def, sizeof(obsdef_GLO));
+    memcpy(obsdef_GAL, obsdef_GAL_def, sizeof(obsdef_GAL));
+    memcpy(obsdef_QZS, obsdef_QZS_def, sizeof(obsdef_QZS));
+    memcpy(obsdef_SBS, obsdef_SBS_def, sizeof(obsdef_SBS));
+    memcpy(obsdef_BDS, obsdef_BDS_def, sizeof(obsdef_BDS));
+    memcpy(obsdef_BD2, obsdef_BD2_def, sizeof(obsdef_BD2));
+    memcpy(obsdef_IRN, obsdef_IRN_def, sizeof(obsdef_IRN));
+}
+
 /* set observation definition by frequency number array -----------------------
  * rearrange obsdef table so that freq_nums[0..MAXFREQ-1] appear at indices
  * 0,1,2,... — used to apply pos2-sig* signal selection options.
@@ -283,30 +355,34 @@ static obsdef_t* get_obsdef(int sys) {
  * return : none
  *-----------------------------------------------------------------------------*/
 extern void set_obsdef(int sys, const int* freq_nums) {
-    obsdef_t obsdef_tmp[MAXFREQ] = {{0}};
     obsdef_t* obsdef;
+    const obsdef_t* def;
     obsdef_t obsdef0 = {0};
     int i, j;
 
-    if (!(obsdef = get_obsdef(sys))) {
+    save_obsdef_defaults();
+
+    if (!(obsdef = get_obsdef(sys)) || !(def = get_obsdef_default(sys))) {
         return;
     }
-
+    /* #186: rebuild from the pristine defaults (not the current table) so a band
+       trimmed by a previous selection can still be restored — idempotent. On the
+       first call the defaults equal the current table, so the result is
+       bit-identical to the historical in-place behaviour. */
     for (i = 0; i < MAXFREQ; i++) {
-        obsdef_tmp[i] = obsdef[i];
         obsdef[i] = obsdef0;
     }
     for (i = 0; i < MAXFREQ; i++) {
         for (j = 0; j < MAXFREQ; j++) {
-            if (obsdef_tmp[j].freq_num == freq_nums[i]) {
+            if (def[j].freq_num == freq_nums[i]) {
                 break;
             }
         }
         if (j == MAXFREQ) {
             continue;
         }
-        obsdef[i].freq_num = obsdef_tmp[j].freq_num;
-        obsdef[i].freq_hz = obsdef_tmp[j].freq_hz;
+        obsdef[i].freq_num = def[j].freq_num;
+        obsdef[i].freq_hz = def[j].freq_hz;
     }
 }
 /* apply PPP signal selection options to obsdef tables -----------------------

--- a/src/data/mrtk_obs.c
+++ b/src/data/mrtk_obs.c
@@ -1269,3 +1269,40 @@ extern int mrtk_sigcfg_to_obsdef(const mrtk_sigcfg_t* cfg) {
     }
     return 0;
 }
+/* mrtk_sigcfg_freq_idx: sigcfg-driven obs slot for a decoded (sys,code) -------
+ * #189: see mrtk_obs.h. When a constellation is configured in sigcfg, the
+ * decoded code is kept only if it is the preferred code for one of the
+ * configured bands (placed at that band's obsdef slot); any other code — a
+ * non-preferred code on a configured band, or any code on a non-configured
+ * band — is dropped. A constellation with no sigcfg entry yields NOOPINION so
+ * the caller keeps its legacy (-R/-G/... option) behaviour.
+ *-----------------------------------------------------------------------------*/
+extern int mrtk_sigcfg_freq_idx(int sys, uint8_t code, const mrtk_sigcfg_t* cfg, int nex) {
+    int sys_idx = sys2sigcfg_idx(sys);
+    int fn, base_idx, i;
+    const mrtk_sigcfg_t* c;
+
+    (void)nex; /* non-selected codes are dropped, not retained as extra obs (phase 1) */
+
+    if (sys_idx < 0 || !cfg) {
+        return MRTK_SIGCFG_NOOPINION;
+    }
+    c = &cfg[sys_idx];
+    if (c->nsig <= 0) {
+        return MRTK_SIGCFG_NOOPINION; /* system not configured: fall back to defaults */
+    }
+
+    fn = code2freq_num(code); /* this code's band (by frequency number) */
+    for (i = 0; i < c->nsig; i++) {
+        if (mrtk_band_to_freq_num(sys, c->sig[i].band) != fn) {
+            continue; /* different band */
+        }
+        /* band is configured: accept only the preferred code (0 = auto/any) */
+        if (c->sig[i].preferred_code == 0 || c->sig[i].preferred_code == code) {
+            base_idx = code2freq_idx(sys, code);
+            return (base_idx >= 0 && base_idx < NFREQ) ? base_idx : -1;
+        }
+        return -1; /* a different code is preferred for this band */
+    }
+    return -1; /* band not configured for this (configured) system */
+}

--- a/src/data/mrtk_rcvraw.c
+++ b/src/data/mrtk_rcvraw.c
@@ -1700,6 +1700,8 @@ extern int init_raw(raw_t* raw, int format) {
         raw->buff[i] = 0;
     }
     raw->opt[0] = '\0';
+    memset(raw->sigcfg, 0, sizeof(raw->sigcfg)); /* #189: default = no sigcfg (legacy -R/-G path) */
+    raw->sigcfg_set = 0;
     raw->format = -1;
 
     raw->obs.data = NULL;

--- a/src/data/rcv/mrtk_rcv_septentrio.c
+++ b/src/data/rcv/mrtk_rcv_septentrio.c
@@ -281,13 +281,26 @@ static uint8_t sig_tbl[SBF_MAXSIG + 1][2] = {
     {SYS_QZS, CODE_L5Z}  /* 39: QZS L5S */
 };
 /* signal number to freq-index and code --------------------------------------*/
-static int sig2idx(int sat, int sig, const char* opt, uint8_t* code) {
+static int sig2idx(int sat, int sig, const raw_t* raw, uint8_t* code) {
+    const char* opt = raw->opt;
     int idx, sys = satsys(sat, NULL), nex = NEXOBS;
 
     if (sig < 0 || sig > SBF_MAXSIG || sig_tbl[sig][0] != sys) {
         return -1;
     }
     *code = sig_tbl[sig][1];
+
+    /* #189: when [positioning].signals (sigcfg) is configured, it is authoritative
+     * for per-band code selection (e.g. GLONASS L2C/A as the 2nd frequency). Fall
+     * through to the legacy -R/-G option logic only when this system has no sigcfg
+     * entry (NOOPINION). */
+    if (raw->sigcfg_set) {
+        int r = mrtk_sigcfg_freq_idx(sys, *code, raw->sigcfg, nex);
+        if (r != MRTK_SIGCFG_NOOPINION) {
+            return r;
+        }
+    }
+
     idx = code2freq_idx(sys, *code);
 
     /* resolve code priority in a freq-index */
@@ -431,7 +444,7 @@ static int decode_measepoch(raw_t* raw) {
         }
 
         /* Store Type-1 observation only if the signal is in obsdef */
-        if ((idx = sig2idx(sat, sig, raw->opt, &code)) >= 0) {
+        if ((idx = sig2idx(sat, sig, raw, &code)) >= 0) {
             if (P1 != 0.0) {
                 raw->obs.data[n].P[idx] = P1;
             }
@@ -471,7 +484,7 @@ static int decode_measepoch(raw_t* raw) {
                 trace(NULL, 3, "sbf measepoch ant error: sat=%d ant=%d\n", sat, ant);
                 continue;
             }
-            if ((idx = sig2idx(sat, sig, raw->opt, &code)) < 0) {
+            if ((idx = sig2idx(sat, sig, raw, &code)) < 0) {
                 trace(NULL, 3, "sbf measepoch sig error: sat=%d sig=%d\n", sat, sig);
                 continue;
             }

--- a/src/stream/mrtk_rtksvr.c
+++ b/src/stream/mrtk_rtksvr.c
@@ -1138,6 +1138,13 @@ extern int rtksvrstart(rtksvr_t* svr, int cycle, int buffsize, int* strs, char**
         strcpy(svr->raw[i].opt, rcvopts[i]);
         strcpy(svr->rtcm[i].opt, rcvopts[i]);
 
+        /* #189: propagate the configured signal selection to the raw decoder so
+         * `[positioning].signals` drives per-band code selection (e.g. GLONASS
+         * L2C/A as the 2nd frequency). Empty sigcfg leaves sigcfg_set=0 and the
+         * decoder keeps its legacy -R/-G option behaviour. */
+        memcpy(svr->raw[i].sigcfg, prcopt->sigcfg, sizeof(svr->raw[i].sigcfg));
+        svr->raw[i].sigcfg_set = prcopt->sigcfg_set;
+
         /* connect dgps corrections */
         svr->rtcm[i].dgps = svr->nav.dgps;
     }

--- a/tests/utest/t_obsdef.c
+++ b/tests/utest/t_obsdef.c
@@ -1,0 +1,73 @@
+/*------------------------------------------------------------------------------
+ * unit test : obsdef signal-selection idempotency and reset (#186)
+ *
+ * apply_pppsig()/set_obsdef() rewrite the global obsdef tables in place. This
+ * test guards that:
+ *   - selection rebuilds from the pristine defaults, so switching the selected
+ *     2nd band restores a band a previous selection had trimmed (idempotency);
+ *   - reset_obsdef() returns the tables to their full multi-band defaults.
+ * Before the #186 fix, a band zeroed by one selection could not be recovered by
+ * the next (it stayed 0), which corrupts code2freq_idx() slot mapping after an
+ * rtkrcv restart. Uses explicit checks (not assert) so it is robust under
+ * -DNDEBUG.
+ *-----------------------------------------------------------------------------*/
+#include <stdio.h>
+
+#include "mrtklib/rtklib.h"
+
+static int fails = 0;
+
+#define CHECK(cond, msg)                 \
+    do {                                 \
+        if (!(cond)) {                   \
+            printf("FAIL: %s\n", (msg)); \
+            fails++;                     \
+        } else {                         \
+            printf("ok  : %s\n", (msg)); \
+        }                                \
+    } while (0)
+
+static int gal(int idx) { return freq_idx2freq_num(SYS_GAL, idx); }
+static int gps(int idx) { return freq_idx2freq_num(SYS_GPS, idx); }
+
+int main(void) {
+    int pppsig[5];
+
+    /* 1. pristine defaults (the first reset_obsdef snapshots them) */
+    reset_obsdef();
+    CHECK(gal(0) == 1 && gal(1) == 5 && gal(2) == 7 && gal(3) == 6 && gal(4) == 8, "GAL pristine = E1,E5a,E5b,E6,E5ab");
+    CHECK(gps(0) == 1 && gps(1) == 2 && gps(2) == 5, "GPS pristine = L1,L2,L5");
+
+    /* 2. select GAL E1-E5b (pppsig[2]=1) and GPS L1-L5 (pppsig[0]=1) */
+    pppsig[0] = 1;
+    pppsig[1] = 0;
+    pppsig[2] = 1;
+    pppsig[3] = 0;
+    pppsig[4] = 0;
+    apply_pppsig(pppsig);
+    CHECK(gal(0) == 1 && gal(1) == 7 && gal(2) == 0, "GAL E1-E5b: idx1=E5b(7), idx2 trimmed");
+    CHECK(gps(0) == 1 && gps(1) == 5 && gps(2) == 0, "GPS L1-L5: idx1=L5(5), idx2 trimmed");
+
+    /* 3. #186 idempotency: switch GAL to E1-E5a and GPS to L1-L2 from the trimmed
+     *    state. The restored band must reappear (not stay 0). */
+    pppsig[0] = 0;
+    pppsig[2] = 0;
+    apply_pppsig(pppsig);
+    CHECK(gal(1) == 5, "GAL E1-E5a after E1-E5b: idx1 restored to E5a(5), not 0");
+    CHECK(gps(1) == 2, "GPS L1-L2 after L1-L5: idx1 restored to L2(2), not 0");
+
+    /* 4. reset_obsdef() restores the full multi-band defaults from any state */
+    pppsig[0] = 1;
+    pppsig[2] = 1;
+    apply_pppsig(pppsig); /* leave tables trimmed */
+    reset_obsdef();
+    CHECK(gal(1) == 5 && gal(2) == 7 && gal(3) == 6 && gal(4) == 8, "reset_obsdef restores GAL E5a/E5b/E6/E5ab");
+    CHECK(gps(2) == 5, "reset_obsdef restores GPS L5");
+
+    if (fails) {
+        printf("\n%d check(s) FAILED\n", fails);
+        return 1;
+    }
+    printf("\nall obsdef #186 checks passed\n");
+    return 0;
+}

--- a/tests/utest/t_sigcfg_decode.c
+++ b/tests/utest/t_sigcfg_decode.c
@@ -1,0 +1,60 @@
+/*------------------------------------------------------------------------------
+ * unit test : sigcfg-driven raw-decoder code selection (#189)
+ *
+ * Guards mrtk_sigcfg_freq_idx(), which lets [positioning].signals (sigcfg) drive
+ * which obs code occupies a band's slot during raw decoding — e.g. GLONASS L2C/A
+ * as the iono-free 2nd frequency without the legacy -RL2C receiver option.
+ * Uses explicit checks (not assert) so it is robust under -DNDEBUG.
+ *-----------------------------------------------------------------------------*/
+#include <stdio.h>
+
+#include "mrtklib/rtklib.h"
+
+static int fails = 0;
+
+#define CHECK(cond, msg)                 \
+    do {                                 \
+        if (!(cond)) {                   \
+            printf("FAIL: %s\n", (msg)); \
+            fails++;                     \
+        } else {                         \
+            printf("ok  : %s\n", (msg)); \
+        }                                \
+    } while (0)
+
+int main(void) {
+    /* full dual-frequency multi-GNSS list; GLONASS 2nd band = L2C/A (R2C) */
+    const char* sigs[] = {"G1C", "G2W", "R1C", "R2C", "E1C", "E7Q", "J1C", "J2L"};
+    mrtk_sigcfg_t cfg[MRTK_NSYS];
+    int nf = 0;
+
+    reset_obsdef();
+
+    CHECK(mrtk_sigcfg_from_signals(sigs, 8, cfg, &nf) == 0, "parse signals list");
+    CHECK(nf == 2, "derived nf == 2");
+
+    /* mirror the real flow: obsdef is rearranged from sigcfg before decoding */
+    CHECK(mrtk_sigcfg_to_obsdef(cfg) == 0, "apply sigcfg to obsdef");
+
+    /* GLONASS: L1 C/A -> slot 0; L2 C/A -> slot 1 (the #189 fix); L2P -> dropped */
+    CHECK(mrtk_sigcfg_freq_idx(SYS_GLO, CODE_L1C, cfg, NEXOBS) == 0, "GLO L1C/A -> main slot 0");
+    CHECK(mrtk_sigcfg_freq_idx(SYS_GLO, CODE_L2C, cfg, NEXOBS) == 1, "GLO L2C/A -> main slot 1 (R2C preferred)");
+    CHECK(mrtk_sigcfg_freq_idx(SYS_GLO, CODE_L2P, cfg, NEXOBS) == -1, "GLO L2P -> dropped (not the preferred R2 code)");
+
+    /* GPS: L2W selected (G2W) -> slot 1; L2L (2C-band, different code) -> dropped */
+    CHECK(mrtk_sigcfg_freq_idx(SYS_GPS, CODE_L2W, cfg, NEXOBS) == 1, "GPS L2W -> main slot 1 (G2W preferred)");
+    CHECK(mrtk_sigcfg_freq_idx(SYS_GPS, CODE_L2L, cfg, NEXOBS) == -1, "GPS L2L -> dropped (G2W preferred)");
+
+    /* a constellation absent from the list yields NOOPINION (caller keeps -R/-G defaults) */
+    CHECK(mrtk_sigcfg_freq_idx(SYS_CMP, CODE_L2I, cfg, NEXOBS) == MRTK_SIGCFG_NOOPINION,
+          "BDS not configured -> NOOPINION (legacy fallback)");
+
+    reset_obsdef();
+
+    if (fails) {
+        printf("\n%d check(s) FAILED\n", fails);
+        return 1;
+    }
+    printf("\nall sigcfg-decode #189 checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
## v0.6.12 — Real-time MADOCA-PPP multi-GNSS signal selection

Release PR: `release/v0.6.12` → `main`. Brings the real-time (`mrtk run`) MADOCA-PPP path up to parity with post-processing for non-GPS constellations.

**Type:** Positioning feature — real-time MADOCA-PPP now uses non-GPS constellations. Post-processing (`mrtk post`) outputs are unchanged.

### What's in it (already merged to `develop`)

- **Non-GPS signals in real time** — Galileo / QZSS now used in `mrtk run` ([#184](https://github.com/h-shiono/MRTKLIB/issues/184), PR #185): `rtkrcv` applies `apply_pppsig()` at server start, mirroring post.
- **obsdef idempotency across `rtkrcv` restarts** ([#186](https://github.com/h-shiono/MRTKLIB/issues/186), PR #188): `set_obsdef()` rebuilds from a pristine snapshot; `reset_obsdef()` added. Bit-identical on the first/single configuration.
- **GLONASS L2C/A via `[positioning].signals`** ([#187](https://github.com/h-shiono/MRTKLIB/issues/187), PR #190): the signal list drives raw-decoder code selection, so GLONASS L2C/A can be the iono-free 2nd frequency on a Septentrio/SBF L2C/A-only receiver (mosaic-CLAS) without `-RL2C`. **Phase 1 = Septentrio/SBF**; remaining decoders / RTCM3 / `convbin` tracked in [#189](https://github.com/h-shiono/MRTKLIB/issues/189) (Phase 2). `-R/-G` retained as the fallback when `signals` is unset.
- **Docs**: `[positioning].signals` documented as the authoritative signal-selection surface; the `[signals]` preset section marked legacy.
- **Tests**: new env-independent `utest_t_obsdef`, `utest_t_sigcfg_decode`.

Originating external report: [#183](https://github.com/h-shiono/MRTKLIB/pull/183) (thanks @hitoshimukai).

### Release artifacts in this PR

- `CMakeLists.txt`: version `0.6.11` → `0.6.12` (binary reports `MRTKLIB ver.0.6.12`)
- `CHANGELOG.md`: v0.6.12 section
- `docs/releases/release-notes-v0.6.12.md` (+ mkdocs nav, also restores the missing v0.6.11 entry)
- `README.md`: Latest / Next / v0.6.x summary

### Testing

Full `ctest` regression on `develop`: only the two documented pre-existing failures (`rtkrcv_rt` headless replay, `madocalib_pppar_ion_check` LAPACK tolerance); no new failures. clang-format 21.1.6 clean; no test tolerances changed.

### Post-merge

- Tag `v0.6.12` (annotated) on the merge commit. No GitHub Release page (minor version).
- Back-merge `main` → `develop`.

Closes #184
Closes #186
Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)
