### PR TITLE
docs(readme): update Live Dashboard URL to live.pntmoni.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ is in the [CHANGELOG](CHANGELOG.md) and [release notes](docs/releases/):
 
 Real-time CLAS PPP-RTK positioning performance can be monitored on a public Grafana dashboard:
 
-> **[CLAS Summary Dashboard](http://34.84.98.16:3000/d/adsw2jc/clas-summary-dashboard)**
+> **[CLAS Summary Dashboard](https://live.pntmoni.com/)**
 
 The dashboard shows fix rate, ENU accuracy, satellite visibility, and correction age
 streamed from an active `mrtk run` session.


### PR DESCRIPTION
Point the **CLAS Summary Dashboard** link in the README at the public Grafana host (`https://live.pntmoni.com/`) instead of the raw IP endpoint.

README one-line change only — no code or test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)