### PR TITLE
fix(rtksvr): advance L6 demux re-lock clock for RTCM3 rovers (#205)

### DIFF
--- a/src/stream/mrtk_rtksvr.c
+++ b/src/stream/mrtk_rtksvr.c
@@ -490,7 +490,16 @@ static int decoderaw(rtksvr_t* svr, int index) {
                  * locked channel's subframe stream is not corrupted by mixing. */
                 int prn = svr->rtcm[index].buff[4];
                 int ptn = (svr->rtcm[index].buff[5] & 0x06) >> 1;
-                ch = clas_route_l6frame(svr->clas, prn, ptn, svr->rtk.opt.l6mrg, svr->raw[0].time);
+                /* current rover observation time drives the demux re-lock
+                 * timeout. The rover decodes into raw[0] (receiver-raw formats)
+                 * or rtcm[0] (RTCM2/3); pick whichever is fresher so the clock
+                 * advances for RTCM3 rovers too — otherwise the timeout never
+                 * fires and a set satellite's stale lock is never released (#205). */
+                gtime_t now = svr->raw[0].time;
+                if (!now.time || (svr->rtcm[0].time.time && timediff(svr->rtcm[0].time, now) > 0)) {
+                    now = svr->rtcm[0].time;
+                }
+                ch = clas_route_l6frame(svr->clas, prn, ptn, svr->rtk.opt.l6mrg, now);
                 if (ch < 0) {
                     continue;
                 }


### PR DESCRIPTION
## 概要 / Summary

リアルタイム CLAS PPP-RTK（`mrtk run`, `l6_margin=0`）で、**追尾していた QZS 衛星が沈下するハンドオーバーを境に補正が永続的に止まり、解が Single (age=1e4) に落ちて復旧しない**事象（#205）を修正します。`Closes #205`。

クラウド3局（IGS RTCM3 ローバー＋共有 D9C L6）が同一 GPST 瞬間に一斉凍結し、復旧しない症状でした。

## 根本原因 / Root cause

`#201` で追加した demux の再ロック・タイムアウトは `clas_route_l6frame(..., svr->raw[0].time)` を時計に使います。しかし **RTCM2/RTCM3 ローバー**の観測は `svr->rtcm[0]` に復号され、**`svr->raw[0]` は更新されません**（`svr->raw[]` は UBX/BINEX 等の生受信機フォーマット用）。

→ `svr->raw[0].time` が起動直後の値で**凍結** → `clas_route_l6frame` の staleness 判定が**永遠に発火しない** → **ロック中の QZS が沈下しても別 PRN へ再ロックされず**、その衛星の補正が止まって `ssr_ch[0]` が永久に stale 化 → `age=1e4` / Single。

全クラウド局が RTCM3 ローバーのため、**起動時にロックした PRN が沈下する瞬間に全局同時凍結**（凍結時刻が運用ごとに可変なのもこれで説明できます）。

**本質的には #197 の再来**：#201 は再ロックを追加したが、**RTCM3 ローバーでは時計凍結で無効化**されていました。

## 修正 / Fix

ローバー形式に依らず obs 時刻で時計が前進するよう、`svr->raw[0].time` と `svr->rtcm[0].time` の**新しい方**を採用：

```c
gtime_t now = svr->raw[0].time;
if (!now.time || (svr->rtcm[0].time.time && timediff(svr->rtcm[0].time, now) > 0)) {
    now = svr->rtcm[0].time;
}
ch = clas_route_l6frame(svr->clas, prn, ptn, svr->rtk.opt.l6mrg, now);
```

ハッピーパス（生受信機ローバー）は不変。差分は `src/stream/mrtk_rtksvr.c` の +10/-1 のみ。

## 検証 / Evidence

凍結した**実機アーカイブ**（2026-06-09 10:24:15 UTC に J195 沈下で凍結したもの）を計装ビルドでリプレイ：

- **修正前**：10:24:15 から永続 `age=1e4`（Single）。
- **修正後**：J195 沈下 → ~14秒の一過性 age ブリップ → **ch0 が J195→J199 へ再ロック → Fix 復帰**。
  - Fix 90%、最大 age 16秒、`age>=1e4` のエポック **0件**。

回帰：
- CLAS 後処理回帰 **15/15 pass**（`claslib_ppp_rtk*` ＋ `utest_t_clas_route`）、reference 一致＝ハッピーパス不変。
- リモート展開で **4h+ 連続 Fix・age 1-5s 安定**（無回帰を確認）。

> Note: live でのハンドオーバー生存は、リプレイで凍結データそのものに対し実証済み。実機での切替跨ぎは今後の自然なハンドオーバーで追加確認予定（必須ではない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)