### PR TITLE
ci(format): retry transient taplo download failures

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -40,7 +40,11 @@ jobs:
           TAPLO_SHA256: 8fe196b894ccf9072f98d4e1013a180306e17d244830b03986ee5e8eabeb6156
         run: |
           mkdir -p "$HOME/.local/bin"
-          curl -fsSL -o taplo.gz \
+          # Retry transient GitHub Releases failures (e.g. HTTP 504) so an
+          # infra hiccup downloading taplo does not fail unrelated PRs.
+          # --retry-all-errors makes --retry also cover HTTP 5xx responses.
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 \
+            --connect-timeout 15 -o taplo.gz \
             https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-x86_64.gz
           echo "${TAPLO_SHA256}  taplo.gz" | sha256sum -c -
           gunzip -c taplo.gz > "$HOME/.local/bin/taplo"


### PR DESCRIPTION
## Problem

The Formatter Check's **Install pinned taplo** step downloads the taplo
binary from GitHub Releases with a plain `curl -fsSL` and no retry. When the
releases CDN returns a transient **HTTP 504**, the step fails immediately
(`curl: (22) ... error: 504`), the next step errors with `taplo: command not
found` (exit 127), and the whole job goes red — even on PRs that change no
TOML (or no code at all).

This just happened repeatedly on #202 (a docs-only PR): the taplo download
504'd on 3 consecutive runs, blocking an otherwise-clean change.

## Fix

Add retry/backoff to the download:

```bash
curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 \
  --connect-timeout 15 -o taplo.gz \
  https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-x86_64.gz
```

- `--retry 5 --retry-delay 3` — up to 5 attempts, 3 s apart
- `--retry-all-errors` — required so `--retry` also retries HTTP 5xx (504),
  not just connection-level errors
- `--connect-timeout 15` — bound a stuck connect

The SHA-256 pin is unchanged, so a retried download is still verified before
use. No change to what is formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)