### PR TITLE
feat(l6): two-receiver QZS L6 support (mosaic-CLAS/G5) + single-SBF MADOCA L6E SSR

### DIFF
--- a/src/data/rcv/mrtk_rcv_septentrio.c
+++ b/src/data/rcv/mrtk_rcv_septentrio.c
@@ -1089,7 +1089,12 @@ static int decode_bdsraw(raw_t* raw) {
 }
 /* decode SBF QZS C/A subframe -----------------------------------------------*/
 static int decode_qzsrawl1ca(raw_t* raw) { return decode_rawca(raw, SYS_QZS); }
-/* decode SBF QZS L6 message -------------------------------------------------*/
+/* decode SBF QZS L6 message (QZSRawL6 / QZSRawL6D / QZSRawL6E) ---------------
+ * Parses the shared QZSRawL6x header + 250-byte L6 frame, then dispatches on
+ * the SBF Source field: L6E (MADOCA-PPP) is decoded inline, L6D (CLAS) returns
+ * 10 for the caller's CLAS redirect. Handles both the legacy generic block
+ * (4069, mosaic-CLAS) and the signal-split blocks (4270/4271, mosaic-G5).
+ *---------------------------------------------------------------------------*/
 static int decode_qzsrawl6(raw_t* raw, rtcm_t* rtcm) {
     gtime_t time;
     double tow;
@@ -1139,68 +1144,20 @@ static int decode_qzsrawl6(raw_t* raw, rtcm_t* rtcm) {
     }
 
     memcpy(rtcm->buff, buff, 250);
+
+    /* Route by the SBF Source field (SBF ref: 1=QZSS L6D, 2=QZSS L6E).
+     * mosaic-CLAS carries both signals under QZSRawL6 (4069); mosaic-G5
+     * pre-splits into QZSRawL6D (4270, Source=1) / QZSRawL6E (4271, Source=2).
+     * L6D (CLAS) -> return 10 so the caller redirects the frame to the CLAS
+     * decoder. L6E and Source=0/Unknown fall through to the MADOCA-PPP decoder,
+     * which self-rejects non-L6E content by vendor ID. */
+    if (source == 1) {
+        raw->ephsat = sat; /* CLAS satellite for redirect / cssr2rtcm3 filtering */
+        return 10;         /* L6D frame ready (skip MADOCA decoder) */
+    }
     ret = decode_qzss_l6emsg(rtcm);
 
     return ret;
-}
-/* decode SBF QZSRawL6D block (CLAS L6D) ------------------------------------
- * Extracts the 250-byte L6D data part from the SBF QZSRawL6D (4270) block
- * and copies it into rtcm->buff WITHOUT passing through the MADOCA L6E
- * decoder.  Returns 10 to signal "L6D frame ready" to the caller.
- *---------------------------------------------------------------------------*/
-static int decode_qzsrawl6d(raw_t* raw, rtcm_t* rtcm) {
-    double tow;
-    int prn, sat, week, i, j;
-    unsigned char svid, parity, rscnt, source, rxchannel;
-    uint8_t* p = (raw->buff) + 8; /* jump to TOW location */
-    unsigned char buff[256];
-
-    if (raw->len < 272) {
-        trace(NULL, 2, "SBF decode_qzsrawl6d frame length error: len=%d\n", raw->len);
-        return -1;
-    }
-
-    /* time */
-    tow = U4(p);
-    week = U2(p + 4);
-    raw->time = gpst2time(week, tow * 0.001);
-
-    svid = U1(p + 6);
-    parity = U1(p + 7);
-    rscnt = U1(p + 8);
-    source = U1(p + 9);
-    rxchannel = U1(p + 11);
-
-    prn = svid - 180 + MINPRNQZS - 1;
-    sat = satno(SYS_QZS, prn);
-
-    if (sat == 0) {
-        trace(NULL, 2, "SBF decode_qzsrawl6d SVID error: SVID=%d prn=%d\n", svid, prn);
-        return -1;
-    }
-    trace(NULL, 3, "SBF QZSRawL6D: %s prn=%d SVID=%d Parity=%d Source=%d\n", time_str(raw->time, 0), prn, svid, parity,
-          source);
-
-    if (parity == 0) {
-        trace(NULL, 2, "SBF decode_qzsrawl6d RS decode error\n");
-        return -1;
-    }
-
-    /* extract 252 bytes (63 x 4B words) → use first 250 bytes */
-    for (i = 0, j = 0; i < 63; i++, j += 4) {
-        buff[j] = (U4(p + 12 + i * 4) >> 24) & 0xFF;
-        buff[j + 1] = (U4(p + 12 + i * 4) >> 16) & 0xFF;
-        buff[j + 2] = (U4(p + 12 + i * 4) >> 8) & 0xFF;
-        buff[j + 3] = U4(p + 12 + i * 4) & 0xFF;
-    }
-
-    memcpy(rtcm->buff, buff, 250);
-
-    /* store satellite number for caller (e.g., cssr2rtcm3 PRN filtering) */
-    raw->ephsat = sat;
-
-    /* return 10 = L6D frame ready (skip MADOCA decoder) */
-    return 10;
 }
 /* decode SBF NavIC/IRNSS subframe -------------------------------------------*/
 static int decode_navicraw(raw_t* raw) {
@@ -1658,13 +1615,10 @@ static int decode_sbf(raw_t* raw, rtcm_t* rtcm) {
             return decode_bdsraw(raw);
         case SBF_QZSRAWL1CA:
             return decode_qzsrawl1ca(raw);
-        case SBF_QZSRAWL6:  /* generic L6 (mosaic-CLAS): MADOCA L6E when Source=2;
-                             * non-L6E (e.g. CLAS L6D) is self-rejected by vendor ID */
-        case SBF_QZSRAWL6E: /* mosaic-G5 L6E-only block (Source always 2); identical
-                             * NavBits layout to QZSRawL6 -> MADOCA L6E decoder */
+        case SBF_QZSRAWL6:  /* generic (mosaic-CLAS): Source field selects L6D/L6E */
+        case SBF_QZSRAWL6D: /* mosaic-G5 CLAS L6D  (Source always 1) */
+        case SBF_QZSRAWL6E: /* mosaic-G5 MADOCA L6E (Source always 2) */
             return decode_qzsrawl6(raw, rtcm);
-        case SBF_QZSRAWL6D:
-            return decode_qzsrawl6d(raw, rtcm);
         case SBF_NAVICRAW:
             return decode_navicraw(raw);
         /* decoded navigation blocks */

--- a/src/data/rcv/mrtk_rcv_septentrio.c
+++ b/src/data/rcv/mrtk_rcv_septentrio.c
@@ -1157,7 +1157,11 @@ static int decode_qzsrawl6(raw_t* raw, rtcm_t* rtcm) {
     }
     ret = decode_qzss_l6emsg(rtcm);
 
-    return ret;
+    /* Remap "L6E SSR decoded" (10) to a dedicated code (15) so consumers that
+     * read 10 as "L6D frame ready for CLAS redirect" (rtksvr redirect block,
+     * cssr2rtcm3) do not misroute MADOCA L6E. rtksvr applies code 15 via
+     * update_ssr when not in CLAS/PPP-RTK mode; cssr2rtcm3 ignores it. */
+    return ret == 10 ? 15 : ret;
 }
 /* decode SBF NavIC/IRNSS subframe -------------------------------------------*/
 static int decode_navicraw(raw_t* raw) {

--- a/src/data/rcv/mrtk_rcv_septentrio.c
+++ b/src/data/rcv/mrtk_rcv_septentrio.c
@@ -120,8 +120,9 @@
 #define SBF_GEORAWL1 4020   /* SBF SBAS L1 navigation frame */
 #define SBF_BDSRAW 4047     /* SBF BDS navigation page */
 #define SBF_QZSRAWL1CA 4066 /* SBF QZSS C/A subframe */
-#define SBF_QZSRAWL6 4069   /* SBF QZSS L6 message */
-#define SBF_QZSRAWL6D 4270  /* SBF QZSS L6D message (mosaic-G5) */
+#define SBF_QZSRAWL6 4069   /* SBF QZSS L6 message (generic; Source: 1=L6D, 2=L6E) */
+#define SBF_QZSRAWL6D 4270  /* SBF QZSS L6D message (mosaic-G5; Source always 1) */
+#define SBF_QZSRAWL6E 4271  /* SBF QZSS L6E message (mosaic-G5; Source always 2) */
 #define SBF_NAVICRAW 4093   /* SBF NavIC/IRNSS subframe */
 
 /* Decoded navigation blocks */
@@ -1657,7 +1658,10 @@ static int decode_sbf(raw_t* raw, rtcm_t* rtcm) {
             return decode_bdsraw(raw);
         case SBF_QZSRAWL1CA:
             return decode_qzsrawl1ca(raw);
-        case SBF_QZSRAWL6:
+        case SBF_QZSRAWL6:  /* generic L6 (mosaic-CLAS): MADOCA L6E when Source=2;
+                             * non-L6E (e.g. CLAS L6D) is self-rejected by vendor ID */
+        case SBF_QZSRAWL6E: /* mosaic-G5 L6E-only block (Source always 2); identical
+                             * NavBits layout to QZSRawL6 -> MADOCA L6E decoder */
             return decode_qzsrawl6(raw, rtcm);
         case SBF_QZSRAWL6D:
             return decode_qzsrawl6d(raw, rtcm);

--- a/src/data/rcv/mrtk_rcv_ublox.c
+++ b/src/data/rcv/mrtk_rcv_ublox.c
@@ -1369,8 +1369,12 @@ static int decode_rxmqzssl6(raw_t* raw, rtcm_t* rtcm) {
             /* L6D (CLAS): skip MADOCA decoder, route to CLAS via redirect block */
             ret = 10;
         } else {
-            /* L6E (MADOCA-PPP): decode SSR corrections */
+            /* L6E (MADOCA-PPP): decode SSR corrections. Remap the "SSR decoded"
+             * code (10) to the dedicated MADOCA L6E code (15) so it is not
+             * mistaken for an L6D frame-ready by the rtksvr CLAS redirect or
+             * cssr2rtcm3 (see decode_qzsrawl6 in mrtk_rcv_septentrio.c). */
             ret = decode_qzss_l6emsg(rtcm);
+            if (ret == 10) ret = 15;
         }
     }
     return ret;

--- a/src/stream/mrtk_rtksvr.c
+++ b/src/stream/mrtk_rtksvr.c
@@ -344,6 +344,12 @@ static void update_svr(rtksvr_t* svr, int ret, obs_t* obs, nav_t* nav, int ephsa
         svr->nmsg[index][5]++;
     } else if (ret == 10) { /* ssr message */
         update_ssr(svr, index);
+    } else if (ret == 15) { /* MADOCA L6E SSR (raw SBF/UBX) */
+        /* Apply only outside CLAS/PPP-RTK mode: there the CLAS decoder owns
+         * nav->ssr_ch[0], so a mixed mosaic-G5 stream (L6D + L6E) must not let
+         * MADOCA L6E overwrite the CLAS biases. In PPP/MADOCA mode svr->clas is
+         * NULL and the L6E SSR is applied like any other ssr_ch[0] source. */
+        if (!svr->clas) update_ssr(svr, index);
     } else if (ret == 11) { /* stat message */
         update_stat(svr, index);
     } else if (ret == 12) { /* local message */


### PR DESCRIPTION
## Summary

Adds full two-receiver (mosaic-CLAS / mosaic-G5) support for the QZSS L6 stream in the SBF/UBX raw decoders, and wires single-stream MADOCA L6E SSR into the realtime engine. Closes the gap where `mrtk run` MADOCA-PPP received no L6E corrections from a mosaic-G5 SBF stream, and fixes a latent CLAS gap for mosaic-CLAS.

Newer Septentrio firmware (mosaic-G5) splits the L6 stream into signal-specific SBF blocks — `QZSRawL6D` (4270, CLAS L6D) and `QZSRawL6E` (4271, MADOCA L6E) — while older receivers (mosaic-CLAS) emit everything under the generic `QZSRawL6` (4069) block, distinguishing the signal with the SBF `Source` byte (1 = L6D, 2 = L6E). The decoder previously routed purely by block ID and only handled 4069 (→ MADOCA) and 4270 (→ CLAS).

Refs #219.

## Commits

1. **`feat(madoca): decode MADOCA L6E from SBF QZSRawL6E (4271)`** — route the mosaic-G5 L6E block to the existing MADOCA decoder (identical NavBits layout).
2. **`feat(clas): route SBF QZS L6 by Source field, decode mosaic-CLAS L6D`** — dispatch the QZSRawL6 family on the `Source` field instead of block ID. Source=1 → CLAS L6D redirect; Source=2 → MADOCA L6E. Removes the duplicate `decode_qzsrawl6d` helper. Also fixes a latent gap: a raw mosaic-CLAS SBF stream (CLAS L6D in the generic 4069 block) was fed to the MADOCA decoder, rejected by vendor ID, and silently dropped — so CLAS never worked from a mosaic-CLAS raw SBF stream (rtkrcv or cssr2rtcm3).
3. **`feat(madoca): apply raw SBF/UBX L6E SSR via dedicated return code (15)`** — the decoders returned `10` for both "L6D frame ready" (CLAS redirect) and "L6E SSR decoded". rtksvr/cssr2rtcm3 read 10 as the former, so single-SBF MADOCA L6E SSR never reached `nav->ssr_ch[0]`, and a mixed mosaic-G5 stream could leak L6E frames into cssr2rtcm3's CLAS decoder. Return a dedicated code `15` for MADOCA L6E SSR; rtksvr applies it via `update_ssr` (same path as RTCM3/IGS-RTS SSR) but only outside CLAS/PPP-RTK mode (where CLAS owns `ssr_ch[0]`); cssr2rtcm3 ignores it.

## Net effect

A single mosaic-G5 SBF stream carrying both `QZSRawL6D` and `QZSRawL6E` now drives **both** `mrtk run ppp-rtk` (CLAS via L6D) **and** `ppp`/MADOCA (L6E SSR applied), and `mrtk cssr2rtcm3` fed the same stream uses only the L6D frames. mosaic-CLAS (single generic 4069 block) works for both CLAS and MADOCA depending on the `Source` byte.

| Receiver | L6 blocks | CLAS (L6D) | MADOCA (L6E) |
|---|---|---|---|
| mosaic-CLAS | 4069 (Source 1/2) | ✅ now decoded | ✅ |
| mosaic-G5 | 4270 + 4271 | ✅ | ✅ now decoded + applied |

## Validation

Real captures replayed through `input_sbff` (a standalone harness feeding the same decoder path):

| capture | ret==10 (L6D→CLAS) | ret==15 (L6E SSR) | L6E SSR sats | CLAS CSSR sets |
|---|---|---|---|---|
| `G5P3100d.sbf` (mosaic-G5) | 15819 (= exact QZSRawL6D count, no L6E leak) | 1053 | 93 | 2576 |
| `MCLA100e` (mosaic-CLAS) | 1155 | 0 | 0 | 1546 (was 0) |

The `Source` field values were verified to match the Septentrio SBF reference (mosaic-CLAS 4069 Source=1; mosaic-G5 4270 Source=1 / 4271 Source=2).

- **ctest: 90/91** — only the pre-existing `madocalib_pppar_ion_check` LAPACK-tolerance failure (reproduces on `develop`, unrelated).
- **clang-format 21.1.6**: clean.

## Residuals / notes for review

- The realtime end-to-end (`mrtk run` producing a MADOCA-PPP position from a single SBF) is **not yet live-tested** (the `rtkrcv_rt` harness is env-fragile on the dev machine). The application path reuses the validated `update_ssr` mechanism and the SSR is confirmed populated in `rtcm->ssr`.
- The UBX `RXM-QZSSL6` L6E remap is by analogy with the SBF path (no UBX L6E sample on hand).
- `update_ssr` applies SSR only when `ssr.iod[0] == ssr.iod[1]` and a matching broadcast ephemeris IODE is present — the same gate as IGS-RTS; MADOCA sets `iod[0]` (orbit) / `iod[1]` (clock) in `decode_mcssr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
