### PR TITLE
feat(rtk): enhanced a-priori SPP seed for PPP-RTK/VRS (default cn0+tdcp)

### DIFF
--- a/conf/benchmark/clas.toml
+++ b/conf/benchmark/clas.toml
@@ -2,16 +2,14 @@
 # Converted from: clas.conf
 
 [positioning]
-mode = "ppp-rtk"        # (9:ppp-rtk)
-correction = "qzs-clas" # QZSS CLAS (L6D CSSR); explicit (was inferred from mode+sateph)
-# frequency           = "l1+2+3"  # GPS/QZSS L1+L2+L5, Galileo E1+E5
+mode = "ppp-rtk"                                                   # (9:ppp-rtk)
+correction = "qzs-clas"                                            # QZSS CLAS (L6D CSSR); explicit (was inferred from mode+sateph)
 signals = ["G1C", "G2W", "E1C", "E5Q", "E7Q", "J1C", "J5Q", "J2X"]
 solution_type = "forward"                                          # (0:forward)
 elevation_mask = 15.0                                              # (deg)
 dynamics = true                                                    # kinematic
 satellite_ephemeris = "brdc+ssrapc"
 excluded_sats = ""
-# constellations    = 25  # deprecated: use systems instead
 systems = ["GPS", "Galileo", "QZSS"]
 
 [positioning.clas]

--- a/conf/benchmark/madoca.toml
+++ b/conf/benchmark/madoca.toml
@@ -3,14 +3,13 @@
 
 [positioning]
 mode = "ppp-kine"
-correction = "qzs-madoca"           # QZSS MADOCA-PPP (L6E SSR); explicit (was inferred from mode+sateph)
+correction = "qzs-madoca"                       # QZSS MADOCA-PPP (L6E SSR); explicit (was inferred from mode+sateph)
 frequency = "l1+2"
 solution_type = "forward"
 elevation_mask = 10.0
-dynamics = true                     # kinematic
+dynamics = true                                 # kinematic
 satellite_ephemeris = "brdc+ssrapc"
 excluded_sats = ""
-# constellations    = 29  # deprecated: use systems instead
 systems = ["GPS", "GLONASS", "Galileo", "QZSS"]
 
 [positioning.snr_mask]

--- a/conf/benchmark/rtk.toml
+++ b/conf/benchmark/rtk.toml
@@ -2,16 +2,14 @@
 # Converted from: rtk.conf
 
 [positioning]
-mode = "kinematic"  # (2:kinematic)
-correction = "none" # relative RTK uses rover+base, no SSR correction (explicit)
-# frequency           = "l1+2+3"  # triple-freq
+mode = "kinematic"                                                                             # (2:kinematic)
+correction = "none"                                                                            # relative RTK uses rover+base, no SSR correction (explicit)
 signals = ["G1C", "G2W", "G5X", "E1C", "E5Q", "E7Q", "J1C", "J5Q", "J2X", "C2I", "C6I", "C7I"]
 solution_type = "forward"
 elevation_mask = 15.0                                                                          # (deg)
 dynamics = true                                                                                # kinematic
 satellite_ephemeris = "brdc"
 excluded_sats = ""
-# constellations    = 57  # deprecated: use systems instead
 systems = ["GPS", "Galileo", "QZSS", "BeiDou"]
 
 [positioning.snr_mask]

--- a/conf/claslib/rnx2rtkp.toml
+++ b/conf/claslib/rnx2rtkp.toml
@@ -2,15 +2,13 @@
 # Converted from: rnx2rtkp.conf
 
 [positioning]
-mode = "ppp-rtk" # (9:ppp-rtk)
-# frequency           = "l1+2+3"  # (2:l1+2 for GPS/QZSS L1+L2, 3:l1+2+3 for GPS/QZSS L1+L2 + Galileo E1+E5)
+mode = "ppp-rtk"                                                   # (9:ppp-rtk)
 signals = ["G1C", "G2W", "E1C", "E5Q", "E7Q", "J1C", "J5Q", "J2X"]
 solution_type = "forward"                                          # (0:forward)
 elevation_mask = 15.0                                              # (deg)
 dynamics = true                                                    # (0:off for static,1:on for kinematic)
 satellite_ephemeris = "brdc+ssrapc"                                # (3:brdc+ssrapc)
 excluded_sats = ""                                                 # (prn ...)
-# constellations    = 25  # deprecated: use systems instead
 systems = ["GPS", "Galileo", "QZSS"]
 
 [positioning.clas]

--- a/conf/claslib/rnx2rtkp_L1CL5.toml
+++ b/conf/claslib/rnx2rtkp_L1CL5.toml
@@ -2,15 +2,13 @@
 # Converted from: rnx2rtkp_L1CL5.conf
 
 [positioning]
-mode = "ppp-rtk" # (9:ppp-rtk)
-# frequency           = "l1+2+3"  # (2:l1+2 for GPS/QZSS L1+L2, 3:l1+2+3 for GPS/QZSS L1+L2+L5 / Galileo E1+E5)
+mode = "ppp-rtk"                                            # (9:ppp-rtk)
 signals = ["G1C", "G2W", "E1C", "E5Q", "E7Q", "J1C", "J5Q"]
 solution_type = "forward"                                   # (0:forward)
 elevation_mask = 15.0                                       # (deg)
 dynamics = true                                             # (0:off for static,1:on for kinematic)
 satellite_ephemeris = "brdc+ssrapc"                         # (3:brdc+ssrapc)
 excluded_sats = ""                                          # (prn ...)
-# constellations    = 25  # deprecated: use systems instead
 systems = ["GPS", "Galileo", "QZSS"]
 
 [positioning.clas]

--- a/conf/claslib/rnx2rtkp_vrs.toml
+++ b/conf/claslib/rnx2rtkp_vrs.toml
@@ -2,15 +2,13 @@
 # Converted from: rnx2rtkp_vrs.conf
 
 [positioning]
-mode = "vrs-rtk" # (12:vrs-rtk)
-# frequency           = "l1+2+3"  # (3:l1+2+3 for GPS/QZSS L1+L2+L5 / Galileo E1+E5)
+mode = "vrs-rtk"                                                   # (12:vrs-rtk)
 signals = ["G1C", "G2W", "E1C", "E5Q", "E7Q", "J1C", "J5Q", "J2X"]
 solution_type = "forward"                                          # (0:forward)
 elevation_mask = 15.0                                              # (deg)
 dynamics = true                                                    # (0:off for static,1:on for kinematic)
 satellite_ephemeris = "brdc"                                       # (0:brdc)
 excluded_sats = ""                                                 # (prn ...)
-# constellations    = 25  # deprecated: use systems instead
 systems = ["GPS", "Galileo", "QZSS"]
 
 [positioning.clas]

--- a/conf/claslib/rnx2rtkp_vrs_g5p3.toml
+++ b/conf/claslib/rnx2rtkp_vrs_g5p3.toml
@@ -2,15 +2,13 @@
 # VRS-RTK config for Septentrio mosaic-G5 P3 (cssr2rtcm3 base)
 
 [positioning]
-mode = "vrs-rtk" # (12:vrs-rtk)
-# frequency           = "l1+2+3"  # (3:l1+2+3 for GPS/QZSS L1+L2+L5 / Galileo E1+E5)
+mode = "vrs-rtk"                                                   # (12:vrs-rtk)
 signals = ["G1C", "G2W", "E1C", "E5Q", "E7Q", "J1C", "J5Q", "J2L"]
 solution_type = "forward"                                          # (0:forward)
 elevation_mask = 15.0                                              # (deg)
 dynamics = true                                                    # (0:off for static,1:on for kinematic)
 satellite_ephemeris = "brdc"                                       # (0:brdc)
 excluded_sats = ""                                                 # (prn ...)
-# constellations    = 25  # deprecated: use systems instead
 systems = ["GPS", "Galileo", "QZSS"]
 
 [positioning.clas]

--- a/conf/claslib/rtkrcv.toml
+++ b/conf/claslib/rtkrcv.toml
@@ -2,15 +2,13 @@
 # Converted from: rtkrcv.conf
 
 [positioning]
-mode = "ppp-rtk" # (9:ppp-rtk)
-# frequency           = "l1+2+3"  # (3:l1+2+3 for GPS/QZSS L1+L2+L5, Galileo E1+E5b)
+mode = "ppp-rtk"                                                   # (9:ppp-rtk)
 signals = ["G1C", "G2W", "E1C", "E5Q", "E7Q", "J1C", "J5Q", "J2X"]
 solution_type = "forward"                                          # (0:forward)
 elevation_mask = 15.0                                              # (deg)
 dynamics = true                                                    # kinematic
 satellite_ephemeris = "brdc+ssrapc"                                # (3:brdc+ssrapc)
 excluded_sats = ""
-# constellations    = 25  # deprecated: use systems instead
 systems = ["GPS", "Galileo", "QZSS"]
 
 [positioning.clas]

--- a/conf/claslib/rtkrcv_2ch.toml
+++ b/conf/claslib/rtkrcv_2ch.toml
@@ -2,15 +2,13 @@
 # Converted from: rtkrcv_2ch.conf
 
 [positioning]
-mode = "ppp-rtk" # (9:ppp-rtk)
-# frequency           = "l1+2"  # (2:l1+2) CLAS does not provide E5a bias; nf=3 degrades AR
+mode = "ppp-rtk"                                     # (9:ppp-rtk)
 signals = ["G1C", "G2W", "E1C", "E5Q", "J1C", "J5Q"]
 solution_type = "forward"                            # (0:forward)
 elevation_mask = 15.0                                # (deg)
 dynamics = true                                      # kinematic
 satellite_ephemeris = "brdc+ssrapc"                  # (3:brdc+ssrapc)
 excluded_sats = ""
-# constellations    = 25  # deprecated: use systems instead
 systems = ["GPS", "Galileo", "QZSS"]
 
 [positioning.clas]

--- a/conf/claslib/rtkrcv_rtcm3_ubx.toml
+++ b/conf/claslib/rtkrcv_rtcm3_ubx.toml
@@ -2,15 +2,13 @@
 # Converted from: rtkrcv_rtcm3_ubx.conf
 
 [positioning]
-mode = "ppp-rtk" # (9:ppp-rtk)
-# frequency           = "l1+2+3"  # (3:l1+2+3 for GPS/QZSS L1+L2+L5, Galileo E1+E5b)
+mode = "ppp-rtk"                                                   # (9:ppp-rtk)
 signals = ["G1C", "G2W", "E1C", "E5Q", "E7Q", "J1C", "J5Q", "J2X"]
 solution_type = "forward"                                          # (0:forward)
 elevation_mask = 15.0                                              # (deg)
 dynamics = true                                                    # kinematic
 satellite_ephemeris = "brdc+ssrapc"                                # (3:brdc+ssrapc)
 excluded_sats = ""
-# constellations    = 25  # deprecated: use systems instead
 systems = ["GPS", "Galileo", "QZSS"]
 
 [positioning.clas]

--- a/conf/claslib/rtkrcv_sbf_l6d.toml
+++ b/conf/claslib/rtkrcv_sbf_l6d.toml
@@ -2,15 +2,13 @@
 # Converted from: rtkrcv_sbf_l6d.conf
 
 [positioning]
-mode = "ppp-rtk" # (9:ppp-rtk)
-# frequency           = "l1+2+3"  # (3:l1+2+3 for GPS/QZSS L1+L2+L5, Galileo E1+E5b)
+mode = "ppp-rtk"                                                   # (9:ppp-rtk)
 signals = ["G1C", "G2W", "E1C", "E5Q", "E7Q", "J1C", "J5Q", "J2X"]
 solution_type = "forward"                                          # (0:forward)
 elevation_mask = 15.0                                              # (deg)
 dynamics = true                                                    # kinematic
 satellite_ephemeris = "brdc+ssrapc"                                # (3:brdc+ssrapc)
 excluded_sats = ""
-# constellations    = 25  # deprecated: use systems instead
 systems = ["GPS", "Galileo", "QZSS"]
 
 [positioning.clas]

--- a/conf/claslib/rtkrcv_ubx_clas.toml
+++ b/conf/claslib/rtkrcv_ubx_clas.toml
@@ -18,7 +18,6 @@ elevation_mask = 15.0                                              # (deg)
 dynamics = true                                                    # kinematic
 satellite_ephemeris = "brdc+ssrapc"                                # (3:brdc+ssrapc)
 excluded_sats = ""
-# constellations    = 25  # deprecated: use systems instead
 systems = ["GPS", "Galileo", "QZSS"]
 
 [positioning.clas]

--- a/conf/claslib/ssr2obs.toml
+++ b/conf/claslib/ssr2obs.toml
@@ -2,11 +2,9 @@
 # Converted from: ssr2obs.conf
 
 [positioning]
-mode = "ssr2osr" # (10:ssr2osr)
-# frequency      = "l1+2+3"  # (3:l1+2+3 for L1+L2+L5)
+mode = "ssr2osr"                                                          # (10:ssr2osr)
 signals = ["G1C", "G2W", "G5X", "E1C", "E5Q", "E7Q", "J1C", "J5Q", "J2X"]
 excluded_sats = ""                                                        # (prn ...)
-# constellations = 25  # deprecated: use systems instead
 systems = ["GPS", "Galileo", "QZSS"]
 
 [positioning.corrections]

--- a/conf/claslib/ssr2osr.toml
+++ b/conf/claslib/ssr2osr.toml
@@ -2,13 +2,11 @@
 # Converted from: ssr2osr.conf
 
 [positioning]
-mode = "ssr2osr" # (10:ssr2osr,11:ssr2osr-fixed)
-# frequency           = "l1+2+3"  # (3:l1+2+3 for L1+L2+L5)
+mode = "ssr2osr"                                                          # (10:ssr2osr,11:ssr2osr-fixed)
 signals = ["G1C", "G2W", "G5X", "E1C", "E5Q", "E7Q", "J1C", "J5Q", "J2X"]
 elevation_mask = 15.0                                                     # (deg)
 satellite_ephemeris = "brdc+ssrapc"                                       # (3:brdc+ssrapc)
 excluded_sats = ""                                                        # (prn ...)
-# constellations    = 25  # deprecated: use systems instead
 systems = ["GPS", "Galileo", "QZSS"]
 
 [positioning.clas]

--- a/conf/madocalib/rnx2rtkp.toml
+++ b/conf/madocalib/rnx2rtkp.toml
@@ -2,14 +2,13 @@
 # Converted from: rnx2rtkp.conf
 
 [positioning]
-mode = "ppp-kine"                   # (6:ppp-kine,7:ppp-static)
-frequency = "l1+2"                  # (1:l1,2:l1+2,3:l1+2+3,4:l1+2+3+4)
-solution_type = "forward"           # (0:forward)
-elevation_mask = 10.0               # (deg)
-dynamics = false                    # (0:off,1:on)
-satellite_ephemeris = "brdc+ssrapc" # (0:brdc,1:precise,3:brdc+ssrapc,4:brdc+ssrcom)
-excluded_sats = ""                  # (prn ...)
-# constellations    = 29  # deprecated: use systems instead
+mode = "ppp-kine"                               # (6:ppp-kine,7:ppp-static)
+frequency = "l1+2"                              # (1:l1,2:l1+2,3:l1+2+3,4:l1+2+3+4)
+solution_type = "forward"                       # (0:forward)
+elevation_mask = 10.0                           # (deg)
+dynamics = false                                # (0:off,1:on)
+satellite_ephemeris = "brdc+ssrapc"             # (0:brdc,1:precise,3:brdc+ssrapc,4:brdc+ssrcom)
+excluded_sats = ""                              # (prn ...)
 systems = ["GPS", "GLONASS", "Galileo", "QZSS"]
 
 [positioning.snr_mask]

--- a/conf/madocalib/rnx2rtkp_pppar.toml
+++ b/conf/madocalib/rnx2rtkp_pppar.toml
@@ -2,14 +2,13 @@
 # Converted from: rnx2rtkp_pppar.conf
 
 [positioning]
-mode = "ppp-kine"                   # (6:ppp-kine,7:ppp-static)
-frequency = "l1+2+3+4"              # (1:l1,2:l1+2,3:l1+2+3,4:l1+2+3+4)
-solution_type = "forward"           # (0:forward)
-elevation_mask = 10.0               # (deg)
-dynamics = false                    # (0:off,1:on)
-satellite_ephemeris = "brdc+ssrapc" # (0:brdc,1:precise,3:brdc+ssrapc,4:brdc+ssrcom)
-excluded_sats = ""                  # (prn ...)
-# constellations    = 61  # deprecated: use systems instead
+mode = "ppp-kine"                                         # (6:ppp-kine,7:ppp-static)
+frequency = "l1+2+3+4"                                    # (1:l1,2:l1+2,3:l1+2+3,4:l1+2+3+4)
+solution_type = "forward"                                 # (0:forward)
+elevation_mask = 10.0                                     # (deg)
+dynamics = false                                          # (0:off,1:on)
+satellite_ephemeris = "brdc+ssrapc"                       # (0:brdc,1:precise,3:brdc+ssrapc,4:brdc+ssrcom)
+excluded_sats = ""                                        # (prn ...)
 systems = ["GPS", "GLONASS", "Galileo", "QZSS", "BeiDou"]
 
 [positioning.snr_mask]

--- a/conf/madocalib/rnx2rtkp_pppar_iono.toml
+++ b/conf/madocalib/rnx2rtkp_pppar_iono.toml
@@ -2,14 +2,13 @@
 # Converted from: rnx2rtkp_pppar_iono.conf
 
 [positioning]
-mode = "ppp-kine"                   # (6:ppp-kine,7:ppp-static)
-frequency = "l1+2+3+4"              # (1:l1,2:l1+2,3:l1+2+3,4:l1+2+3+4)
-solution_type = "forward"           # (0:forward)
-elevation_mask = 10.0               # (deg)
-dynamics = false                    # (0:off,1:on)
-satellite_ephemeris = "brdc+ssrapc" # (0:brdc,1:precise,3:brdc+ssrapc,4:brdc+ssrcom)
-excluded_sats = ""                  # (prn ...)
-# constellations    = 61  # deprecated: use systems instead
+mode = "ppp-kine"                                         # (6:ppp-kine,7:ppp-static)
+frequency = "l1+2+3+4"                                    # (1:l1,2:l1+2,3:l1+2+3,4:l1+2+3+4)
+solution_type = "forward"                                 # (0:forward)
+elevation_mask = 10.0                                     # (deg)
+dynamics = false                                          # (0:off,1:on)
+satellite_ephemeris = "brdc+ssrapc"                       # (0:brdc,1:precise,3:brdc+ssrapc,4:brdc+ssrcom)
+excluded_sats = ""                                        # (prn ...)
 systems = ["GPS", "GLONASS", "Galileo", "QZSS", "BeiDou"]
 
 [positioning.snr_mask]

--- a/conf/malib/rnx2rtkp.toml
+++ b/conf/malib/rnx2rtkp.toml
@@ -2,14 +2,13 @@
 # Converted from: rnx2rtkp.conf
 
 [positioning]
-mode = "ppp-kine"                   # (0:single,1:dgps,2:kinematic,3:static,4:movingbase,5:fixed,6:ppp-kine,7:ppp-static,8:ppp-fixed)
-frequency = "l1+2"                  # (1:l1,2:l1+2,3:l1+2+3,4:l1+2+3+4,5:l1+2+3+4+5)
-solution_type = "forward"           # (0:forward,1:backward,2:combined)
-elevation_mask = 10.0               # (deg)
-dynamics = false                    # (0:off,1:on)
-satellite_ephemeris = "brdc+ssrapc" # (0:brdc,1:precise,2:brdc+sbas,3:brdc+ssrapc,4:brdc+ssrcom)
-excluded_sats = ""                  # (prn ...)
-# constellations    = 29  # deprecated: use systems instead
+mode = "ppp-kine"                               # (0:single,1:dgps,2:kinematic,3:static,4:movingbase,5:fixed,6:ppp-kine,7:ppp-static,8:ppp-fixed)
+frequency = "l1+2"                              # (1:l1,2:l1+2,3:l1+2+3,4:l1+2+3+4,5:l1+2+3+4+5)
+solution_type = "forward"                       # (0:forward,1:backward,2:combined)
+elevation_mask = 10.0                           # (deg)
+dynamics = false                                # (0:off,1:on)
+satellite_ephemeris = "brdc+ssrapc"             # (0:brdc,1:precise,2:brdc+sbas,3:brdc+ssrapc,4:brdc+ssrcom)
+excluded_sats = ""                              # (prn ...)
 systems = ["GPS", "GLONASS", "Galileo", "QZSS"]
 
 [positioning.snr_mask]

--- a/conf/malib/rtkrcv.toml
+++ b/conf/malib/rtkrcv.toml
@@ -2,14 +2,13 @@
 # Converted from: rtkrcv.conf
 
 [positioning]
-mode = "ppp-kine"                   # (0:single,1:dgps,2:kinematic,3:static,4:movingbase,5:fixed,6:ppp-kine,7:ppp-static,8:ppp-fixed)
-frequency = "l1+2"                  # (1:l1,2:l1+2,3:l1+2+3,4:l1+2+3+4,5:l1+2+3+4+5)
-solution_type = "forward"           # (0:forward,1:backward,2:combined)
-elevation_mask = 10.0               # (deg)
-dynamics = false                    # (0:off,1:on)
-satellite_ephemeris = "brdc+ssrapc" # (0:brdc,1:precise,2:brdc+sbas,3:brdc+ssrapc,4:brdc+ssrcom)
-excluded_sats = ""                  # (prn ...)
-# constellations    = 29  # deprecated: use systems instead
+mode = "ppp-kine"                               # (0:single,1:dgps,2:kinematic,3:static,4:movingbase,5:fixed,6:ppp-kine,7:ppp-static,8:ppp-fixed)
+frequency = "l1+2"                              # (1:l1,2:l1+2,3:l1+2+3,4:l1+2+3+4,5:l1+2+3+4+5)
+solution_type = "forward"                       # (0:forward,1:backward,2:combined)
+elevation_mask = 10.0                           # (deg)
+dynamics = false                                # (0:off,1:on)
+satellite_ephemeris = "brdc+ssrapc"             # (0:brdc,1:precise,2:brdc+sbas,3:brdc+ssrapc,4:brdc+ssrcom)
+excluded_sats = ""                              # (prn ...)
 systems = ["GPS", "GLONASS", "Galileo", "QZSS"]
 
 [positioning.snr_mask]

--- a/docs/design/spp-accuracy.md
+++ b/docs/design/spp-accuracy.md
@@ -779,7 +779,7 @@ the existing test tolerances; one VRS case improves (fix 98.9 % → 99.9 %).
 
 ### 11.4 Why robust is opt-in, not default — and why it cannot be auto-gated
 
-Adding `robust` raises the aggregate fix rate (+1.0 pp more) and helps opener
+Adding `robust` raises the aggregate fix rate (+1.0 pp more) and helps open-sky
 runs markedly (nagoya_run2 fixed-RMS 2.00 m → 1.12 m, worst fixed error 24.8 m →
 14.8 m). **But on the deep-urban-canyon run (tokyo_run3) it is destructive**:
 mis-fixes 5 → 71, worst fixed error 4.4 m → 12 m, in sustained ~15-epoch clusters.
@@ -809,3 +809,14 @@ SPP-fallback regime (tokyo_run3 = 82 % SPP fallback vs nagoya_run2 = 11 %), i.e.
 how reset-prone the filter is — not with geometry (tokyo_run3 has the *most*
 satellites). So robust is left as an explicit operator opt-in: use it where the
 environment is open-sky, omit it in dense urban canyons.
+
+### 11.5 Real-time applicability
+
+Real-time PPP-RTK/VRS-RTK (`mrtk run`) runs the same `rtkpos()` and the same seed
+block (`mrtk_rtksvr.c` calls `rtkpos(&svr->rtk, ...)`), with the loaded `prcopt`
+propagated to `svr->rtk.opt` via `rtkinit` in `rtksvrstart`, so the default
+profile is active in real time as well. The persistent `svr->rtk.ssat` carries
+the TDCP phase history across the stream loop. Real-time is arguably where the
+seed matters most — stream gaps and cycle slips make it the reset-prone regime
+the enhancement targets — but the benchmark numbers in this document are
+post-processing; the real-time effect has not yet been separately measured.

--- a/docs/design/spp-accuracy.md
+++ b/docs/design/spp-accuracy.md
@@ -736,3 +736,72 @@ primary, ○ corroborating / applied.
   (§5.2/§5.3), able to absorb errors the loose post-filter cannot. Not pursued
   now; the residual tail is largely NLOS bias, which no filter fixes (needs
   3DMA / external aiding).
+
+## 11. Enhanced a-priori SPP seed for PPP-RTK (2026-06)
+
+### 11.1 Motivation and mechanism
+
+PPP-RTK/VRS computes a single-point fix every epoch (`pntpos`) that seeds and,
+on reset, re-seeds the CLAS/VRS filter position state `x[0..2]`
+([`mrtk_rtkpos.c`](../../src/pos/mrtk_rtkpos.c) seed block). On filter resets
+(obs-loss gap, persistent-FLOAT, large PPP-RTK↔SPP divergence) `udpos_ppp`
+re-initialises the position from this seed, and `resamb_LAMBDA` then builds its
+float vector — including the position states — from `rtk->x`. So a poor seed can
+propagate into the ambiguity search. The hypothesis was that the v0.6.10 SPP
+accuracy work could lift the seed quality and reduce mis-fixes.
+
+### 11.2 The err[5]/err[6] aliasing constraint
+
+The seed runs on a private option copy (`prcopt_t sppopt = rtk->opt`), but until
+now it inherited the CLAS error model verbatim. The two slots `err[5]`/`err[6]`
+are **overloaded**: in `mrtk_spp.c::varerr` they are the C/N0 `snr_max`/`snr_error`
+coefficients, but in `mrtk_ppp_rtk.c::varerr` the same slots are the iono/trop
+estimation-error terms. Setting them on `rtk->opt` to enable seed C/N0 weighting
+would corrupt the CLAS measurement model. The fix is to set the SPP error model
+on `sppopt` **only**, leaving `rtk->opt` (read by the CLAS engine) untouched.
+
+### 11.3 The `enhanced_spp_seed` profile
+
+`[positioning.clas] enhanced_spp_seed` (opt key `pos1-seedenh`), default off:
+
+| Value | Seed gets |
+|-------|-----------|
+| `off` | nothing — bit-identical to prior behaviour |
+| `cn0+tdcp` | C/N0 weighting + TDCP jump-reject (**recommended "on"**) |
+| `cn0+tdcp+robust` | the above + IGG-III robust (open-sky opt-in) |
+
+PPC-Dataset (6 urban runs), `cn0+tdcp` vs baseline: fix rate 23.7 % → 24.7 %,
+fixed-epoch 95th-pct 3.23 m → 3.02 m, with no large-misfix regression.
+
+### 11.4 Why robust is opt-in, not default — and why it cannot be auto-gated
+
+Adding `robust` raises the aggregate fix rate (+1.0 pp more) and helps opener
+runs markedly (nagoya_run2 fixed-RMS 2.00 m → 1.12 m, worst fixed error 24.8 m →
+14.8 m). **But on the deep-urban-canyon run (tokyo_run3) it is destructive**:
+mis-fixes 5 → 71, worst fixed error 4.4 m → 12 m, in sustained ~15-epoch clusters.
+
+The mechanism is *not* seed inaccuracy — robust actually improves that run's seed
+accuracy (Q1 median 2.48 m → 2.23 m). Instead, the *different* (even better) seed
+trajectory trips the filter's reset/AR thresholds at discrete epochs, and
+fix-and-hold then locks the resulting wrong integer (the clusters hold a constant
+multi-metre offset). Dropping fix-and-hold globally is not viable — it halves the
+fix rate on this data.
+
+Two auto-gating strategies were implemented and benchmarked, then **removed**:
+
+- **Self-gating in `estpos`** (skip robust when its MAD scale `s0` is large or the
+  flagged-satellite fraction is high): *failed*. On tokyo_run3 robust is
+  internally valid (residuals are not flagged), so the gate never fired —
+  identical to always-on — and per-epoch on/off flipping worsened aggregate p95.
+- **Filter-health gating** (enable robust only when an EWMA of recent fixed
+  epochs is high): *partial*. Best aggregate p95 and fewest mis-fixes among the
+  robust arms, and it halved tokyo_run3 mis-fixes (88 → 38), but it failed to
+  capture robust's per-case benefit and a 12 m cluster survived.
+
+**Conclusion:** robust's harm is a filter-coupling effect invisible to any
+seed-local diagnostic; only an external filter-state signal points the right way,
+and a coarse one cannot cleanly separate. The robust harm correlates with the
+SPP-fallback regime (tokyo_run3 = 82 % SPP fallback vs nagoya_run2 = 11 %), i.e.
+how reset-prone the filter is — not with geometry (tokyo_run3 has the *most*
+satellites). So robust is left as an explicit operator opt-in: use it where the
+environment is open-sky, omit it in dense urban canyons.

--- a/docs/design/spp-accuracy.md
+++ b/docs/design/spp-accuracy.md
@@ -762,16 +762,20 @@ on `sppopt` **only**, leaving `rtk->opt` (read by the CLAS engine) untouched.
 
 ### 11.3 The `enhanced_spp_seed` profile
 
-`[positioning.clas] enhanced_spp_seed` (opt key `pos1-seedenh`), default off:
+`[positioning.clas] enhanced_spp_seed` (opt key `pos1-seedenh`):
 
 | Value | Seed gets |
 |-------|-----------|
 | `off` | nothing — bit-identical to prior behaviour |
-| `cn0+tdcp` | C/N0 weighting + TDCP jump-reject (**recommended "on"**) |
+| `cn0+tdcp` | C/N0 weighting + TDCP jump-reject (**default**, `prcopt_default`) |
 | `cn0+tdcp+robust` | the above + IGG-III robust (open-sky opt-in) |
 
 PPC-Dataset (6 urban runs), `cn0+tdcp` vs baseline: fix rate 23.7 % → 24.7 %,
-fixed-epoch 95th-pct 3.23 m → 3.02 m, with no large-misfix regression.
+fixed-epoch 95th-pct 3.23 m → 3.02 m, with no large-misfix regression. It is the
+default because it is a net win on kinematic data and **inert on the static
+regression suite** — all six claslib static (みなしローバー) cases run
+byte-close to the off baseline, with deltas (sub-cm RMS-vs-reference) well inside
+the existing test tolerances; one VRS case improves (fix 98.9 % → 99.9 %).
 
 ### 11.4 Why robust is opt-in, not default — and why it cannot be auto-gated
 

--- a/docs/reference/benchmark.md
+++ b/docs/reference/benchmark.md
@@ -589,7 +589,7 @@ horizontal error over fixed epochs.
 - **C/N0 weighting drives the p95 (tail) improvement**; the seed-only TDCP
   jump-reject guards against wild SPP jumps but is neutral on this data.
 - **IGG-III robust is opt-in, not default.** It lifts the mean fix rate a further
-  +1.0 pp and helps opener runs, but on the deep-urban-canyon run (tokyo_run3) it
+  +1.0 pp and helps open-sky runs, but on the deep-urban-canyon run (tokyo_run3) it
   shifts the seed enough to trip fix-and-hold into sustained mis-fixes
   (mis-fixes 5 → 71, worst fixed error 4.4 m → 12 m). The harm is a filter-
   coupling effect invisible to seed-local diagnostics and could not be reliably
@@ -599,6 +599,11 @@ horizontal error over fixed epochs.
   regression cases run byte-close to the off baseline — deltas sub-cm RMS,
   inside the existing test tolerances — so the default is safe for the static
   use case while helping the kinematic one.
+- **Applies to real-time too.** Real-time PPP-RTK/VRS-RTK (`mrtk run`) calls the
+  same `rtkpos()` seed path, so the default profile is active there as well —
+  arguably where it matters most (stream gaps and slips make real-time the
+  reset-prone regime the seed targets). The numbers above are post-processing;
+  the real-time effect has not yet been separately benchmarked.
 
 ---
 

--- a/docs/reference/benchmark.md
+++ b/docs/reference/benchmark.md
@@ -546,6 +546,62 @@ horizontal error < 2 m.
 
 ---
 
+## Enhanced a-priori SPP seed for PPP-RTK (CLAS)
+
+PPP-RTK computes a single-point fix every epoch that seeds — and, on a filter
+reset (obs-loss gap, persistent-FLOAT, large PPP-RTK↔SPP divergence), re-seeds —
+the CLAS filter position, which then feeds the ambiguity search. The same
+v0.6.10 SPP error model can be applied to that seed **without touching the CLAS
+measurement model** (the seed runs on a private option copy; the C/N0 slots
+`err[5]/err[6]` mean snr_max/snr_error in SPP but iono/trop terms in the CLAS
+engine, so they are set on the copy only). Controlled by
+`[positioning.clas] enhanced_spp_seed`, **default `cn0+tdcp`**:
+
+| Value | Seed gets |
+|-------|-----------|
+| `off` | nothing — bit-identical to prior behaviour |
+| `cn0+tdcp` | C/N0 weighting + TDCP jump-reject (**default**) |
+| `cn0+tdcp+robust` | the above + IGG-III robust (open-sky opt-in) |
+
+Full rationale in [`docs/design/spp-accuracy.md`](../design/spp-accuracy.md) §11.
+
+### Results: CLAS PPP-RTK, baseline (off) → default (`cn0+tdcp`)
+
+`--mode clas --skip-epochs 60`. **Fix%** = Q=4 epochs; **p95** = 95th-percentile
+horizontal error over fixed epochs.
+
+| Case | Fix% | p95 (fixed) |
+|------|-----:|------------:|
+| nagoya_run1 | 13.9 → 12.3 % | 4.60 → 5.07 m |
+| nagoya_run2 | 35.0 → **36.1 %** | 1.08 → 1.24 m |
+| nagoya_run3 | 8.7 → 8.8 % | 2.31 → 2.30 m |
+| tokyo_run1  | 30.3 → **32.3 %** | 5.44 → **3.52 m** |
+| tokyo_run2  | 42.5 → **46.4 %** | 5.86 → 5.84 m |
+| tokyo_run3  | 11.9 → 12.4 % | 0.10 → 0.12 m |
+| **Mean** | **23.7 → 24.7 %** | **3.23 → 3.02 m** |
+
+### Key findings
+
+- A **modest net-positive**: mean fix rate **+1.0 pp**, mean fixed-epoch p95
+  **−21 cm**, with the largest single gain on tokyo_run1 (p95 5.44 → 3.52 m).
+  The change is per-case mixed (nagoya_run1 regresses slightly), so it is a
+  refinement, not a step change.
+- **C/N0 weighting drives the p95 (tail) improvement**; the seed-only TDCP
+  jump-reject guards against wild SPP jumps but is neutral on this data.
+- **IGG-III robust is opt-in, not default.** It lifts the mean fix rate a further
+  +1.0 pp and helps opener runs, but on the deep-urban-canyon run (tokyo_run3) it
+  shifts the seed enough to trip fix-and-hold into sustained mis-fixes
+  (mis-fixes 5 → 71, worst fixed error 4.4 m → 12 m). The harm is a filter-
+  coupling effect invisible to seed-local diagnostics and could not be reliably
+  auto-gated, so robust is left to the operator (use in open sky, omit in dense
+  urban). See [`docs/design/spp-accuracy.md`](../design/spp-accuracy.md) §11.4.
+- **Inert on static positioning.** All six claslib static (みなしローバー)
+  regression cases run byte-close to the off baseline — deltas sub-cm RMS,
+  inside the existing test tolerances — so the default is safe for the static
+  use case while helping the kinematic one.
+
+---
+
 ## Metrics Definitions
 
 | Metric | Description |
@@ -571,7 +627,7 @@ the keys it specifies.
 
 **Mode confs** (common settings per algorithm):
 
-- `conf/benchmark/clas.toml` — CLAS PPP-RTK
+- `conf/benchmark/clas.toml` — CLAS PPP-RTK (a-priori SPP seed enhanced by default; see above)
 - `conf/benchmark/madoca.toml` — MADOCA PPP
 - `conf/benchmark/rtk.toml` — Baseline RTK
 - `conf/benchmark/single.toml` — SPP (single-point), with the v0.6.10 accuracy features enabled

--- a/include/mrtklib/mrtk_opt.h
+++ b/include/mrtklib/mrtk_opt.h
@@ -306,12 +306,21 @@ typedef struct prcopt_t {         /* processing options type */
 
     /* PPP-RTK/VRS a-priori SPP seed quality (appended for ABI stability).
      * When set, the per-epoch single-point seed (pntpos) used to (re)initialize
-     * the CLAS/VRS filter applies the proven v0.6.10 SPP profile (C/N0 weighting
-     * + IGG-III robust + TDCP jump-reject) on its PRIVATE option copy only, so
-     * the CLAS measurement model (which reuses err[5]/err[6] as iono/trop terms)
-     * is left untouched. Default 0: bit-identical to prior seed behaviour. */
-    int enhanced_spp_seed; /* 0:off, 1:apply v0.6.10 SPP profile to the a-priori seed */
+     * the CLAS/VRS filter applies a v0.6.10 SPP profile (see SEEDENH_??? below) on
+     * its PRIVATE option copy only, so the CLAS measurement model (which reuses
+     * err[5]/err[6] as iono/trop terms) is left untouched. Default 0 (off):
+     * bit-identical to prior seed behaviour. */
+    int enhanced_spp_seed; /* a-priori SPP seed profile (SEEDENH_???) */
 } prcopt_t;
+
+/* enhanced_spp_seed profiles (applied to the PPP-RTK/VRS a-priori SPP seed only).
+ * BASE (C/N0 + TDCP) is the recommended "on" setting. ROBUST adds IGG-III robust
+ * weighting: it helps in open sky but, in deep urban canyons, perturbs the seed
+ * enough to trip the filter into fix-and-hold mis-fixes, so it is an explicit
+ * operator opt-in, not the default. See docs/design/spp-accuracy.md. */
+#define SEEDENH_OFF 0    /* off: seed bit-identical to prior behaviour */
+#define SEEDENH_BASE 1   /* C/N0 weighting + TDCP jump-reject (recommended) */
+#define SEEDENH_ROBUST 2 /* BASE + IGG-III robust (open-sky opt-in) */
 
 /*============================================================================
  * Solution Options Type

--- a/include/mrtklib/mrtk_opt.h
+++ b/include/mrtklib/mrtk_opt.h
@@ -308,18 +308,19 @@ typedef struct prcopt_t {         /* processing options type */
      * When set, the per-epoch single-point seed (pntpos) used to (re)initialize
      * the CLAS/VRS filter applies a v0.6.10 SPP profile (see SEEDENH_??? below) on
      * its PRIVATE option copy only, so the CLAS measurement model (which reuses
-     * err[5]/err[6] as iono/trop terms) is left untouched. Default 0 (off):
-     * bit-identical to prior seed behaviour. */
+     * err[5]/err[6] as iono/trop terms) is left untouched. prcopt_default sets
+     * SEEDENH_BASE (C/N0 + TDCP): a net win on kinematic data and inert on the
+     * static regression suite. Set SEEDENH_OFF to restore prior seed behaviour. */
     int enhanced_spp_seed; /* a-priori SPP seed profile (SEEDENH_???) */
 } prcopt_t;
 
 /* enhanced_spp_seed profiles (applied to the PPP-RTK/VRS a-priori SPP seed only).
- * BASE (C/N0 + TDCP) is the recommended "on" setting. ROBUST adds IGG-III robust
+ * BASE (C/N0 + TDCP) is the default (prcopt_default). ROBUST adds IGG-III robust
  * weighting: it helps in open sky but, in deep urban canyons, perturbs the seed
  * enough to trip the filter into fix-and-hold mis-fixes, so it is an explicit
  * operator opt-in, not the default. See docs/design/spp-accuracy.md. */
 #define SEEDENH_OFF 0    /* off: seed bit-identical to prior behaviour */
-#define SEEDENH_BASE 1   /* C/N0 weighting + TDCP jump-reject (recommended) */
+#define SEEDENH_BASE 1   /* C/N0 weighting + TDCP jump-reject (default) */
 #define SEEDENH_ROBUST 2 /* BASE + IGG-III robust (open-sky opt-in) */
 
 /*============================================================================

--- a/include/mrtklib/mrtk_opt.h
+++ b/include/mrtklib/mrtk_opt.h
@@ -303,6 +303,14 @@ typedef struct prcopt_t {         /* processing options type */
     int tdcp;        /* SPP TDCP mode (0:off, 1:on time-differenced carrier phase) */
     double tdcpjump; /* TDCP jump-rejection threshold (m); reject epoch if the code position
                       * change disagrees with the TDCP displacement by more than this (<=0: code default) */
+
+    /* PPP-RTK/VRS a-priori SPP seed quality (appended for ABI stability).
+     * When set, the per-epoch single-point seed (pntpos) used to (re)initialize
+     * the CLAS/VRS filter applies the proven v0.6.10 SPP profile (C/N0 weighting
+     * + IGG-III robust + TDCP jump-reject) on its PRIVATE option copy only, so
+     * the CLAS measurement model (which reuses err[5]/err[6] as iono/trop terms)
+     * is left untouched. Default 0: bit-identical to prior seed behaviour. */
+    int enhanced_spp_seed; /* 0:off, 1:apply v0.6.10 SPP profile to the a-priori seed */
 } prcopt_t;
 
 /*============================================================================

--- a/src/core/mrtk_toml.c
+++ b/src/core/mrtk_toml.c
@@ -47,6 +47,7 @@ static const toml_map_t toml_mapping[] = {
     /* ── positioning.clas ──────────────────────────────────────────────────── */
     {"positioning.clas", "grid_selection_radius", "pos1-gridsel"},
     {"positioning.clas", "receiver_type", "pos1-rectype"},
+    {"positioning.clas", "enhanced_spp_seed", "pos1-seedenh"},
     {"positioning.clas", "position_uncertainty_x", "pos1-rux"},
     {"positioning.clas", "position_uncertainty_y", "pos1-ruy"},
     {"positioning.clas", "position_uncertainty_z", "pos1-ruz"},

--- a/src/pos/mrtk_opt.c
+++ b/src/pos/mrtk_opt.c
@@ -85,6 +85,7 @@ const prcopt_t prcopt_default = {
     0,
     0, /* pppsatcb,pppsatpb,unbias,maxbiasdt */
     .correction = CORR_AUTO,
+    .enhanced_spp_seed = SEEDENH_BASE, /* default on: C/N0 + TDCP a-priori seed (PPP-RTK/VRS) */
 };
 const solopt_t solopt_default = {
     /* defaults solution output options */

--- a/src/pos/mrtk_options.c
+++ b/src/pos/mrtk_options.c
@@ -46,6 +46,7 @@ static char signals_[1024];
 
 /* system options table ------------------------------------------------------*/
 #define SWTOPT "0:off,1:on"
+#define SEEDOPT "0:off,1:cn0+tdcp,2:cn0+tdcp+robust"
 #define MODOPT                                                                                                    \
     "0:single,1:dgps,2:kinematic,3:static,4:movingbase,5:fixed,6:ppp-kine,7:ppp-static,8:ppp-fixed,9:ppp-rtk,10:" \
     "ssr2osr,11:ssr2osr-fixed,12:vrs-rtk"
@@ -101,7 +102,7 @@ opt_t sysopts[] = {
     {"pos1-robustk1", 1, (void*)&prcopt_.robustk[1], ""},
     {"pos1-tdcp", 3, (void*)&prcopt_.tdcp, SWTOPT},
     {"pos1-tdcpjump", 1, (void*)&prcopt_.tdcpjump, "m"},
-    {"pos1-seedenh", 3, (void*)&prcopt_.enhanced_spp_seed, SWTOPT},
+    {"pos1-seedenh", 3, (void*)&prcopt_.enhanced_spp_seed, SEEDOPT},
     {"pos1-sateph", 3, (void*)&prcopt_.sateph, EPHOPT},
     {"pos1-posopt1", 3, (void*)&prcopt_.posopt[0], SWTOPT},
     {"pos1-posopt2", 3, (void*)&prcopt_.posopt[1], SWTOPT},

--- a/src/pos/mrtk_options.c
+++ b/src/pos/mrtk_options.c
@@ -101,6 +101,7 @@ opt_t sysopts[] = {
     {"pos1-robustk1", 1, (void*)&prcopt_.robustk[1], ""},
     {"pos1-tdcp", 3, (void*)&prcopt_.tdcp, SWTOPT},
     {"pos1-tdcpjump", 1, (void*)&prcopt_.tdcpjump, "m"},
+    {"pos1-seedenh", 3, (void*)&prcopt_.enhanced_spp_seed, SWTOPT},
     {"pos1-sateph", 3, (void*)&prcopt_.sateph, EPHOPT},
     {"pos1-posopt1", 3, (void*)&prcopt_.posopt[0], SWTOPT},
     {"pos1-posopt2", 3, (void*)&prcopt_.posopt[1], SWTOPT},

--- a/src/pos/mrtk_rtkpos.c
+++ b/src/pos/mrtk_rtkpos.c
@@ -2717,24 +2717,31 @@ extern int rtkpos(mrtk_ctx_t* ctx, rtk_t* rtk, const obsd_t* obs, int n, nav_t* 
         /* PPP-RTK/VRS: force broadcast ephemeris for SPP initial position */
         if (sppopt.mode == PMODE_PPP_RTK || sppopt.mode == PMODE_VRS_RTK) {
             sppopt.sateph = EPHOPT_BRDC;
-            /* Enhanced seed (opt-in): give the a-priori single-point fix the proven
-             * v0.6.10 SPP error model on this PRIVATE copy only. err[5]/err[6] are
-             * the C/N0 snr_max/snr_error coefficients here (varerr in mrtk_spp.c);
-             * the CLAS engine reads rtk->opt where the same slots mean the iono/trop
-             * estimation-error terms, so it stays untouched. Values match
-             * conf/benchmark/single.toml. Skipped when the flag is 0, leaving the
-             * seed bit-identical to prior behaviour. */
-            if (rtk->opt.enhanced_spp_seed) {
-                sppopt.err[5] = 50.0; /* C/N0 reference snr_max (dB-Hz) */
-                sppopt.err[6] = 0.5;  /* C/N0 weighting coefficient (m) */
-                /* IGG-III robust intentionally omitted: it improves average seed
-                 * accuracy but perturbs the seed trajectory enough to trip the
-                 * filter's reset/AR thresholds, and fix-and-hold then locks the
-                 * resulting wrong integer (tokyo_run3 misfix 5->71). C/N0+TDCP
-                 * keep the p95 benefit without that regression. */
+            /* Enhanced seed (opt-in): apply the proven v0.6.10 SPP error model to
+             * this PRIVATE copy only. err[5]/err[6] are the C/N0 snr_max/snr_error
+             * coefficients here (varerr in mrtk_spp.c); the CLAS engine reads
+             * rtk->opt where the same slots mean the iono/trop estimation-error
+             * terms, so it stays untouched. Skipped when the profile is OFF,
+             * leaving the seed bit-identical to prior behaviour. */
+            if (rtk->opt.enhanced_spp_seed >= SEEDENH_BASE) {
+                sppopt.err[5] = 50.0;  /* C/N0 reference snr_max (dB-Hz) */
+                sppopt.err[6] = 0.5;   /* C/N0 weighting coefficient (m) */
                 sppopt.tdcp = 1;       /* TDCP velocity + jump-rejection QC */
                 sppopt.tdcpjump = 5.0; /* reject seed epoch on code-vs-TDCP jump > 5 m */
                 sppopt.thresdop = 1.0; /* TDCP cycle-slip Doppler threshold (cyc/s) */
+                /* IGG-III robust is an explicit opt-in (SEEDENH_ROBUST), not the
+                 * recommended default: it improves average seed accuracy but in deep
+                 * urban canyons perturbs the seed enough to trip the filter into
+                 * fix-and-hold mis-fixes (tokyo_run3 misfix 5->71). Auto-gating it
+                 * from seed-local diagnostics proved infeasible (the harm is a filter
+                 * coupling effect, invisible to the robust residual statistics); see
+                 * docs/design/spp-accuracy.md. So it is left to the operator, who
+                 * knows whether the environment is open-sky (use it) or urban (don't). */
+                if (rtk->opt.enhanced_spp_seed == SEEDENH_ROBUST) {
+                    sppopt.robust = 1;
+                    sppopt.robustk[0] = 1.5;
+                    sppopt.robustk[1] = 4.0;
+                }
             }
         }
         if (!pntpos(ctx, obs, nu, nav, &sppopt, &rtk->sol, NULL, rtk->ssat, msg)) {

--- a/src/pos/mrtk_rtkpos.c
+++ b/src/pos/mrtk_rtkpos.c
@@ -2717,12 +2717,12 @@ extern int rtkpos(mrtk_ctx_t* ctx, rtk_t* rtk, const obsd_t* obs, int n, nav_t* 
         /* PPP-RTK/VRS: force broadcast ephemeris for SPP initial position */
         if (sppopt.mode == PMODE_PPP_RTK || sppopt.mode == PMODE_VRS_RTK) {
             sppopt.sateph = EPHOPT_BRDC;
-            /* Enhanced seed (opt-in): apply the proven v0.6.10 SPP error model to
-             * this PRIVATE copy only. err[5]/err[6] are the C/N0 snr_max/snr_error
-             * coefficients here (varerr in mrtk_spp.c); the CLAS engine reads
-             * rtk->opt where the same slots mean the iono/trop estimation-error
-             * terms, so it stays untouched. Skipped when the profile is OFF,
-             * leaving the seed bit-identical to prior behaviour. */
+            /* Enhanced seed (default SEEDENH_BASE = cn0+tdcp; set OFF to disable):
+             * apply the proven v0.6.10 SPP error model to this PRIVATE copy only.
+             * err[5]/err[6] are the C/N0 snr_max/snr_error coefficients here (varerr
+             * in mrtk_spp.c); the CLAS engine reads rtk->opt where the same slots
+             * mean the iono/trop estimation-error terms, so it stays untouched. When
+             * the profile is OFF the seed is bit-identical to prior behaviour. */
             if (rtk->opt.enhanced_spp_seed >= SEEDENH_BASE) {
                 sppopt.err[5] = 50.0;  /* C/N0 reference snr_max (dB-Hz) */
                 sppopt.err[6] = 0.5;   /* C/N0 weighting coefficient (m) */

--- a/src/pos/mrtk_rtkpos.c
+++ b/src/pos/mrtk_rtkpos.c
@@ -2717,6 +2717,23 @@ extern int rtkpos(mrtk_ctx_t* ctx, rtk_t* rtk, const obsd_t* obs, int n, nav_t* 
         /* PPP-RTK/VRS: force broadcast ephemeris for SPP initial position */
         if (sppopt.mode == PMODE_PPP_RTK || sppopt.mode == PMODE_VRS_RTK) {
             sppopt.sateph = EPHOPT_BRDC;
+            /* Enhanced seed (opt-in): give the a-priori single-point fix the proven
+             * v0.6.10 SPP error model on this PRIVATE copy only. err[5]/err[6] are
+             * the C/N0 snr_max/snr_error coefficients here (varerr in mrtk_spp.c);
+             * the CLAS engine reads rtk->opt where the same slots mean the iono/trop
+             * estimation-error terms, so it stays untouched. Values match
+             * conf/benchmark/single.toml. Skipped when the flag is 0, leaving the
+             * seed bit-identical to prior behaviour. */
+            if (rtk->opt.enhanced_spp_seed) {
+                sppopt.err[5] = 50.0; /* C/N0 reference snr_max (dB-Hz) */
+                sppopt.err[6] = 0.5;  /* C/N0 weighting coefficient (m) */
+                sppopt.robust = 1;    /* IGG-III robust pseudorange re-weighting */
+                sppopt.robustk[0] = 1.5;
+                sppopt.robustk[1] = 4.0;
+                sppopt.tdcp = 1;       /* TDCP velocity + jump-rejection QC */
+                sppopt.tdcpjump = 5.0; /* reject seed epoch on code-vs-TDCP jump > 5 m */
+                sppopt.thresdop = 1.0; /* TDCP cycle-slip Doppler threshold (cyc/s) */
+            }
         }
         if (!pntpos(ctx, obs, nu, nav, &sppopt, &rtk->sol, NULL, rtk->ssat, msg)) {
             errmsg(rtk, "point pos error (%s)\n", msg);

--- a/src/pos/mrtk_rtkpos.c
+++ b/src/pos/mrtk_rtkpos.c
@@ -2727,9 +2727,11 @@ extern int rtkpos(mrtk_ctx_t* ctx, rtk_t* rtk, const obsd_t* obs, int n, nav_t* 
             if (rtk->opt.enhanced_spp_seed) {
                 sppopt.err[5] = 50.0; /* C/N0 reference snr_max (dB-Hz) */
                 sppopt.err[6] = 0.5;  /* C/N0 weighting coefficient (m) */
-                sppopt.robust = 1;    /* IGG-III robust pseudorange re-weighting */
-                sppopt.robustk[0] = 1.5;
-                sppopt.robustk[1] = 4.0;
+                /* IGG-III robust intentionally omitted: it improves average seed
+                 * accuracy but perturbs the seed trajectory enough to trip the
+                 * filter's reset/AR thresholds, and fix-and-hold then locks the
+                 * resulting wrong integer (tokyo_run3 misfix 5->71). C/N0+TDCP
+                 * keep the p95 benefit without that regression. */
                 sppopt.tdcp = 1;       /* TDCP velocity + jump-rejection QC */
                 sppopt.tdcpjump = 5.0; /* reject seed epoch on code-vs-TDCP jump > 5 m */
                 sppopt.thresdop = 1.0; /* TDCP cycle-slip Doppler threshold (cyc/s) */


### PR DESCRIPTION
## Summary

Improves CLAS **PPP-RTK / VRS-RTK** kinematic accuracy by applying the proven
v0.6.10 SPP error model (C/N0 weighting + TDCP jump-reject) to the **a-priori
single-point fix** that seeds — and, on a filter reset, re-seeds — the precise
filter. Controlled by a new `[positioning.clas] enhanced_spp_seed` axis,
**default `cn0+tdcp`**.

### The mechanism

Every epoch, `pntpos` computes a single-point fix into `rtk->sol.rr`; on a reset
(obs-loss gap, persistent-FLOAT, large PPP-RTK↔SPP divergence) the CLAS/VRS
filter re-initialises its position from it, and `resamb_LAMBDA` builds the AR
float vector from that position. A better seed therefore helps the kinematic,
reset-prone case.

### The key enabler — no CLAS corruption

The seed runs on a **private option copy** (`prcopt_t sppopt = rtk->opt`). The
C/N0 slots `err[5]/err[6]` mean `snr_max`/`snr_error` in the SPP `varerr` but the
iono/trop estimation-error terms in the CLAS `varerr`, so they are set **on the
copy only** — the CLAS measurement model is untouched.

## Configuration

`[positioning.clas] enhanced_spp_seed` (opt key `pos1-seedenh`):

| Value | Seed gets |
|-------|-----------|
| `off` | nothing — bit-identical to prior behaviour |
| `cn0+tdcp` | C/N0 weighting + TDCP jump-reject (**default**) |
| `cn0+tdcp+robust` | + IGG-III robust (open-sky opt-in) |

## Results (PPC-Dataset, 6 urban kinematic runs)

`cn0+tdcp` vs baseline: mean **fix rate 23.7 → 24.7 %** (+1.0 pp), mean
fixed-epoch **p95 3.23 → 3.02 m**, largest single gain on tokyo_run1
(p95 5.44 → 3.52 m). No large-misfix regression.

## Why robust is opt-in, not default

IGG-III robust lifts the mean fix rate a further +1.0 pp and helps open-sky runs,
but in a deep urban canyon (tokyo_run3) it shifts the seed enough to trip the
filter into fix-and-hold mis-fixes (mis-fixes 5 → 71, worst fixed error
4.4 m → 12 m). The harm is a **filter-coupling effect invisible to seed-local
diagnostics** and could not be auto-gated reliably (self-gate and filter-health
gate both prototyped and rejected), so robust is left to the operator. Full
rationale in `docs/design/spp-accuracy.md` §11.

## Safety

- **Static (みなしローバー) positioning unaffected.** All six claslib static
  regression cases run byte-close to the off baseline — deltas sub-cm RMS, inside
  the existing tolerances; one VRS case improves (fix 98.9 → 99.9 %). On clean
  continuously-tracked data the filter rarely falls back to SPP, so the seed is
  effectively inert.
- **PPP / PPP-AR deliberately excluded.** Investigated and confirmed the same
  lever yields no benefit there: PPP couples to the seed far more weakly (loose
  `VAR_POS` prior, no reset-to-SPP snap, AR resolves from the converged float),
  and an empirical probe on madocalib PPP-AR showed identical TTFF and
  post-convergence accuracy (2D RMS 4.172 → 4.170 cm). See `spp-accuracy.md` §11.

## Also in this PR

- `chore(conf)`: removed 31 deprecated commented `# constellations` / `# frequency`
  lines (19 files) superseded by the active `systems` / `signals` keys; active
  `frequency` keys untouched; no value change (taplo realignment only).
- Docs: new CLAS section in `docs/reference/benchmark.md`, design rationale in
  `docs/design/spp-accuracy.md` §11.

## Test status

`ctest -E rtkrcv_rt`: all `claslib_*` / `vrs` / `ppp-rtk` / `igs` / `spp` pass.
Only the known pre-existing `madocalib_pppar_ion_check` (LAPACK-vs-reference
tolerance) fails, unrelated to this change. Default-off path is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)