### PR TITLE
refactor(convrnx): unify frequency indexing on code2freq_idx (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to MRTKLIB are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **RINEX converter unified on obsdef frequency indexing**
+  ([#71](https://github.com/h-shiono/MRTKLIB/issues/71)) — `mrtk convert`
+  (convrnx) now derives observation-type frequency indices from
+  `code2freq_idx()`, the obsdef-based mapping already used by every receiver
+  decoder, the RINEX parser, RTCM3 and CLAS. The legacy fixed per-band
+  `code2idx()` / `band2idx_fixed()` are removed. **Output change (converter
+  only, no positioning impact):** RINEX obs-type columns now follow obsdef band
+  order, so Galileo lists **E5a before E5b** and QZSS lists **L5 before L2**
+  (BeiDou columns reorder similarly). The `-freq N` band count keeps its
+  meaning but now selects the same N bands the positioning engines use.
+  Positioning output is byte-identical (the obsdef tables are untouched).
+
+### Known limitations
+
+`mrtk convert` does not emit two rare signals that have no slot in the obsdef
+frequency tables. Adding slots for them would perturb GLONASS / BeiDou
+positioning, so the tables are intentionally left as-is
+([#71](https://github.com/h-shiono/MRTKLIB/issues/71)):
+
+- **GLONASS G3 (CDMA, GLONASS-K2 only)** — no `obsdef_GLO` slot.
+- **BeiDou B2a+b (AltBOC)** — maps to the 6th obsdef slot, beyond the
+  converter's 5-band `-freq` mask.
+
+### Tests
+
+- `utest_t_freqidx` — pins the `code2freq_idx()` (sys, code) → frequency-index
+  contract for GPS/GLONASS/Galileo/QZSS/BeiDou, including the GLONASS G3
+  regression guard.
+
 ## [v0.6.12] - 2026-06-03
 
 **Real-time MADOCA-PPP multi-GNSS signal selection.** Brings the real-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `code2idx()` / `band2idx_fixed()` are removed. **Output change (converter
   only, no positioning impact):** RINEX obs-type columns now follow obsdef band
   order, so Galileo lists **E5a before E5b** and QZSS lists **L5 before L2**
-  (BeiDou columns reorder similarly). The `-freq N` band count keeps its
-  meaning but now selects the same N bands the positioning engines use.
+  (BeiDou columns reorder similarly). The `-f` / `--freq N` band count keeps
+  its meaning but now selects the same N bands the positioning engines use.
   Positioning output is byte-identical (the obsdef tables are untouched).
 
 ### Known limitations
@@ -30,7 +30,7 @@ positioning, so the tables are intentionally left as-is
 
 - **GLONASS G3 (CDMA, GLONASS-K2 only)** — no `obsdef_GLO` slot.
 - **BeiDou B2a+b (AltBOC)** — maps to the 6th obsdef slot, beyond the
-  converter's 5-band `-freq` mask.
+  converter's 5-band `--freq` mask.
 
 ### Tests
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,7 @@ enable_testing()
 # ── Unit tests ───────────────────────────────────────────────────────────────
 set(_UTEST_DIR ${CMAKE_SOURCE_DIR}/tests/utest)
 set(_UTEST_SOURCES
-    t_atmos t_coord t_geoid t_gloeph t_ionex
+    t_atmos t_coord t_freqidx t_geoid t_gloeph t_ionex
     t_lambda t_matrix t_misc t_obsdef t_ppp t_preceph
     t_rinex t_rinex4 t_sigcfg_decode t_time
     # t_tle excluded: tle_pos() implementation not yet in library

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -143,6 +143,31 @@ mrtk convert [options] rawfile
 mrtk convert -r ubx -v 3.04 --output obs.obs --nav nav.nav raw.ubx
 ```
 
+**Frequency ordering and `-freq N`.** Observation types are written in the
+library's obsdef band order — the same order the positioning engines use — so
+the *N*-th band selected by `-freq N` matches what `mrtk post` / `mrtk run`
+would use. Per constellation that order is:
+
+| System | band 1 | band 2 | band 3 | band 4 | band 5 |
+|--------|--------|--------|--------|--------|--------|
+| GPS | L1 | L2 | L5 | – | – |
+| GLONASS | G1 | G2 | – | – | – |
+| Galileo | E1 | **E5a** | **E5b** | E6 | E5a+b |
+| QZSS | L1 | **L5** | **L2** | L6 | – |
+| BeiDou | B1I | B3 | B2b | B1C | B2a |
+| SBAS | L1 | L5 | – | – | – |
+| NavIC | L5 | S | – | – | – |
+
+So `mrtk convert -f 2` keeps the first two bands of each system (e.g. Galileo
+E1 + E5a). All bands above are emitted at the default (`-f 5`).
+
+!!! note "Known limitations: GLONASS G3 and BeiDou B2a+b"
+    Two rare signals have no slot in the obsdef frequency tables and are not
+    emitted to RINEX: **GLONASS G3** (CDMA, GLONASS-K2 only) and **BeiDou
+    B2a+b** (AltBOC, beyond the converter's 5-band `-freq` mask). Adding slots
+    for them would perturb GLONASS / BeiDou positioning, so the tables are left
+    as-is (see [#71](https://github.com/h-shiono/MRTKLIB/issues/71)).
+
 ---
 
 ## Format Translation

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -143,10 +143,10 @@ mrtk convert [options] rawfile
 mrtk convert -r ubx -v 3.04 --output obs.obs --nav nav.nav raw.ubx
 ```
 
-**Frequency ordering and `-freq N`.** Observation types are written in the
-library's obsdef band order — the same order the positioning engines use — so
-the *N*-th band selected by `-freq N` matches what `mrtk post` / `mrtk run`
-would use. Per constellation that order is:
+**Frequency ordering and `-f` / `--freq N`.** Observation types are written in
+the library's obsdef band order — the same order the positioning engines use —
+so the *N*-th band selected by `-f N` (`--freq N`) matches what `mrtk post` /
+`mrtk run` would use. Per constellation that order is:
 
 | System | band 1 | band 2 | band 3 | band 4 | band 5 |
 |--------|--------|--------|--------|--------|--------|
@@ -164,7 +164,7 @@ E1 + E5a). All bands above are emitted at the default (`-f 5`).
 !!! note "Known limitations: GLONASS G3 and BeiDou B2a+b"
     Two rare signals have no slot in the obsdef frequency tables and are not
     emitted to RINEX: **GLONASS G3** (CDMA, GLONASS-K2 only) and **BeiDou
-    B2a+b** (AltBOC, beyond the converter's 5-band `-freq` mask). Adding slots
+    B2a+b** (AltBOC, beyond the converter's 5-band `--freq` mask). Adding slots
     for them would perturb GLONASS / BeiDou positioning, so the tables are left
     as-is (see [#71](https://github.com/h-shiono/MRTKLIB/issues/71)).
 

--- a/include/mrtklib/mrtk_obs.h
+++ b/include/mrtklib/mrtk_obs.h
@@ -88,14 +88,6 @@ uint8_t obs2code(const char* obs);
 char* code2obs(uint8_t code);
 
 /**
- * @brief Convert system and obs code to frequency index.
- * @param[in] sys   Satellite system (SYS_???)
- * @param[in] code  Obs code (CODE_???)
- * @return Frequency index (-1: error)
- */
-int code2idx(int sys, uint8_t code);
-
-/**
  * @brief Extract frequency number from obs code.
  * @param[in] code  Obs code (CODE_???)
  * @return Frequency number (1,2,5,...) (0: error)

--- a/src/data/mrtk_convrnx.c
+++ b/src/data/mrtk_convrnx.c
@@ -344,8 +344,8 @@ static void sort_obstype(uint8_t* codes, uint8_t* types, int n, int sys) {
 
     for (i = 0; i < n - 1; i++)
         for (j = i + 1; j < n; j++) {
-            idx1 = code2idx(navsys[sys], codes[i]);
-            idx2 = code2idx(navsys[sys], codes[j]);
+            idx1 = code2freq_idx(navsys[sys], codes[i]);
+            idx2 = code2freq_idx(navsys[sys], codes[j]);
             pri1 = getcodepri(navsys[sys], codes[i], "");
             pri2 = getcodepri(navsys[sys], codes[j], "");
             if (idx1 < idx2 || (idx1 == idx2 && pri1 >= pri2)) continue;
@@ -370,7 +370,7 @@ static void setopt_obstype(const uint8_t* codes, const uint8_t* types, int sys, 
     if (!(navsys[sys] & opt->navsys)) return;
 
     for (i = 0; codes[i]; i++) {
-        if (!(id = code2obs(codes[i])) || (idx = code2idx(navsys[sys], codes[i])) < 0) {
+        if (!(id = code2obs(codes[i])) || (idx = code2freq_idx(navsys[sys], codes[i])) < 0) {
             continue;
         }
         if (!(opt->freqtype & (1 << idx)) || opt->mask[sys][codes[i] - 1] == '0') {

--- a/src/data/mrtk_obs.c
+++ b/src/data/mrtk_obs.c
@@ -103,8 +103,6 @@ static char* obscodes[] = {
  * Private Functions
  *===========================================================================*/
 
-static int band2idx_fixed(mrtk_band_t band); /* forward declaration */
-
 /* compare observation data -------------------------------------------------*/
 static int cmpobs(const void* p1, const void* p2) {
     obsd_t *q1 = (obsd_t*)p1, *q2 = (obsd_t*)p2;
@@ -195,31 +193,6 @@ extern char* code2obs(uint8_t code) {
     }
     return obscodes[code];
 }
-/* system and obs code to frequency index --------------------------------------
- * convert system and obs code to frequency index
- * args   : int    sys       I   satellite system (SYS_???)
- *          uint8_t code     I   obs code (CODE_???)
- * return : frequency index (-1: error)
- *            freq-index    0        1        2        3        4
- *            Signal ID    L1       L2       L3       L4       L5
- *            -----------------------------------------------------
- *            GPS          L1       L2       L5        -        -
- *            GLONASS    G1/G1a   G2/G2a     G3        -        -
- *            Galileo      E1       E5b     E5a       E6      E5a+b
- *            QZSS         L1       L2       L5       L6        -
- *            SBAS         L1       L5       -         -        -
- *            BDS      B1/B1C/B1A B2/B2b    B2a     B3/B3A    B2a+b
- *            NavIC        L5        S       -         -        -
- *-----------------------------------------------------------------------------*/
-extern int code2idx(int sys, uint8_t code) {
-    int freq_num = code2freq_num(code);
-    mrtk_band_t band;
-    if (sys == SYS_BD2) {
-        sys = SYS_CMP;
-    }
-    band = mrtk_rinex_freq_to_band(sys, freq_num);
-    return band2idx_fixed(band);
-}
 /* obs code to frequency number ------------------------------------------------
  * extract frequency number from obs code
  * args   : uint8_t code     I   obs code (CODE_???)
@@ -242,7 +215,7 @@ extern int code2freq_num(uint8_t code) {
  *            freq-index    0        1        2        3        4
  *            -----------------------------------------------------
  *            GPS          L1       L2       L5        -        -
- *            GLONASS      G1       G2        -        -        -
+ *            GLONASS      G1       G2       G3        -        -
  *            Galileo      E1      E5a      E5b       E6      E5a+b
  *            QZSS         L1       L5       L2       L6        -
  *            SBAS         L1       L5       -         -        -
@@ -819,52 +792,6 @@ extern double mrtk_band2freq_hz(mrtk_band_t band) {
         case MRTK_BAND_IRN_L5:  return FREQ5;
         case MRTK_BAND_IRN_S:   return FREQ9;
         default:                return 0.0;
-    }
-    /* clang-format on */
-}
-
-/* band2idx_fixed: physical band -> fixed frequency index ---------------------
- * convert mrtk_band_t to the fixed per-system frequency index used by code2idx().
- * this is the "Layer A" mapping that does NOT depend on obsdef table ordering.
- * args   : mrtk_band_t band  I  physical frequency band
- * return : fixed frequency index (0,1,2,...), -1 on error
- *----------------------------------------------------------------------------*/
-static int band2idx_fixed(mrtk_band_t band) {
-    /* clang-format off */
-    switch (band) {
-        /* GPS: L1=0, L2=1, L5=2 */
-        case MRTK_BAND_GPS_L1:  return 0;
-        case MRTK_BAND_GPS_L2:  return 1;
-        case MRTK_BAND_GPS_L5:  return 2;
-        /* GLO: G1=0, G2=1, G3=2 */
-        case MRTK_BAND_GLO_G1:  return 0;
-        case MRTK_BAND_GLO_G2:  return 1;
-        case MRTK_BAND_GLO_G3:  return 2;
-        /* GAL: E1=0, E5b=1, E5a=2, E6=3, E5ab=4 */
-        case MRTK_BAND_GAL_E1:  return 0;
-        case MRTK_BAND_GAL_E5b: return 1;
-        case MRTK_BAND_GAL_E5a: return 2;
-        case MRTK_BAND_GAL_E6:  return 3;
-        case MRTK_BAND_GAL_E5ab:return 4;
-        /* QZS: L1=0, L2=1, L5=2, L6=3 */
-        case MRTK_BAND_QZS_L1:  return 0;
-        case MRTK_BAND_QZS_L2:  return 1;
-        case MRTK_BAND_QZS_L5:  return 2;
-        case MRTK_BAND_QZS_L6:  return 3;
-        /* SBS: L1=0, L5=1 */
-        case MRTK_BAND_SBS_L1:  return 0;
-        case MRTK_BAND_SBS_L5:  return 1;
-        /* BDS: B1C/B1I=0, B2b=1, B2a=2, B3=3, B2ab=4 */
-        case MRTK_BAND_BDS_B1C: return 0;
-        case MRTK_BAND_BDS_B1I: return 0;
-        case MRTK_BAND_BDS_B2b: return 1;
-        case MRTK_BAND_BDS_B2a: return 2;
-        case MRTK_BAND_BDS_B3:  return 3;
-        case MRTK_BAND_BDS_B2ab:return 4;
-        /* IRN: L5=0, S=1 */
-        case MRTK_BAND_IRN_L5:  return 0;
-        case MRTK_BAND_IRN_S:   return 1;
-        default:                return -1;
     }
     /* clang-format on */
 }

--- a/src/data/mrtk_obs.c
+++ b/src/data/mrtk_obs.c
@@ -215,7 +215,7 @@ extern int code2freq_num(uint8_t code) {
  *            freq-index    0        1        2        3        4
  *            -----------------------------------------------------
  *            GPS          L1       L2       L5        -        -
- *            GLONASS      G1       G2       G3        -        -
+ *            GLONASS      G1       G2        -        -        -
  *            Galileo      E1      E5a      E5b       E6      E5a+b
  *            QZSS         L1       L5       L2       L6        -
  *            SBAS         L1       L5       -         -        -

--- a/tests/utest/t_freqidx.c
+++ b/tests/utest/t_freqidx.c
@@ -1,0 +1,77 @@
+/*------------------------------------------------------------------------------
+ * unit test : code2freq_idx() obs-slot contract for RINEX conversion (#71)
+ *
+ * #71 unifies the converter (convrnx) onto code2freq_idx(), the obsdef-based
+ * mapping already used by every receiver decoder, the RINEX parser, RTCM3 and
+ * CLAS. This test pins the resulting (sys,code) -> frequency-index contract so
+ * the converter's column ordering and signal preservation cannot regress.
+ *
+ * Two properties matter for the converter:
+ *   - ordering: indices follow the obsdef table order, NOT the legacy fixed
+ *     per-band order (e.g. Galileo E5a precedes E5b, QZSS L5 precedes L2);
+ *   - preservation: a band the receiver can decode survives conversion only if
+ *     it owns an obsdef slot. Bands with no slot return -1 and are dropped by
+ *     setopt_obstype() — a documented converter known-limitation. GLONASS G3
+ *     (CDMA, GLONASS-K2 only) is the canonical case: obsdef_GLO has no G3 row
+ *     (adding one perturbs GLONASS positioning, so it is intentionally absent).
+ *
+ * Uses explicit checks (not assert) so it is robust under -DNDEBUG.
+ *-----------------------------------------------------------------------------*/
+#include <stdio.h>
+
+#include "mrtklib/rtklib.h"
+
+static int fails = 0;
+
+#define CHECK(cond, msg)                 \
+    do {                                 \
+        if (!(cond)) {                   \
+            printf("FAIL: %s\n", (msg)); \
+            fails++;                     \
+        } else {                         \
+            printf("ok  : %s\n", (msg)); \
+        }                                \
+    } while (0)
+
+/* frequency index for a (system, RINEX obs-code string) pair */
+static int idx(int sys, const char* obs) { return code2freq_idx(sys, obs2code(obs)); }
+
+int main(void) {
+    reset_obsdef(); /* pristine multi-band defaults */
+
+    /* GPS: L1=0, L2=1, L5=2 (unchanged by #71) */
+    CHECK(idx(SYS_GPS, "1C") == 0 && idx(SYS_GPS, "2W") == 1 && idx(SYS_GPS, "5Q") == 2, "GPS L1/L2/L5 -> 0/1/2");
+
+    /* Galileo: E1=0, E5a=1, E5b=2, E6=3 — obsdef order, E5a BEFORE E5b */
+    CHECK(idx(SYS_GAL, "1C") == 0, "GAL E1 -> 0");
+    CHECK(idx(SYS_GAL, "5Q") == 1, "GAL E5a -> 1 (was 2 under fixed band order)");
+    CHECK(idx(SYS_GAL, "7Q") == 2, "GAL E5b -> 2 (was 1 under fixed band order)");
+    CHECK(idx(SYS_GAL, "6C") == 3, "GAL E6 -> 3");
+
+    /* QZSS: L1=0, L5=1, L2=2, L6=3 — obsdef order, L5 BEFORE L2 */
+    CHECK(idx(SYS_QZS, "1C") == 0, "QZS L1 -> 0");
+    CHECK(idx(SYS_QZS, "5Q") == 1, "QZS L5 -> 1 (was 2 under fixed band order)");
+    CHECK(idx(SYS_QZS, "2L") == 2, "QZS L2 -> 2 (was 1 under fixed band order)");
+    CHECK(idx(SYS_QZS, "6L") == 3, "QZS L6 -> 3");
+
+    /* BDS: B1I=0, B3=1, B2b=2, B1C=3, B2a=4 — obsdef order */
+    CHECK(idx(SYS_CMP, "2I") == 0, "BDS B1I -> 0");
+    CHECK(idx(SYS_CMP, "6I") == 1, "BDS B3 -> 1");
+    CHECK(idx(SYS_CMP, "7I") == 2, "BDS B2b -> 2");
+    CHECK(idx(SYS_CMP, "1P") == 3, "BDS B1C -> 3");
+    CHECK(idx(SYS_CMP, "5P") == 4, "BDS B2a -> 4");
+
+    /* GLONASS: G1=0, G2=1; G3 has no obsdef slot -> -1 (known limitation:
+     * converter does not emit GLONASS G3, see #71. Adding a G3 slot to
+     * obsdef_GLO perturbs GLONASS positioning, so it is intentionally absent.) */
+    CHECK(idx(SYS_GLO, "1C") == 0, "GLO G1 -> 0");
+    CHECK(idx(SYS_GLO, "2C") == 1, "GLO G2 -> 1");
+    CHECK(idx(SYS_GLO, "3Q") == -1, "GLO G3 -> -1 (no obsdef slot; dropped by convrnx, known limitation)");
+
+    if (fails) {
+        printf("\n%d check(s) FAILED\n", fails);
+        return 1;
+    }
+    printf("\nall code2freq_idx #71 checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Closes #71. Unifies the RINEX converter (`mrtk convert` / convrnx) onto `code2freq_idx()` — the obsdef-based frequency-index mapping every receiver decoder, the RINEX parser, RTCM3 and CLAS already use — and removes the legacy fixed per-band `code2idx()` / `band2idx_fixed()`.

**Converter-only change. Positioning output is byte-identical** (the obsdef tables and `src/pos/` are untouched).

## What changes

- `src/data/mrtk_convrnx.c` — 3 call sites switched from `code2idx()` to `code2freq_idx()` (obs-type sort + `-freq` filter).
- `src/data/mrtk_obs.c`, `include/mrtklib/mrtk_obs.h` — remove `code2idx()` / `band2idx_fixed()`; modernize the frequency-index comment.
- RINEX obs-type columns now follow obsdef band order: **Galileo E5a before E5b**, **QZSS L5 before L2** (BeiDou reorders similarly). `-freq N` keeps its meaning but now selects the same N bands the positioning engines use.

## Verification

- Multi-GNSS Septentrio capture, before/after `mrtk convert`: per-system obs counts **identical** (no signal dropped) — only column ordering changes.
- New `utest_t_freqidx` pins the `code2freq_idx()` (sys, code) → index contract for GPS/GLONASS/Galileo/QZSS/BeiDou.
- Full ctest: only the two perennial env failures (`rtkrcv_rt`, `madocalib_pppar_ion_check`). `madocalib_pppar_check` (which had briefly regressed during an intermediate approach) passes; `rtkrcv_rt_clas_2ch` passes cleanly (371 s).

## Known limitations (documented)

Two rare signals have no obsdef slot and are not emitted by the converter. Adding slots perturbs positioning (an intermediate attempt to add GLONASS G3 to `obsdef_GLO` shifted `madocalib_pppar` past tolerance), so the tables are intentionally left as-is:

- **GLONASS G3** (CDMA, GLONASS-K2 only)
- **BeiDou B2a+b** (AltBOC, beyond the converter's 5-band `-freq` mask)

## Notes

- Surfaced an unrelated test-harness bug while verifying — `run_rtkrcv_test.sh` uses non-portable `mktemp` templates on macOS. Filed separately as #194 (not addressed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)