### PR TITLE
fix(clas): VRS/OSR output correctness — signal-slot desync + skip dead satellites

### DIFF
--- a/src/clas/mrtk_clas_osr.c
+++ b/src/clas/mrtk_clas_osr.c
@@ -1649,6 +1649,26 @@ int clas_ssr2osr(rtk_t* rtk, obsd_t* obs, int n, nav_t* nav, clas_osrd_t* osr, i
             if (osr[i].sat <= 0) {
                 continue;
             }
+
+            /* Skip satellites with no usable observation on any signal. When
+             * CLAS provides no valid code/phase bias for a satellite (or it is
+             * stale), every signal comes out P = L = 0. The MSM encoder then
+             * writes such a satellite with rough range 255 (invalid): a dead
+             * entry that occupies the satellite mask but carries no usable
+             * range or carrier. The rover cannot position with it and may let
+             * it disturb satellite selection, so do not advertise it at all. */
+            {
+                int any_valid = 0;
+                for (j = 0; j < nf; j++) {
+                    if (osr[i].p[j] != 0.0 || osr[i].c[j] != 0.0) {
+                        any_valid = 1;
+                        break;
+                    }
+                }
+                if (!any_valid) {
+                    continue;
+                }
+            }
             sys_v = satsys(sati, NULL);
 
             obs[ko].time = obs[i].time;

--- a/src/clas/mrtk_clas_osr.c
+++ b/src/clas/mrtk_clas_osr.c
@@ -1175,10 +1175,12 @@ int clas_osr_zdres(const obsd_t* obs, int n, const double* rs, const double* dts
          * slot ordering matches the VRS fill in clas_ssr2osr(), which emits
          * obs[].code[j] = smode[j] and reads osr[].c[j] by the same index.
          *
-         * This MUST be unconditional. The dummy-obs buffer is reused across
-         * epochs, so obs_copy[].code[j] can hold a stale non-zero code from a
-         * previous epoch (or a different satellite). A `code[j]==0` guard then
-         * leaves that stale code in place, desyncing the slot order from smode:
+         * This MUST be unconditional. VRS/OSR callers (e.g. cssr2rtcm3) reuse
+         * one input obs buffer across epochs and that buffer is copied into
+         * obs_copy at the top of this function, so obs_copy[].code[j] can carry
+         * a stale non-zero code from a previous epoch (or a different
+         * satellite). A `code[j]==0` guard then leaves that stale code in
+         * place, desyncing the slot order from smode:
          * zdres computes osr[].c[] for one signal while the fill reads it as
          * another, leaking a stale carrier value (observed as ~1153 m E5a
          * glitches on E33 when the receiver-tracked signal set differs from the

--- a/src/clas/mrtk_clas_osr.c
+++ b/src/clas/mrtk_clas_osr.c
@@ -1190,6 +1190,13 @@ int clas_osr_zdres(const obsd_t* obs, int n, const double* rs, const double* dts
             for (j = 0; j < nf; j++) {
                 obs_copy[i].code[j] = corr->smode[sat - 1][j];
             }
+            /* Clear the unused (>= nf) code slots too: the reused input buffer
+             * can leave stale non-zero codes there, and downstream readers
+             * (sat_wavelengths over all slots, the GAL L2-slot / L2C checks)
+             * would otherwise pick them up when nf < NFREQ. */
+            for (j = nf; j < NFREQ + NEXOBS; j++) {
+                obs_copy[i].code[j] = 0;
+            }
         }
 
         /* compute wavelengths for this satellite */

--- a/src/clas/mrtk_clas_osr.c
+++ b/src/clas/mrtk_clas_osr.c
@@ -1171,15 +1171,22 @@ int clas_osr_zdres(const obsd_t* obs, int n, const double* rs, const double* dts
         sys = satsys(sat, &prn);
         osr[i].sat = sat;
 
-        /* VRS mode (y==NULL): pre-populate obs codes from CLAS smode
-         * so that clas_osr_corrmeas can match bias corrections.
-         * Guard with code[j]==0 to avoid overwriting real receiver codes
-         * in PPP-RTK mode. */
+        /* VRS mode (y==NULL): set obs codes from CLAS smode so the per-signal
+         * slot ordering matches the VRS fill in clas_ssr2osr(), which emits
+         * obs[].code[j] = smode[j] and reads osr[].c[j] by the same index.
+         *
+         * This MUST be unconditional. The dummy-obs buffer is reused across
+         * epochs, so obs_copy[].code[j] can hold a stale non-zero code from a
+         * previous epoch (or a different satellite). A `code[j]==0` guard then
+         * leaves that stale code in place, desyncing the slot order from smode:
+         * zdres computes osr[].c[] for one signal while the fill reads it as
+         * another, leaking a stale carrier value (observed as ~1153 m E5a
+         * glitches on E33 when the receiver-tracked signal set differs from the
+         * CLAS-corrected set). PPP-RTK mode (y!=NULL) skips this block entirely,
+         * so real receiver codes are preserved there. */
         if (y == NULL && sat > 0 && sat <= MAXSAT) {
             for (j = 0; j < nf; j++) {
-                if (obs_copy[i].code[j] == 0) {
-                    obs_copy[i].code[j] = corr->smode[sat - 1][j];
-                }
+                obs_copy[i].code[j] = corr->smode[sat - 1][j];
             }
         }
 


### PR DESCRIPTION
## Summary

Two related VRS/OSR output-correctness fixes for the cssr2rtcm3 path (#98).
Both live in `clas_osr_zdres()` / `clas_ssr2osr()` VRS mode (`y == NULL`);
PPP-RTK mode (`y != NULL`) is untouched.

### 1. Signal-slot desync → carrier glitches

`clas_osr_zdres()` set the per-satellite obs codes from `corr->smode[sat-1][j]`
only when `obs_copy[i].code[j] == 0`. The VRS/OSR caller's input obs buffer is
reused across epochs and copied into `obs_copy`, so a slot can carry a stale
non-zero code from a previous epoch/satellite. The guard left it in place,
desyncing the per-signal slot order from smode: `clas_osr_zdres()` computed
`osr[].c[]` for one signal while the VRS fill (which emits
`obs[].code[j] = smode[j]` and reads `osr[].c[j]` by the same index) read it as
another, leaking a stale carrier value.

Observed on a live G5 session as single-epoch **~1153 m carrier-phase glitches
on E33 (Galileo) E5a** (and on E11/E16/G22/E25) whenever the receiver-tracked
signal set differed from the CLAS-corrected set — a cycle slip for the rover.
It was **not** a phase-bias discontinuity (the indicator was 0 and all
correction components were smooth); surfaced by `scripts/analysis/osr_residual.py`.

Fix: set the obs codes **unconditionally** from smode in the VRS branch.

### 2. Skip satellites with no usable observation

When CLAS provides no valid code/phase bias for a satellite (or it is stale),
every signal comes out `P = L = 0`. The MSM encoder then writes the satellite
with **rough range 255** (invalid): a dead entry occupying the satellite mask
but carrying no usable range or carrier. A correct rover ignores it (MRTKLIB's
own VRS-RTK reaches 99.9 % Fix with these present), but it can disturb a
receiver's satellite selection.

Fix: skip such satellites in the `clas_ssr2osr()` VRS fill so they are not
advertised; a satellite with at least one valid signal is still emitted. This
depends on fix #1 — without it, the stale-code desync interacts with the
changed obs layout and corrupts other satellites' carrier values
(`osr_residual.py`: 16 → 2587 GF jumps); with both, the output is clean.

## Validation (offline replay of the G5 sessions + bundled tests)

- E33 E5a glitch gone (`5X` 23893224.7 → 23894378.5 m at the bad epoch);
  `osr_residual.py` total GF jumps **2587/16 → 1**, jitter 52.7 m → ~mm.
- Invalid-rough-range satellites (E12/G10 etc.) no longer emitted; total
  satellite-observations otherwise preserved.
- Independent confirmation the VRS obs are good: MRTKLIB VRS-RTK (DD-RTK on the
  cssr2rtcm3 obs) reaches **99.9 % Fix / 2.2 cm**, and PP-RTK **99 % / 1 cm**,
  on the same session.
- **CLAS test suite: no regression**, no tolerance changes. PPP-RTK checks
  bit-for-bit unchanged (gated `y==NULL`); VRS/OSR checks at baseline
  (vrs_rtk 3.36 cm, ssr2obs_vrs 6.14 cm, ssr2osr 3580 GGA position-verified).
  Both changes are a no-op on the bundled data (no desync / always-invalid
  satellites there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
