### PR TITLE
fix(clas): fall back to global orbit/clock when network partition is stale (#218)

### DIFF
--- a/src/clas/mrtk_clas.c
+++ b/src/clas/mrtk_clas.c
@@ -432,49 +432,70 @@ static clas_trop_bank_t* get_same_trop(clas_bank_ctrl_t* bank, gtime_t time) {
  *===========================================================================*/
 
 static clas_orbit_bank_t* get_close_orbit(clas_bank_ctrl_t* bank, gtime_t time, int network, double age) {
-    int search = (bank->separation & (1 << (network - 1))) ? network : 0;
-    int pos = -1, i;
+    /* Prefer the network-separated partition when its separation bit is set,
+     * but fall back to the global (net=0) partition if that has no fresh entry.
+     * Without the fallback a stale separation bit (set by an ST11 net combo and
+     * never cleared until a facility change) strands the lookup on an empty
+     * partition while global orbit corrections keep arriving — the CLAS
+     * handover fix->single freeze (#218). Mirrors get_close_net_cbias/pbias. */
+    int sep = (bank->separation & (1 << (network - 1))) ? network : 0;
+    int trysearch[2] = {sep, 0}, ntry = (sep != 0) ? 2 : 1, t;
 
-    for (i = 0; i < CLAS_BANK_NUM; i++) {
-        if (!bank->OrbitBank[i].use || bank->OrbitBank[i].network != search) {
-            continue;
+    for (t = 0; t < ntry; t++) {
+        int search = trysearch[t];
+        int pos = -1, i;
+        for (i = 0; i < CLAS_BANK_NUM; i++) {
+            if (!bank->OrbitBank[i].use || bank->OrbitBank[i].network != search) {
+                continue;
+            }
+            if (fabs(timediff(bank->OrbitBank[i].time, time)) > age) {
+                continue;
+            }
+            if (pos != -1 &&
+                fabs(timediff(bank->OrbitBank[pos].time, time)) < fabs(timediff(bank->OrbitBank[i].time, time))) {
+                continue;
+            }
+            if (timediff(bank->OrbitBank[i].time, time) > 0.0) {
+                continue;
+            }
+            pos = i;
         }
-        if (fabs(timediff(bank->OrbitBank[i].time, time)) > age) {
-            continue;
+        if (pos != -1) {
+            return &bank->OrbitBank[pos];
         }
-        if (pos != -1 &&
-            fabs(timediff(bank->OrbitBank[pos].time, time)) < fabs(timediff(bank->OrbitBank[i].time, time))) {
-            continue;
-        }
-        if (timediff(bank->OrbitBank[i].time, time) > 0.0) {
-            continue;
-        }
-        pos = i;
     }
-    return (pos != -1) ? &bank->OrbitBank[pos] : NULL;
+    return NULL;
 }
 
 static clas_clock_bank_t* get_close_clock(clas_bank_ctrl_t* bank, gtime_t obstime, gtime_t time, int network,
                                           double age) {
-    int search = (bank->separation & (1 << (network - 1))) ? network : 0;
-    int pos = -1, i;
+    /* Same global (net=0) fallback as get_close_orbit — see #218. */
+    int sep = (bank->separation & (1 << (network - 1))) ? network : 0;
+    int trysearch[2] = {sep, 0}, ntry = (sep != 0) ? 2 : 1, t;
 
-    for (i = 0; i < CLAS_BANK_NUM; i++) {
-        if (!bank->ClockBank[i].use || bank->ClockBank[i].network != search) {
-            continue;
+    for (t = 0; t < ntry; t++) {
+        int search = trysearch[t];
+        int pos = -1, i;
+        for (i = 0; i < CLAS_BANK_NUM; i++) {
+            if (!bank->ClockBank[i].use || bank->ClockBank[i].network != search) {
+                continue;
+            }
+            if (timediff(bank->ClockBank[i].time, time) >= age) {
+                continue;
+            }
+            if (pos != -1 && timediff(bank->ClockBank[pos].time, bank->ClockBank[i].time) > 0.0) {
+                continue;
+            }
+            if (timediff(bank->ClockBank[i].time, obstime) > 0.0) {
+                continue;
+            }
+            pos = i;
         }
-        if (timediff(bank->ClockBank[i].time, time) >= age) {
-            continue;
+        if (pos != -1) {
+            return &bank->ClockBank[pos];
         }
-        if (pos != -1 && timediff(bank->ClockBank[pos].time, bank->ClockBank[i].time) > 0.0) {
-            continue;
-        }
-        if (timediff(bank->ClockBank[i].time, obstime) > 0.0) {
-            continue;
-        }
-        pos = i;
     }
-    return (pos != -1) ? &bank->ClockBank[pos] : NULL;
+    return NULL;
 }
 
 static clas_bias_bank_t* get_close_cbias(clas_bank_ctrl_t* bank, gtime_t time, int network, double age) {

--- a/src/clas/mrtk_clas.c
+++ b/src/clas/mrtk_clas.c
@@ -438,7 +438,9 @@ static clas_orbit_bank_t* get_close_orbit(clas_bank_ctrl_t* bank, gtime_t time, 
      * never cleared until a facility change) strands the lookup on an empty
      * partition while global orbit corrections keep arriving — the CLAS
      * handover fix->single freeze (#218). Mirrors get_close_net_cbias/pbias. */
-    int sep = (bank->separation & (1 << (network - 1))) ? network : 0;
+    /* guard the shift below: network is normally 1..CLAS_MAX_NETWORK-1; treat
+     * out-of-range / global (net<=0) as the global partition (no UB shift). */
+    int sep = (network >= 1 && network < CLAS_MAX_NETWORK && (bank->separation & (1u << (network - 1)))) ? network : 0;
     int trysearch[2] = {sep, 0}, ntry = (sep != 0) ? 2 : 1, t;
 
     for (t = 0; t < ntry; t++) {
@@ -470,7 +472,9 @@ static clas_orbit_bank_t* get_close_orbit(clas_bank_ctrl_t* bank, gtime_t time, 
 static clas_clock_bank_t* get_close_clock(clas_bank_ctrl_t* bank, gtime_t obstime, gtime_t time, int network,
                                           double age) {
     /* Same global (net=0) fallback as get_close_orbit — see #218. */
-    int sep = (bank->separation & (1 << (network - 1))) ? network : 0;
+    /* guard the shift below: network is normally 1..CLAS_MAX_NETWORK-1; treat
+     * out-of-range / global (net<=0) as the global partition (no UB shift). */
+    int sep = (network >= 1 && network < CLAS_MAX_NETWORK && (bank->separation & (1u << (network - 1)))) ? network : 0;
     int trysearch[2] = {sep, 0}, ntry = (sep != 0) ? 2 : 1, t;
 
     for (t = 0; t < ntry; t++) {


### PR DESCRIPTION
## Problem (#218)

Real-time CLAS PPP-RTK freezes at a QZSS L6 satellite handover: stations drop to
single (age→10000) and stay there for hours despite corrections continuing to
arrive. Observed across 3 GEONET stations (stk200/tsk200/aira00) freezing
simultaneously.

## Root cause

`bank->separation` is a sticky per-network bitmask:
- ST11 combined orbit/clock (`decode_cssr_combo`) with `flg_net` sets
  `separation |= bit(netid)` and banks orbit/clock under net=netid.
- ST2/ST3 (`decode_cssr_oc`/`decode_cssr_cc`) always bank **global** orbit/clock
  under net=0 and never touch `separation`.
- `get_close_orbit`/`get_close_clock` pick the partition by
  `search = (separation & bit(net)) ? net : 0`.
- `separation` is cleared **only** by a facility change or init — never when the
  broadcast reverts to global ST2/ST3.

So once an ST11 net-separated combo sets a network's bit, if the stream reverts
to global, `clas_bank_get_close(net=N)` keeps searching the now-stale net=N
partition → after 180 s returns -1 → `clas_update_global` is never called →
`nav->ssr.t0` freezes → all sats single until the next facility change.

## Fix

`get_close_orbit`/`get_close_clock` now try the separation-selected partition and
**fall back to net=0 (global)** when it has no fresh entry — mirroring the
existing `get_close_net_cbias`/`get_close_net_pbias` behaviour. Global orbit/clock
are valid for every network, so this is safe; it is a no-op whenever the primary
lookup already succeeds.

## Validation

- Full `ctest`: deterministic CLAS / PPP-RTK / MADOCA / VRS / PPP-AR regression
  suites all pass — **no numerical change** to existing solutions.
- **>1 day of continuous real-time operation on the production VM** (3-station
  GCP deployment) with no handover freeze.

Single file changed: `src/clas/mrtk_clas.c`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)