### PR TITLE
fix(clas): demux interleaved multi-PRN L6D by active-source lock (#197)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,7 @@ enable_testing()
 # ── Unit tests ───────────────────────────────────────────────────────────────
 set(_UTEST_DIR ${CMAKE_SOURCE_DIR}/tests/utest)
 set(_UTEST_SOURCES
-    t_atmos t_coord t_freqidx t_geoid t_gloeph t_ionex
+    t_atmos t_clas_route t_coord t_freqidx t_geoid t_gloeph t_ionex
     t_lambda t_matrix t_misc t_obsdef t_ppp t_preceph
     t_rinex t_rinex4 t_sigcfg_decode t_time
     # t_tle excluded: tle_pos() implementation not yet in library

--- a/include/mrtklib/mrtk_clas.h
+++ b/include/mrtklib/mrtk_clas.h
@@ -618,6 +618,13 @@ typedef struct {
      * within the same pattern) keeps feeding the same channel. */
     int l6pattern[CLAS_CH_NUM];
 
+    /* Obs time when each channel last accepted an L6 frame from its active
+     * source PRN (l6delivery[ch]).  The demux drops frames from any other PRN
+     * to keep each channel's subframe assembly coherent, and re-locks the
+     * channel to a new PRN/pattern once the active source has been silent
+     * longer than CLAS_L6_RELOCK_TIMEOUT (QZS handover recovery). */
+    gtime_t l6lock_time[CLAS_CH_NUM];
+
     /* nav_t update flag (signals positioning engine to refresh) */
     int updateac;
 
@@ -753,22 +760,35 @@ void clas_check_grid_status(clas_ctx_t* ctx, const clas_corr_t* corr, int ch);
  */
 int clas_get_correct_fac(int msgid);
 
+/** Seconds an L6 channel's active source PRN may be silent before the demux
+ *  re-locks the channel to a newly arriving PRN/pattern (QZS handover). */
+#define CLAS_L6_RELOCK_TIMEOUT 10.0
+
 /**
- * @brief Map a CLAS Transmit Pattern ID to an L6 channel index.
+ * @brief Route one interleaved L6D frame to a CLAS channel (or drop it).
  *
- * Routes L6D frames by augmentation pattern rather than broadcasting PRN.
- * The first pattern seen locks to ch 0; the other pattern locks to ch 1.
- * A QZS satellite handover that changes the PRN but not the pattern keeps
- * the same channel, so corrections are not stranded on an unread channel.
+ * A single UBX/SBF stream from a multi-channel L6 receiver (e.g. u-blox D9C,
+ * and future receivers with more channels) carries L6D frames from several
+ * QZS PRNs interleaved.  Each CLAS channel decodes one PRN's subframe sequence
+ * statefully, so frames from different PRNs must NOT be mixed into the same
+ * channel.  This router keeps each channel locked to a single active source
+ * PRN and drops frames from any other PRN, re-locking only after the active
+ * source has been silent for CLAS_L6_RELOCK_TIMEOUT seconds.
  *
- * @param[in,out] ctx  CLAS context (holds the per-channel pattern lock)
- * @param[in]     ptn  CLAS Transmit Pattern ID, extracted from the L6
- *                     message-ID byte (`buff[5]`, the byte after the 4-byte
- *                     preamble and PRN; same byte the decoder reads as
- *                     `msgid`) as `(msgid & 0x06) >> 1`
- * @return L6 channel index (0..CLAS_CH_NUM-1)
+ * Channels are keyed by CLAS Transmit Pattern ID (IS-QZSS-L6 §4.1.1.2): there
+ * are only two patterns, so two channels suffice regardless of how many PRNs
+ * the receiver tracks.  Single-channel CLAS (`l6mrg=0`) uses ch 0 only and
+ * collapses to whichever pattern is currently active; dual-channel CLAS
+ * (`l6mrg!=0`) maps each pattern to its own channel for merging.
+ *
+ * @param[in,out] ctx    CLAS context (holds per-channel PRN/pattern/time lock)
+ * @param[in]     prn    Broadcasting QZS PRN (L6 frame byte `buff[4]`)
+ * @param[in]     ptn    CLAS Transmit Pattern ID, `(buff[5] & 0x06) >> 1`
+ * @param[in]     l6mrg  L6 merge mode (0:single channel, !=0:dual channel)
+ * @param[in]     now    Current observation time (GPST) used for the timeout
+ * @return Channel index (0..CLAS_CH_NUM-1) to feed, or -1 to drop the frame.
  */
-int clas_pattern_to_ch(clas_ctx_t* ctx, int ptn);
+int clas_route_l6frame(clas_ctx_t* ctx, int prn, int ptn, int l6mrg, gtime_t now);
 
 /*============================================================================
  * Grid Interpolation (mrtk_clas_grid.c)

--- a/src/clas/mrtk_clas.c
+++ b/src/clas/mrtk_clas.c
@@ -78,6 +78,8 @@ extern int clas_ctx_init(clas_ctx_t* ctx) {
         ctx->l6facility[i] = -1;
         ctx->l6delivery[i] = -1;
         ctx->l6pattern[i] = -1;
+        ctx->l6lock_time[i].time = 0;
+        ctx->l6lock_time[i].sec = 0.0;
     }
     ctx->initialized = 1;
     return 0;
@@ -2860,25 +2862,61 @@ extern int clas_get_correct_fac(int msgid) {
     }
 }
 
-extern int clas_pattern_to_ch(clas_ctx_t* ctx, int ptn) {
-    int ch;
+extern int clas_route_l6frame(clas_ctx_t* ctx, int prn, int ptn, int l6mrg, gtime_t now) {
+    int ch, target, locked_prn, stale;
+    int nch = l6mrg ? CLAS_CH_NUM : 1;
 
-    /* return the channel already locked to this pattern */
-    for (ch = 0; ch < CLAS_CH_NUM; ch++) {
-        if (ctx->l6pattern[ch] == ptn) {
+    /* 1. already the active source on some channel → accept and refresh */
+    for (ch = 0; ch < nch; ch++) {
+        if (ctx->l6delivery[ch] == prn) {
+            ctx->l6lock_time[ch] = now;
             return ch;
         }
     }
-    /* otherwise lock this pattern to the first free channel */
-    for (ch = 0; ch < CLAS_CH_NUM; ch++) {
-        if (ctx->l6pattern[ch] < 0) {
-            ctx->l6pattern[ch] = ptn;
-            trace(NULL, 2, "L6 pattern lock: ch=%d pattern=%d\n", ch, ptn);
-            return ch;
+
+    /* 2. pick the target channel for this frame.
+     *    single channel: ch 0 carries whatever pattern is active.
+     *    dual channel:   one channel per pattern (lock pattern→channel). */
+    if (!l6mrg) {
+        target = 0;
+    } else {
+        target = -1;
+        for (ch = 0; ch < nch; ch++) {
+            if (ctx->l6pattern[ch] == ptn) {
+                target = ch;
+                break;
+            }
+        }
+        if (target < 0) { /* assign this pattern to a free channel */
+            for (ch = 0; ch < nch; ch++) {
+                if (ctx->l6pattern[ch] < 0) {
+                    target = ch;
+                    break;
+                }
+            }
+        }
+        if (target < 0) {
+            return -1; /* >CLAS_CH_NUM patterns (not expected): drop */
         }
     }
-    /* all channels taken (>2 patterns is not expected): fall back to ch 0 */
-    return 0;
+
+    /* 3. (re)lock the target channel to this PRN only if it is free or its
+     *    current active source has gone silent past the handover timeout;
+     *    otherwise drop to keep the channel's subframe stream coherent. */
+    locked_prn = ctx->l6delivery[target];
+    stale = (ctx->l6lock_time[target].time == 0) || (timediff(now, ctx->l6lock_time[target]) > CLAS_L6_RELOCK_TIMEOUT);
+
+    if (locked_prn < 0 || stale) {
+        if (locked_prn != prn || ctx->l6pattern[target] != ptn) {
+            trace(NULL, 2, "L6 lock: ch=%d prn=%d pattern=%d (was prn=%d pattern=%d)\n", target, prn, ptn, locked_prn,
+                  ctx->l6pattern[target]);
+        }
+        ctx->l6delivery[target] = prn;
+        ctx->l6pattern[target] = ptn;
+        ctx->l6lock_time[target] = now;
+        return target;
+    }
+    return -1; /* channel busy with a different, still-active PRN → drop */
 }
 
 extern int clas_input_cssr(clas_ctx_t* ctx, uint8_t data, int ch) {

--- a/src/stream/mrtk_rtksvr.c
+++ b/src/stream/mrtk_rtksvr.c
@@ -481,20 +481,18 @@ static int decoderaw(rtksvr_t* svr, int index) {
             int k, ch, cret, max_cret = 0;
 
             if (svr->format[index] == STRFMT_UBX || svr->format[index] == STRFMT_SEPT) {
-                /* UBX/SBF: both L6 channels arrive interleaved in one stream.
-                 * Single-channel CLAS (l6mrg=0) only ever reads ssr_ch[0], so
-                 * route every frame to ch 0 — this keeps corrections flowing
-                 * across a QZS satellite handover (PRN change), see #197.
-                 * Dual-channel CLAS (l6mrg!=0) demuxes by CLAS Transmit Pattern
-                 * ID (bits 2-1 of the L6 message-ID byte buff[5], i.e. the byte
-                 * after the 4-byte preamble and PRN), not by PRN, so each of the
-                 * two augmentation patterns locks to its own channel and a
-                 * handover within a pattern stays on the same channel. */
-                if (!svr->rtk.opt.l6mrg) {
-                    ch = 0;
-                } else {
-                    int ptn = (svr->rtcm[index].buff[5] & 0x06) >> 1;
-                    ch = clas_pattern_to_ch(svr->clas, ptn);
+                /* UBX/SBF: a multi-channel L6 receiver (e.g. u-blox D9C, 2ch)
+                 * interleaves L6D frames from several QZS PRNs in one stream.
+                 * Route each frame to a CLAS channel keyed by transmit pattern,
+                 * keeping each channel locked to a single active PRN so subframe
+                 * assembly stays coherent across a satellite handover (#197).
+                 * ch<0 means the frame is from a non-active PRN — drop it so the
+                 * locked channel's subframe stream is not corrupted by mixing. */
+                int prn = svr->rtcm[index].buff[4];
+                int ptn = (svr->rtcm[index].buff[5] & 0x06) >> 1;
+                ch = clas_route_l6frame(svr->clas, prn, ptn, svr->rtk.opt.l6mrg, svr->raw[0].time);
+                if (ch < 0) {
+                    continue;
                 }
             } else {
                 /* L6E: use stream index mapping (separate streams per channel) */

--- a/tests/utest/t_clas_route.c
+++ b/tests/utest/t_clas_route.c
@@ -1,0 +1,96 @@
+/*------------------------------------------------------------------------------
+ * unit test : clas_route_l6frame() L6D demux contract (#197)
+ *
+ * A multi-channel L6 receiver (u-blox D9C, 2ch; future receivers with more)
+ * interleaves L6D frames from several QZS PRNs in one UBX/SBF stream. Each CLAS
+ * channel decodes one PRN's subframe sequence statefully, so the demux must:
+ *   - lock each channel to a single active source PRN and DROP frames from any
+ *     other PRN (mixing two PRNs into one channel corrupts subframe assembly,
+ *     which manifested as "L6 Lost" with corrections flowing but not decoding);
+ *   - re-lock a channel to a new PRN/pattern only after the active source has
+ *     been silent past CLAS_L6_RELOCK_TIMEOUT (QZS satellite handover, #197);
+ *   - key channels by CLAS Transmit Pattern ID in dual mode (l6mrg!=0) so the
+ *     two augmentation patterns map to separate channels for merging, while
+ *     single mode (l6mrg=0) collapses to ch0.
+ *
+ * The routing decision is a pure function of (prn, ptn, l6mrg, now) and the
+ * per-channel lock state, so it is fully testable without a raw L6 stream.
+ * Explicit checks (not assert) so it is robust under -DNDEBUG.
+ *-----------------------------------------------------------------------------*/
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "mrtklib/mrtk_clas.h"
+
+static int fails = 0;
+
+#define CHECK(cond, msg)                 \
+    do {                                 \
+        if (!(cond)) {                   \
+            printf("FAIL: %s\n", (msg)); \
+            fails++;                     \
+        } else {                         \
+            printf("ok  : %s\n", (msg)); \
+        }                                \
+    } while (0)
+
+/* GPST time t seconds past an arbitrary epoch */
+static gtime_t at(int t) {
+    gtime_t g;
+    g.time = (time_t)(1000000000 + t);
+    g.sec = 0.0;
+    return g;
+}
+
+/* fresh context with the demux lock state cleared (banks not needed here) */
+static clas_ctx_t* fresh(void) {
+    clas_ctx_t* ctx = (clas_ctx_t*)calloc(1, sizeof(clas_ctx_t));
+    int i;
+    for (i = 0; i < CLAS_CH_NUM; i++) {
+        ctx->l6delivery[i] = -1;
+        ctx->l6pattern[i] = -1;
+        ctx->l6lock_time[i].time = 0;
+        ctx->l6lock_time[i].sec = 0.0;
+    }
+    return ctx;
+}
+
+/* single-channel CLAS (l6mrg=0): one coherent PRN on ch0, handover re-lock */
+static void test_single(void) {
+    clas_ctx_t* ctx = fresh();
+
+    CHECK(clas_route_l6frame(ctx, 194, 2, 0, at(0)) == 0, "single: first PRN locks ch0");
+    CHECK(clas_route_l6frame(ctx, 194, 2, 0, at(1)) == 0, "single: active PRN stays on ch0");
+    CHECK(clas_route_l6frame(ctx, 199, 1, 0, at(1)) == -1, "single: interleaved 2nd PRN dropped");
+    CHECK(clas_route_l6frame(ctx, 194, 2, 0, at(5)) == 0, "single: active PRN refreshes lock");
+    CHECK(clas_route_l6frame(ctx, 199, 1, 0, at(8)) == -1, "single: 2nd PRN still dropped within timeout");
+    CHECK(clas_route_l6frame(ctx, 199, 1, 0, at(16)) == 0, "single: re-lock to new PRN after timeout (handover)");
+    CHECK(clas_route_l6frame(ctx, 199, 1, 0, at(17)) == 0, "single: new active PRN stays on ch0");
+    CHECK(clas_route_l6frame(ctx, 194, 2, 0, at(17)) == -1, "single: old PRN now dropped");
+
+    free(ctx);
+}
+
+/* dual-channel CLAS (l6mrg!=0): one channel per transmit pattern */
+static void test_dual(void) {
+    clas_ctx_t* ctx = fresh();
+
+    CHECK(clas_route_l6frame(ctx, 194, 2, 1, at(0)) == 0, "dual: pattern 2 → ch0");
+    CHECK(clas_route_l6frame(ctx, 199, 1, 1, at(0)) == 1, "dual: pattern 1 → ch1");
+    CHECK(clas_route_l6frame(ctx, 194, 2, 1, at(0)) == 0, "dual: pattern 2 PRN stays ch0");
+    CHECK(clas_route_l6frame(ctx, 195, 1, 1, at(1)) == -1, "dual: 2nd same-pattern PRN dropped");
+    CHECK(clas_route_l6frame(ctx, 195, 1, 1, at(12)) == 1, "dual: same-pattern handover re-locks ch1");
+    CHECK(clas_route_l6frame(ctx, 195, 1, 1, at(13)) == 1, "dual: new active PRN stays ch1");
+    CHECK(clas_route_l6frame(ctx, 199, 1, 1, at(13)) == -1, "dual: replaced PRN now dropped");
+    CHECK(clas_route_l6frame(ctx, 194, 2, 1, at(13)) == 0, "dual: active PRN short-circuits regardless of pattern arg");
+
+    free(ctx);
+}
+
+int main(void) {
+    test_single();
+    test_dual();
+
+    printf("\n%s: %d check(s) failed\n", fails ? "FAIL" : "PASS", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
## 概要

#200 で入れた「`l6mrg=0` のとき全 L6D フレームを ch0 に集約」は、**マルチチャンネル L6 受信機**（u-blox D9C は QZS を2機同時追尾、将来機種はさらに多ch）が**1本のストリームに複数 PRN のフレームを交互に載せる**ケースで破綻していました。2つの PRN のサブフレーム列を単一 `l6buf[0]` に混ぜてしまい CSSR の組み立てが壊れ、補正は流入しているのに復号できず（`age=10000` / Q=5）「**L6 Lost**」となります。`Refs #197`。

## 実機データで根本原因を確定

ライブの TUMSAT D9C ストリーム（`ntrip://.../TUMSATD9C`）を `l6extract` で解析：

| PRN | 衛星 | Transmit Pattern | フレーム数 |
|---|---|---|---|
| J195 | QZS4 | Pattern 1 | 174 |
| J196 | QZS1R | Pattern 2 | 174 |

→ **2 PRN（=2パターン）がほぼ 1:1 で連続交互流入**。集約 ch0 が混線していました。

## 修正

`clas_route_l6frame()` を新設し、UBX/SBF 単一ストリームのデマックスを置換：

- **各チャンネルを単一アクティブ PRN にロック**し、他 PRN のフレームは**ドロップ**してサブフレーム列を一貫させる（混線=L6 Lost の根治）。
- アクティブ PRN が `CLAS_L6_RELOCK_TIMEOUT`（**10秒**）途絶したら新 PRN/パターンへ**再ロック**（QZS ハンドオーバー復旧＝#197 本体）。
- チャンネルは **CLAS Transmit Pattern ID** でキーイング。パターンは2種類なので、**受信機の ch 数によらず2チャンネルで対応**（D9C 2ch も将来の N ch も）。単一CLAS（`l6mrg=0`）は ch0、デュアル（`l6mrg!=0`）は各パターンを別 ch に割り当ててマージ。

#200 の ch0 集約 / `clas_pattern_to_ch` を置き換えます。L6E 別ストリーム経路は不変。

## テスト

- **新規ユニットテスト `t_clas_route`（16 チェック全 pass）**：交互流入ドロップ／ハンドオーバー再ロック／2パターン分離を網羅。振り分けは `(prn, ptn, l6mrg, now)` の純関数なので生ストリーム無しで完全検証可能。
- utest 全20件 pass、フルビルド OK、フォーマット適用済み。

## 検証ステータス（重要）

- ✅ 根本原因＝実機 D9C データで確定（交互流入）。
- ✅ 振り分けロジック＝ユニットテストで網羅。
- ⏳ **測位 E2E は別環境で実施予定**。ローカルでは positioning E2E ができませんでした：(1) 提供マウント `TUMSATF9P` は **NMEA 出力**で生観測が無い、(2) headless `vt is NULL` でローカル RT replay が不安定。**raw 観測が得られる別環境**で本ブランチを develop に取り込んで E2E（ハンドオーバーをまたいで Fix 継続）を確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)