### PR TITLE
fix(relay): create runtime context so `mrtk relay -t` writes a trace file (#79)

### DIFF
--- a/apps/str2str/str2str.c
+++ b/apps/str2str/str2str.c
@@ -40,6 +40,7 @@
 #include <unistd.h>
 
 #include "mrtklib/mrtk_cli.h"
+#include "mrtklib/mrtk_context.h"
 #include "mrtklib/rtklib.h"
 
 #define PRGNAME "str2str"      /* program name */
@@ -248,6 +249,7 @@ int mrtk_relay(int argc, char** argv) {
     int i, j, n = 0, dispint = 5000, trlevel = 0, opts[] = {10000, 10000, 2000, 32768, 10, 0, 30, 0};
     int types[MAXSTR] = {STR_FILE, STR_FILE}, stat[MAXSTR] = {0}, log_stat[MAXSTR] = {0};
     int byte[MAXSTR] = {0}, bps[MAXSTR] = {0}, fmts[MAXSTR] = {0}, sta = 0;
+    mrtk_ctx_t* ctx = NULL;
 
     /* translate --long flags to their -short aliases before parsing */
     mrtk_normalize_args(argc, argv, opt_aliases);
@@ -359,6 +361,10 @@ int mrtk_relay(int argc, char** argv) {
     strsvrinit(&strsvr, n);
 
     if (trlevel > 0) {
+        /* trace*() resolve their target through the global runtime context;
+           without it traceopen() no-ops and no trace file is written (#79) */
+        ctx = mrtk_ctx_create();
+        g_mrtk_ctx = ctx;
         traceopen(NULL, *logfile ? logfile : TRFILE);
         tracelevel(NULL, trlevel);
     }
@@ -374,6 +380,11 @@ int mrtk_relay(int argc, char** argv) {
     /* start stream server */
     if (!strsvrstart(&strsvr, opts, types, paths, logs, conv, cmds, cmds_periodic, stapos)) {
         fprintf(stderr, "stream server start error\n");
+        if (trlevel > 0) {
+            traceclose(NULL);
+            g_mrtk_ctx = NULL;
+            mrtk_ctx_destroy(ctx);
+        }
         return -1;
     }
     for (intrflg = 0; !intrflg;) {
@@ -398,6 +409,8 @@ int mrtk_relay(int argc, char** argv) {
     }
     if (trlevel > 0) {
         traceclose(NULL);
+        g_mrtk_ctx = NULL;
+        mrtk_ctx_destroy(ctx);
     }
     fprintf(stderr, "stream server stop\n");
     return 0;

--- a/apps/str2str/str2str.c
+++ b/apps/str2str/str2str.c
@@ -380,6 +380,9 @@ int mrtk_relay(int argc, char** argv) {
     /* start stream server */
     if (!strsvrstart(&strsvr, opts, types, paths, logs, conv, cmds, cmds_periodic, stapos)) {
         fprintf(stderr, "stream server start error\n");
+        for (i = 0; i < n; i++) {
+            strconvfree(conv[i]);
+        }
         if (trlevel > 0) {
             traceclose(NULL);
             g_mrtk_ctx = NULL;


### PR DESCRIPTION
## Summary

Fixes #79 — `mrtk relay -t <level>` did not create a trace file (`str2str.trace` or `-fl` target).

## Root cause

`trace*()` resolve their output target through the global runtime context `g_mrtk_ctx`, which defaults to `NULL`. Every other subcommand (`run`, `post`, `ssr2osr`, `recvbias`) calls `mrtk_ctx_create()` and assigns `g_mrtk_ctx` at startup — but `mrtk_relay()` (apps/str2str/str2str.c) never did. So `traceopen(NULL, ...)` resolved to the NULL global, returned early, and no file was opened.

This is **not** the argv/dispatch-offset issue the original report suspected: `-t` parsing (`str2str.c`) and the subcommand dispatch (`mrtk_main.c`, `argc-1, argv+1`) are both correct. `TRACE` is defined in the build, so the trace functions are real, not stubs.

## Change

`apps/str2str/str2str.c` (+13 lines):
- When `trlevel > 0`, create the runtime context and set `g_mrtk_ctx` before `traceopen()`.
- Tear it down (`traceclose` + `mrtk_ctx_destroy` + `g_mrtk_ctx = NULL`) on both exit paths — normal stop and `strsvrstart` failure.

No positioning/algorithm/constant code touched.

## Verification

Manual (3 cases):
- `-t 3 -fl mytrace.trace` → 7 KB trace written with expected content
- `-t 2` (default name) → `str2str.trace` created
- no `-t` → no trace file (unchanged correct behaviour)

`ctest`: 80/82 passing; the only 2 failures are the known pre-existing env failures (`rtkrcv_rt`, `madocalib_pppar_ion_check`) that reproduce on clean `develop`. No regression.

clang-format 21.1.6 clean.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)