### PR TITLE
chore: back-merge main into develop (v0.6.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,70 @@ All notable changes to MRTKLIB are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.6.12] - 2026-06-03
+
+**Real-time MADOCA-PPP multi-GNSS signal selection.** Brings the real-time
+(`mrtk run`) path up to parity with post-processing for non-GPS constellations:
+Galileo and QZSS are now used, GLONASS L2C/A can be selected, and the obsdef
+signal tables survive in-process restarts. **This is a positioning change** for
+real-time MADOCA-PPP (more constellations enter the solution); post-processing
+outputs are unchanged.
+
+### Added
+
+- **Non-GPS signals in real-time MADOCA-PPP** ([#184](https://github.com/h-shiono/MRTKLIB/issues/184),
+  PR #185) — `rtkrcv` now applies the configured PPP signal selection
+  (`apply_pppsig()`) at server start, mirroring the post-processing path. Without
+  it the obsdef tables kept their defaults and the engine could only form the
+  iono-free pair for GPS, silently dropping Galileo/QZSS/BeiDou. IGS-product PPP
+  still skips it (#135) so the receiver's actual 2nd band survives.
+- **`[positioning].signals` drives raw-decoder code selection**
+  ([#187](https://github.com/h-shiono/MRTKLIB/issues/187), PR #190) — the
+  signal list is now authoritative for which observation code occupies each
+  band's slot during decoding, so e.g. **GLONASS L2C/A** can be used as the
+  iono-free 2nd frequency on an L2C/A-only receiver (Septentrio mosaic-CLAS)
+  without the legacy `-RL2C` option. New `mrtk_sigcfg_freq_idx()` helper;
+  `raw_t` carries the resolved `sigcfg`. **Phase 1 covers the Septentrio (SBF)
+  decoder**; other decoders, the RTCM3 obs path and `convbin` follow in
+  [#189](https://github.com/h-shiono/MRTKLIB/issues/189). The `-R/-G` receiver
+  options are retained as the fallback when `signals` is unset.
+- **Unit tests** — `utest_t_obsdef` (obsdef idempotency/reset) and
+  `utest_t_sigcfg_decode` (sigcfg-driven per-code slotting), both env-independent.
+
+### Changed
+
+- **obsdef signal selection is idempotent across `rtkrcv` restarts**
+  ([#186](https://github.com/h-shiono/MRTKLIB/issues/186), PR #188) —
+  `set_obsdef()` now rebuilds from a pristine default snapshot instead of mutating
+  in place, and a new `reset_obsdef()` is applied before re-selecting signals at
+  server start. A `load`+`restart` that changes the correction source or signal
+  selection (including switching to `correction = "igs"`, which skips
+  `apply_pppsig()`) can no longer inherit a trimmed obsdef. Bit-identical on the
+  first/single configuration.
+- **Docs** — `[positioning].signals` is documented as the recommended,
+  authoritative signal-selection surface (overrides `frequency` / the `[signals]`
+  presets, derives the frequency count, and drives decoder code selection). The
+  `[signals]` preset section is marked **legacy** (coarse, no per-code control,
+  no GLONASS entry). List every band you want — `signals = ["R2C"]` alone derives
+  a single frequency.
+
+### Fixed
+
+- **`init_raw()` initializes the new `raw_t.sigcfg`/`sigcfg_set` fields**
+  (PR #190 review) — `init_raw()` sets members individually, so the
+  `malloc()`+`init_raw()` paths (stream converter, `convbin`) could otherwise
+  evaluate the sigcfg-driven branch on uninitialized state. Defaults to the
+  legacy path.
+
+### Known limitations
+
+- Decoder code-selection from `[positioning].signals` is **Septentrio/SBF only**
+  in this release; the remaining decoders, RTCM3 observations and `convbin` are
+  tracked in [#189](https://github.com/h-shiono/MRTKLIB/issues/189) (Phase 2).
+- GLONASS in MADOCA-PPP requires dual-frequency observations (G1 + G2). On a
+  GLONASS-L2C/A receiver, list `"R2C"` in `[positioning].signals`; an L2P-capable
+  receiver works out-of-the-box.
+
 ## [v0.6.11] - 2026-05-25
 
 **Tooling / developer experience** — no positioning change; all binaries and

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(MRTKLIB VERSION 0.6.11 LANGUAGES C)
+project(MRTKLIB VERSION 0.6.12 LANGUAGES C)
 
 # ── Version header generation ─────────────────────────────────────────────────
 set(MRTKLIB_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ is in the [CHANGELOG](CHANGELOG.md) and [release notes](docs/releases/):
 |-----|-------|
 | **v0.4.x** | demo5 RTK / PPP-RTK algorithm port (PAR, `detslp_dop` / `detslp_code`, full-constellation `varerr`, false-fix fixes); real-time CLAS PPP-RTK (1ch / 2ch) |
 | **v0.5.x** | TOML configuration; code-quality sweeps (`clang-format`, mandatory braces); signals restructuring; RINEX 4.00 CNAV; `convbin` / `str2str` ports |
-| **v0.6.x** | Unified `mrtk` CLI; NTRIP v2; `mrtk cssr2rtcm3` (CSSR→RTCM3); IGS-products float / RTS / integer PPP-AR (the `correction` axis); SPP accuracy; formatter CI gate; GSDC smartphone benchmark |
+| **v0.6.x** | Unified `mrtk` CLI; NTRIP v2; `mrtk cssr2rtcm3` (CSSR→RTCM3); IGS-products float / RTS / integer PPP-AR (the `correction` axis); SPP accuracy; formatter CI gate; GSDC smartphone benchmark; real-time MADOCA-PPP multi-GNSS signal selection |
 
-**Latest — v0.6.11:** developer experience / tooling (no positioning change — outputs bit-identical to v0.6.10) — enforced formatter CI gate + repo-wide format baseline ([#166](https://github.com/h-shiono/MRTKLIB/issues/166)), GSDC-2023 smartphone SPP benchmark ([#165](https://github.com/h-shiono/MRTKLIB/issues/165)), and faster network-free regression CI
+**Latest — v0.6.12:** real-time MADOCA-PPP multi-GNSS signal selection — Galileo / QZSS now used in `mrtk run` ([#184](https://github.com/h-shiono/MRTKLIB/issues/184)), GLONASS L2C/A selectable via `[positioning].signals` on Septentrio/SBF ([#187](https://github.com/h-shiono/MRTKLIB/issues/187)), and obsdef signal tables made idempotent across `rtkrcv` restarts ([#186](https://github.com/h-shiono/MRTKLIB/issues/186)). Real-time positioning change; post-processing outputs unchanged.
 
-**Next:** tuned SPP P5/P6 (clock-jump + position EKF) on the GSDC smartphone benchmark ([#165](https://github.com/h-shiono/MRTKLIB/issues/165)); Doxygen docstring coverage
+**Next:** extend `signals`-driven decoder code selection to the remaining decoders / RTCM3 / `convbin` ([#189](https://github.com/h-shiono/MRTKLIB/issues/189)); tuned SPP P5/P6 (clock-jump + position EKF) on the GSDC smartphone benchmark ([#165](https://github.com/h-shiono/MRTKLIB/issues/165))
 
 > [!NOTE]
 > demo5 algorithm improvements are adapted from **[demo5 RTKLIB](https://github.com/rtklibexplorer/RTKLIB)**

--- a/docs/releases/release-notes-v0.6.12.md
+++ b/docs/releases/release-notes-v0.6.12.md
@@ -1,0 +1,124 @@
+# Release Notes — v0.6.12
+
+## Real-time MADOCA-PPP multi-GNSS signal selection
+
+**Release date:** 2026-06-03
+**Type:** Positioning feature — real-time MADOCA-PPP now uses non-GPS constellations (post-processing outputs unchanged)
+**Branch:** `release/v0.6.12`
+
+---
+
+### Overview
+
+v0.6.12 brings the **real-time** (`mrtk run`) MADOCA-PPP path up to parity with
+post-processing for non-GPS constellations. Before this release, real-time
+MADOCA-PPP effectively produced a GPS-only solution; this release makes
+Galileo and QZSS usable, lets GLONASS L2C/A be selected as the iono-free 2nd
+frequency, and hardens the signal-selection tables against in-process restarts.
+
+It bundles four issues, originally surfaced by an external bug report
+([#183](https://github.com/h-shiono/MRTKLIB/pull/183), thanks @hitoshimukai):
+
+1. **Non-GPS signals in real time** — Galileo / QZSS ([#184](https://github.com/h-shiono/MRTKLIB/issues/184), PR #185)
+2. **obsdef idempotency across restarts** ([#186](https://github.com/h-shiono/MRTKLIB/issues/186), PR #188)
+3. **GLONASS L2C/A via `[positioning].signals`** ([#187](https://github.com/h-shiono/MRTKLIB/issues/187), PR #190)
+4. **Docs**: `signals` positioned as the authoritative signal-selection surface
+
+> **Positioning impact.** Real-time MADOCA-PPP solutions now include more
+> constellations, so outputs differ from v0.6.11 (more satellites in the filter).
+> Post-processing (`mrtk post`) is unchanged.
+
+---
+
+### 1. Non-GPS signals in real-time MADOCA-PPP (#184, PR #185)
+
+The post-processing entry point calls `apply_pppsig()` after resolving the
+correction source, but the real-time server (`startsvr()`) never did. As a
+result the obsdef tables — consulted by every receiver decoder via
+`code2freq_idx()` — kept their defaults, the non-GPS 2nd band was not mapped into
+a frequency slot, and the madocalib PPP engine could only form the iono-free pair
+for GPS.
+
+`rtkrcv` now applies the configured PPP signal selection at server start,
+mirroring `mrtk post`. IGS precise-product PPP keeps skipping it (#135) so a
+receiver's actual 2nd band (e.g. GAL E5b / BDS B2I on a u-blox F9P) survives.
+Galileo and QZSS are now used in real-time MADOCA-PPP, confirmed by the reporter.
+
+### 2. obsdef idempotency across rtkrcv restarts (#186, PR #188)
+
+`set_obsdef()` rewrote the global obsdef tables in place (zeroing bands not in
+the selected pair), with no way to restore them — so a band trimmed by one
+selection could not be recovered by the next. In the `rtkrcv` shell a
+`load`+`restart` that changed the correction source or signal selection inherited
+a corrupted obsdef, mis-mapping frequency slots in later runs.
+
+`set_obsdef()` now rebuilds from a pristine default snapshot (captured before any
+mutation), and a new `reset_obsdef()` is applied before re-selecting signals at
+server start. The result is **bit-identical** to the previous behaviour on the
+first/single configuration; only repeated/changed selections within one process
+differ (the bug case). Guarded by `utest_t_obsdef`.
+
+### 3. GLONASS L2C/A via `[positioning].signals` (#187, PR #190)
+
+GLONASS was unused on a Septentrio **mosaic-CLAS** rover because the observations
+came out single-frequency (L1 C/A only) — no iono-free pair. mosaic-CLAS outputs
+GLONASS **L2C/A** (not L2P); the SBF decoder routes L2C/A to an extra observation
+slot unless the legacy `-RL2C` option is set, and `rtkrcv` had no way to pass it.
+
+`obsdef` is band-level and cannot distinguish L2C from L2P, but the signal config
+parsed from `[positioning].signals` already carries a per-band **preferred code**.
+This release consumes it: a new `mrtk_sigcfg_freq_idx()` helper resolves the
+observation slot from sigcfg, and `raw_t` carries the configured `sigcfg`. With
+
+```toml
+[positioning]
+signals = ["G1C", "G2W", "R1C", "R2C", "E1C", "E7Q", "J1C", "J2L"]  # nf=2; GLONASS 2nd band = L2C/A
+```
+
+GLONASS L2C/A is placed in the iono-free 2nd frequency with no `-RL2C`. Guarded by
+`utest_t_sigcfg_decode`.
+
+**Phase 1 covers the Septentrio (SBF) decoder** — which is the mosaic-CLAS case.
+The remaining decoders (NovAtel / JAVAD / u-blox / BINEX), the RTCM3 observation
+path and `convbin` are tracked in
+[#189](https://github.com/h-shiono/MRTKLIB/issues/189) (Phase 2). The `-R/-G`
+receiver options remain as the fallback when `signals` is unset, so existing
+configurations are unaffected.
+
+### 4. `signals` is now the recommended signal-selection surface
+
+`[positioning].signals` (RINEX3-style tokens, e.g. `"R2C"`) is the authoritative
+way to select signals: it overrides `frequency` and the `[signals]` presets,
+derives the number of frequencies, **and** drives decoder code selection. List
+every band you want — `signals = ["R2C"]` alone derives a single frequency. The
+`[signals]` preset section (`gps`/`qzs`/`galileo`/`bds2`/`bds3`) is now documented
+as **legacy**: coarse, no per-code control, and **no GLONASS entry** (which is why
+GLONASS L2 code selection requires `signals`). See
+[Configuration Options](../reference/config-options.md).
+
+---
+
+### Compatibility & migration
+
+- **Real-time MADOCA-PPP users**: no config change is required to gain Galileo /
+  QZSS. To use GLONASS on an L2C/A-only receiver, switch from the `[signals]`
+  presets / `frequency` to a full `[positioning].signals` list that includes
+  `"R2C"` (see §3). An L2P-capable receiver works without any change.
+- **Everyone else**: when `[positioning].signals` is unset, signal selection and
+  raw decoding are unchanged (legacy `-R/-G` path); post-processing is unchanged.
+
+### Tests
+
+Full `ctest` regression: only the two documented pre-existing environment/numerical
+failures (`rtkrcv_rt` headless replay, `madocalib_pppar_ion_check` LAPACK
+tolerance); no new failures. Two new env-independent unit tests added
+(`utest_t_obsdef`, `utest_t_sigcfg_decode`). clang-format 21.1.6 clean; no test
+tolerances changed.
+
+### Issues / PRs
+
+- [#184](https://github.com/h-shiono/MRTKLIB/issues/184) / PR #185 — non-GPS signals in real-time MADOCA-PPP
+- [#186](https://github.com/h-shiono/MRTKLIB/issues/186) / PR #188 — obsdef idempotency across restarts
+- [#187](https://github.com/h-shiono/MRTKLIB/issues/187) / PR #190 — GLONASS L2C/A via `[positioning].signals`
+- [#189](https://github.com/h-shiono/MRTKLIB/issues/189) — Phase 2 (remaining decoders / RTCM3 / convbin), open
+- [#183](https://github.com/h-shiono/MRTKLIB/pull/183) — originating external report (thanks @hitoshimukai)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,8 @@ nav:
     - Positioning Configuration Model: design/configuration.md
   - Releases:
     - Changelog: releases/changelog.md
+    - v0.6.12: releases/release-notes-v0.6.12.md
+    - v0.6.11: releases/release-notes-v0.6.11.md
     - v0.6.10: releases/release-notes-v0.6.10.md
     - v0.6.9: releases/release-notes-v0.6.9.md
     - v0.6.8: releases/release-notes-v0.6.8.md


### PR DESCRIPTION
Back-merge of the v0.6.12 release commit from `main` into `develop` (tag `v0.6.12` is on the `main` merge commit f84f207).

Brings the version bump (0.6.12), CHANGELOG entry, `release-notes-v0.6.12.md`, mkdocs nav, and README updates onto `develop`. No code changes — all v0.6.12 code was already on `develop` before the release.

Merge-commit only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)