### PR TITLE
fix(clas): route real-time L6D demux by transmit pattern, not PRN (#197)

### DIFF
--- a/include/mrtklib/mrtk_clas.h
+++ b/include/mrtklib/mrtk_clas.h
@@ -762,8 +762,10 @@ int clas_get_correct_fac(int msgid);
  * the same channel, so corrections are not stranded on an unread channel.
  *
  * @param[in,out] ctx  CLAS context (holds the per-channel pattern lock)
- * @param[in]     ptn  CLAS Transmit Pattern ID, extracted from L6 header
- *                     byte 5 as `(byte5 & 0x06) >> 1`
+ * @param[in]     ptn  CLAS Transmit Pattern ID, extracted from the L6
+ *                     message-ID byte (`buff[5]`, the byte after the 4-byte
+ *                     preamble and PRN; same byte the decoder reads as
+ *                     `msgid`) as `(msgid & 0x06) >> 1`
  * @return L6 channel index (0..CLAS_CH_NUM-1)
  */
 int clas_pattern_to_ch(clas_ctx_t* ctx, int ptn);

--- a/include/mrtklib/mrtk_clas.h
+++ b/include/mrtklib/mrtk_clas.h
@@ -612,6 +612,12 @@ typedef struct {
     int l6delivery[CLAS_CH_NUM];
     int l6facility[CLAS_CH_NUM];
 
+    /* CLAS Transmit Pattern ID locked to each channel (-1=unset).
+     * Used by the real-time demux to route L6D frames by augmentation
+     * pattern instead of broadcasting PRN, so a QZS handover (PRN change
+     * within the same pattern) keeps feeding the same channel. */
+    int l6pattern[CLAS_CH_NUM];
+
     /* nav_t update flag (signals positioning engine to refresh) */
     int updateac;
 
@@ -746,6 +752,21 @@ void clas_check_grid_status(clas_ctx_t* ctx, const clas_corr_t* corr, int ch);
  * @return Facility ID (0-3)
  */
 int clas_get_correct_fac(int msgid);
+
+/**
+ * @brief Map a CLAS Transmit Pattern ID to an L6 channel index.
+ *
+ * Routes L6D frames by augmentation pattern rather than broadcasting PRN.
+ * The first pattern seen locks to ch 0; the other pattern locks to ch 1.
+ * A QZS satellite handover that changes the PRN but not the pattern keeps
+ * the same channel, so corrections are not stranded on an unread channel.
+ *
+ * @param[in,out] ctx  CLAS context (holds the per-channel pattern lock)
+ * @param[in]     ptn  CLAS Transmit Pattern ID, extracted from L6 header
+ *                     byte 5 as `(byte5 & 0x06) >> 1`
+ * @return L6 channel index (0..CLAS_CH_NUM-1)
+ */
+int clas_pattern_to_ch(clas_ctx_t* ctx, int ptn);
 
 /*============================================================================
  * Grid Interpolation (mrtk_clas_grid.c)

--- a/src/clas/mrtk_clas.c
+++ b/src/clas/mrtk_clas.c
@@ -77,6 +77,7 @@ extern int clas_ctx_init(clas_ctx_t* ctx) {
     for (i = 0; i < CLAS_CH_NUM; i++) {
         ctx->l6facility[i] = -1;
         ctx->l6delivery[i] = -1;
+        ctx->l6pattern[i] = -1;
     }
     ctx->initialized = 1;
     return 0;
@@ -2857,6 +2858,27 @@ extern int clas_get_correct_fac(int msgid) {
                 return -1;
         }
     }
+}
+
+extern int clas_pattern_to_ch(clas_ctx_t* ctx, int ptn) {
+    int ch;
+
+    /* return the channel already locked to this pattern */
+    for (ch = 0; ch < CLAS_CH_NUM; ch++) {
+        if (ctx->l6pattern[ch] == ptn) {
+            return ch;
+        }
+    }
+    /* otherwise lock this pattern to the first free channel */
+    for (ch = 0; ch < CLAS_CH_NUM; ch++) {
+        if (ctx->l6pattern[ch] < 0) {
+            ctx->l6pattern[ch] = ptn;
+            trace(NULL, 2, "L6 pattern lock: ch=%d pattern=%d\n", ch, ptn);
+            return ch;
+        }
+    }
+    /* all channels taken (>2 patterns is not expected): fall back to ch 0 */
+    return 0;
 }
 
 extern int clas_input_cssr(clas_ctx_t* ctx, uint8_t data, int ch) {

--- a/src/stream/mrtk_rtksvr.c
+++ b/src/stream/mrtk_rtksvr.c
@@ -486,7 +486,8 @@ static int decoderaw(rtksvr_t* svr, int index) {
                  * route every frame to ch 0 — this keeps corrections flowing
                  * across a QZS satellite handover (PRN change), see #197.
                  * Dual-channel CLAS (l6mrg!=0) demuxes by CLAS Transmit Pattern
-                 * ID (L6 header byte 5, bits 2-1), not by PRN, so each of the
+                 * ID (bits 2-1 of the L6 message-ID byte buff[5], i.e. the byte
+                 * after the 4-byte preamble and PRN), not by PRN, so each of the
                  * two augmentation patterns locks to its own channel and a
                  * handover within a pattern stays on the same channel. */
                 if (!svr->rtk.opt.l6mrg) {

--- a/src/stream/mrtk_rtksvr.c
+++ b/src/stream/mrtk_rtksvr.c
@@ -480,24 +480,20 @@ static int decoderaw(rtksvr_t* svr, int index) {
              svr->format[index] == STRFMT_SEPT)) {
             int k, ch, cret, max_cret = 0;
 
-            if (svr->format[index] == STRFMT_UBX) {
-                /* UBX: demux L6D frames by PRN (both channels in same stream) */
-                int l6prn = svr->rtcm[index].buff[4]; /* PRN from L6 frame header */
-                if (svr->clas->l6delivery[0] < 0 || svr->clas->l6delivery[0] == l6prn) {
+            if (svr->format[index] == STRFMT_UBX || svr->format[index] == STRFMT_SEPT) {
+                /* UBX/SBF: both L6 channels arrive interleaved in one stream.
+                 * Single-channel CLAS (l6mrg=0) only ever reads ssr_ch[0], so
+                 * route every frame to ch 0 — this keeps corrections flowing
+                 * across a QZS satellite handover (PRN change), see #197.
+                 * Dual-channel CLAS (l6mrg!=0) demuxes by CLAS Transmit Pattern
+                 * ID (L6 header byte 5, bits 2-1), not by PRN, so each of the
+                 * two augmentation patterns locks to its own channel and a
+                 * handover within a pattern stays on the same channel. */
+                if (!svr->rtk.opt.l6mrg) {
                     ch = 0;
                 } else {
-                    ch = 1;
-                }
-            } else if (svr->format[index] == STRFMT_SEPT) {
-                /* SBF: demux L6D frames by PRN from raw->ephsat */
-                int l6prn = 0, sat = svr->raw[index].ephsat;
-                if (sat > 0) {
-                    satsys(sat, &l6prn);
-                }
-                if (svr->clas->l6delivery[0] < 0 || svr->clas->l6delivery[0] == l6prn) {
-                    ch = 0;
-                } else {
-                    ch = 1;
+                    int ptn = (svr->rtcm[index].buff[5] & 0x06) >> 1;
+                    ch = clas_pattern_to_ch(svr->clas, ptn);
                 }
             } else {
                 /* L6E: use stream index mapping (separate streams per channel) */


### PR DESCRIPTION
## 概要

リアルタイム CLAS（`mrtk run`, PPP-RTK）で、QZSS L6 衛星のハンドオーバー（追尾 PRN の切替）を境に CLAS 補正が止まり、解が Single (Q=5, age=10000) に落ちる事象を修正します。`Closes #197`。

## 原因（#197 解析と一致）

UBX/SBF 単一ストリームの L6 デマックスが ch0 を「起動時に最初に見た PRN」へ固定（`l6delivery[0]`）。ハンドオーバーで PRN が変わると新フレームが未使用の `ch=1` に振り分けられ、単一CLAS（`l6mrg=0`）のソルバは `ssr_ch[0]` のみ参照するため補正が途絶 → `age=1e4` → Q=5。区間の自然復旧/再起動復旧/恒星日回帰の signature まで #197 の観測と整合。

## 修正

[`src/stream/mrtk_rtksvr.c`](../blob/fix/clas-l6-pattern-demux/src/stream/mrtk_rtksvr.c) の UBX/SBF 単一ストリーム経路を再キー化：

- **`l6mrg=0`（単一CLAS, 既定）**: PRN によらず全フレームを ch0 へ集約。ハンドオーバーをまたいで補正が継続 → #197 解消。
- **`l6mrg!=0`（2ch）**: PRN ではなく **CLAS Transmit Pattern ID**（L6 ヘッダ byte5 の bit2-1）でデマックス。2つの補強パターンがそれぞれ別 ch にロックされ（`clas_pattern_to_ch()` + `ctx->l6pattern[]`）、同一パターン内のハンドオーバーは同じ ch に留まる。両パターン受信・マージで最大22衛星補強（IS-QZSS-L6 §4.1.1.2）。

L6E / STRFMT_CLAS の別ストリーム経路（index ルーティング）は不変。`l6delivery[]` は trace 用に保持しルーティングからは除外。

## 変更ファイル

- `src/stream/mrtk_rtksvr.c` — UBX/SBF デマックスをパターン基盤に
- `src/clas/mrtk_clas.c` — `clas_pattern_to_ch()` 追加、`l6pattern[]` 初期化
- `include/mrtklib/mrtk_clas.h` — フィールド＋ヘルパ宣言（Doxygen）

## テスト

ローカル回帰スモーク green：
- CLAS PP: `claslib_ppp_rtk` / `_2ch` / `_bnx` / `_st12` / `_l1cl5` 全 pass
- RT: `rtkrcv_rt_clas`（単一ch）pass、`rtkrcv_rt_clas_2ch` pass（クリーン実行）
- テスト許容値の変更なし

### カバレッジの限界（重要）
登録済みの CLAS テストは `format="clas"`（STRFMT_CLAS, 別ストリーム index ルーティング＝**経路①**）を通り、**本修正の経路③（UBX/SBF 単一ストリーム）を実行しません**。リポジトリに経路③用データが無いためです。よって CI は経路①②の**無回帰のみ**を担保します。経路③の実機実証（`G5P3073h.sbf` 等、QZS ハンドオーバーを含む UBX/SBF データでのリプレイ）は **follow-up** とします。ロジックは #197 のコード解析と IS-QZSS-L6 §4.1.1.2 に整合しており回帰リスクは低いと評価。

🤖 Generated with [Claude Code](https://claude.com/claude-code)