### PR TITLE
feat(madoca): real-time MADOCA-PPP PPP-AR/IONO — wire L6D iono into mrtk run (SBF)

### DIFF
--- a/conf/madocalib/rtkrcv_madoca_pppar_iono.toml
+++ b/conf/madocalib/rtkrcv_madoca_pppar_iono.toml
@@ -1,0 +1,212 @@
+# MRTKLIB Configuration (TOML v1.0.0)
+# Real-time MADOCA-PPP integer PPP-AR with L6D wide-area ionospheric
+# augmentation (PPP-AR/IONO) for `mrtk run`.
+#
+# A single Septentrio SBF stream from a mosaic-G5 carries everything needed:
+#   - rover observations + broadcast ephemeris (MeasEpoch / *Raw* blocks)
+#   - MADOCA-PPP L6E SSR  (QZSRawL6E 4271, Source=2)  -> orbit/clock/bias
+#   - MADOCA-PPP L6D iono (QZSRawL6D 4270, PRN 200/201) -> wide-area ionosphere
+# The L6D iono frames (PRN 200/201) are decoded into nav.pppiono and constrain
+# the est-stec ionosphere states, the real-time analogue of the post-processing
+# conf/madocalib/rnx2rtkp_pppar_iono.toml. Requires that PRN 200/201 L6D be
+# tracked ([1] IS-QZSS-MDC-004 Table 3-1, "Technology Demonstration").
+#
+#   mrtk run -o conf/madocalib/rtkrcv_madoca_pppar_iono.toml -s
+#
+# Replace the rover stream with your live receiver (serial://..., tcpcli://...).
+
+[positioning]
+mode = "ppp-kine"                                         # (6:ppp-kine,7:ppp-static)
+frequency = "l1+2+3+4"                                    # (1:l1,2:l1+2,3:l1+2+3,4:l1+2+3+4)
+solution_type = "forward"
+elevation_mask = 10.0                                     # (deg)
+dynamics = false
+satellite_ephemeris = "brdc+ssrapc"                       # MADOCA SSR = APC
+excluded_sats = ""
+systems = ["GPS", "GLONASS", "Galileo", "QZSS", "BeiDou"]
+correction = "qzs-madoca"                                 # must be set explicitly (shares brdc+ssrapc with igs-rts)
+
+[positioning.snr_mask]
+rover_enabled = false
+base_enabled = false
+L1 = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+L2 = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+L5 = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+[positioning.corrections]
+satellite_antenna = false
+receiver_antenna = true
+phase_windup = "on"
+raim_fde = false
+tidal_correction = "on"
+
+[positioning.atmosphere]
+ionosphere = "est-stec" # uncombined; L6D iono augmentation constrains the STEC states
+troposphere = "est-ztd"
+
+[ambiguity_resolution]
+mode = "continuous" # (0:off,1:continuous,3:fix-and-hold)
+systems = 57        # (1:gps+8:gal+16:qzs+32:bds)
+
+[ambiguity_resolution.thresholds]
+ratio = 1.5
+ratio1 = 1.5
+elevation_mask = 15.0
+
+[ambiguity_resolution.counters]
+min_fix = 600
+max_iterations = 10
+
+[rejection]
+innovation = 50.0
+gdop = 30.0
+
+[slip_detection]
+threshold = 0.15
+
+[kalman_filter]
+iterations = 1
+
+[kalman_filter.measurement_error]
+code_phase_ratio_L1 = 300.0
+code_phase_ratio_L2 = 300.0
+ura_ratio = 0.1
+phase = 0.003
+phase_elevation = 0.003
+
+[kalman_filter.process_noise]
+bias = 1.00e-04
+ionosphere = 0.01
+troposphere = 1.00e-04
+position = 0.0
+ifb = 1.00e-05
+
+[signals]
+gps = "L1/L2/L5"
+qzs = "L1/L5/L2"
+galileo = "E1/E5a/E5b/E6"
+bds2 = "B1I/B3I/B2I"
+bds3 = "B1I/B3I/B2a"
+
+[receiver]
+iono_correction = true # enable L6D wide-area ionospheric augmentation (PPP-AR/IONO)
+max_age = 30.0
+
+[antenna.rover]
+position_type = "single" # PPP seeds position from single-point; rover is estimated
+position_1 = 0.0
+position_2 = 0.0
+position_3 = 0.0
+type = "*"               # "*" = use rover-reported antenna; set the exact ANTEX name if absent
+delta_e = 0.0
+delta_n = 0.0
+delta_u = 0.0
+
+[antenna.base]
+position_type = "llh"
+position_1 = 0.0
+position_2 = 0.0
+position_3 = 0.0
+type = ""
+delta_e = 0.0
+delta_n = 0.0
+delta_u = 0.0
+max_average_epochs = 0
+init_reset = false
+
+[output]
+format = "llh"
+header = true
+options = true
+velocity = false
+time_system = "gpst"
+time_format = "hms"
+time_decimals = 3
+coordinate_format = "deg"
+field_separator = ""
+single_output = false
+max_solution_std = 0.0
+height_type = "ellipsoidal"
+geoid_model = "internal"
+static_solution = "all"
+nmea_interval_1 = 0.0
+nmea_interval_2 = 0.0
+solution_status = "off"
+
+[files]
+satellite_atx = ""
+receiver_atx = ""  # path to an ANTEX (igs20.atx) for receiver PCV
+station_pos = ""
+geoid = ""
+ionosphere = ""
+dcb = ""
+eop = ""
+ocean_loading = ""
+temp_dir = ""
+geexe = ""
+solution_stat = ""
+trace = ""
+
+[server]
+time_interpolation = false
+sbas_satellite = "0"
+rinex_option_1 = ""
+rinex_option_2 = ""
+ppp_option = ""
+rtcm_option = ""
+cycle_ms = 10
+timeout_ms = 10000
+reconnect_ms = 10000
+nmea_cycle_ms = 5000
+buffer_size = 32768
+nav_msg_select = "all"
+proxy = ""
+swap_margin = 30
+
+[console]
+passwd = ""
+timetype = "gpst"
+soltype = "deg"
+solflag = "off"
+
+# --- Stream: single mosaic-G5 SBF carries obs + L6E SSR + L6D iono ---
+# Replace with your live receiver. For a recorded replay use type = "file".
+[streams.input.rover]
+type = "serial"
+path = "cu.usbmodem1101:115200:8:n:1:off" # macOS: cu.* (not tty.*); see docs
+format = "sbf"
+
+[streams.input.base]
+type = "off"
+path = ""
+format = ""
+nmeareq = false
+nmealat = 0.0
+nmealon = 0.0
+
+[streams.input.correction]
+type = "off" # not needed: corrections ride on the rover SBF
+path = ""
+format = ""
+
+[streams.output.stream1]
+type = "file"
+path = "madoca_pppar_iono_realtime.pos"
+format = "llh"
+
+[streams.output.stream2]
+type = "off"
+path = ""
+format = "llh"
+
+[streams.log.stream1]
+type = "off"
+path = ""
+
+[streams.log.stream2]
+type = "off"
+path = ""
+
+[streams.log.stream3]
+type = "off"
+path = ""

--- a/docs/guide/quickstart-madoca-ppp.md
+++ b/docs/guide/quickstart-madoca-ppp.md
@@ -115,6 +115,24 @@ mrtk post -k conf/madocalib/rnx2rtkp_pppar_iono.toml \
 This adds `receiver.iono_correction = true`, enabling MADOCA-specific
 ionospheric corrections for faster convergence.
 
+### Real-Time PPP-AR/IONO (`mrtk run`)
+
+The same PPP-AR/IONO mode is available in real time. A single Septentrio SBF
+stream from a mosaic-G5 carries everything needed in one slot: rover
+observations + broadcast ephemeris, the MADOCA-PPP L6E SSR (QZSRawL6E 4271),
+and the L6D wide-area ionospheric augmentation on **PRN 200/201** (QZSRawL6D
+4270). The L6D iono frames are decoded into `nav.pppiono` and constrain the
+`est-stec` ionosphere states, exactly as the post-processing path does.
+
+```bash
+mrtk run -o conf/madocalib/rtkrcv_madoca_pppar_iono.toml -s
+```
+
+Requires that PRN 200/201 L6D be tracked (IS-QZSS-MDC-004 Table 3-1,
+"Technology Demonstration"). Set `correction = "qzs-madoca"` and
+`receiver.iono_correction = true`; the corrections ride on the rover SBF, so no
+separate correction stream is needed.
+
 ---
 
 ## Key Configuration Points

--- a/include/mrtklib/mrtk_rtksvr.h
+++ b/include/mrtklib/mrtk_rtksvr.h
@@ -37,6 +37,7 @@ extern "C" {
 #include "mrtklib/mrtk_nav.h"
 #include "mrtklib/mrtk_obs.h"
 #include "mrtklib/mrtk_opt.h"
+#include "mrtklib/mrtk_ppp.h"
 #include "mrtklib/mrtk_rcvraw.h"
 #include "mrtklib/mrtk_rtcm.h"
 #include "mrtklib/mrtk_rtkpos.h"
@@ -92,6 +93,7 @@ typedef struct {                      /* RTK server type */
     mrtk_ctx_t* ctx;                  /* runtime context */
     clas_ctx_t* clas;                 /* CLAS CSSR decoder context (NULL if unused) */
     has_t* has;                       /* Galileo HAS decoder context (NULL if unused) */
+    mdcl6d_t* mdciono;                /* MADOCA-PPP L6D iono decoder contexts (MIONO_MAX_PRN, NULL if unused) */
 } rtksvr_t;
 
 /*============================================================================

--- a/src/data/rcv/mrtk_rcv_septentrio.c
+++ b/src/data/rcv/mrtk_rcv_septentrio.c
@@ -1153,7 +1153,14 @@ static int decode_qzsrawl6(raw_t* raw, rtcm_t* rtcm) {
      * which self-rejects non-L6E content by vendor ID. */
     if (source == 1) {
         raw->ephsat = sat; /* CLAS satellite for redirect / cssr2rtcm3 filtering */
-        return 10;         /* L6D frame ready (skip MADOCA decoder) */
+        /* MADOCA-PPP wide-area ionospheric augmentation rides on L6D PRN 200/201
+         * ([1] Table 3-1, "Technology Demonstration"; 197 reserved for test) and
+         * is disjoint from CLAS (PRN 193-199). Return a dedicated code so rtksvr
+         * routes it to the L6D iono decoder instead of the CLAS redirect. */
+        if (prn == 200 || prn == 201 || prn == 197) {
+            return 16; /* MADOCA-PPP iono L6D frame ready */
+        }
+        return 10; /* CLAS L6D frame ready (skip MADOCA decoder) */
     }
     ret = decode_qzss_l6emsg(rtcm);
 

--- a/src/stream/mrtk_rtksvr.c
+++ b/src/stream/mrtk_rtksvr.c
@@ -590,6 +590,7 @@ static int decoderaw(rtksvr_t* svr, int index) {
                             svr->mdciono[m].nbyte = 0;
                             svr->mdciono[m].re.rvalid = 0;
                             strncpy(svr->mdciono[m].opt, svr->rtk.opt.pppopt, sizeof(svr->mdciono[m].opt) - 1);
+                            svr->mdciono[m].opt[sizeof(svr->mdciono[m].opt) - 1] = '\0'; /* guarantee NUL termination */
                         }
                     }
                 }

--- a/src/stream/mrtk_rtksvr.c
+++ b/src/stream/mrtk_rtksvr.c
@@ -475,9 +475,11 @@ static int decoderaw(rtksvr_t* svr, int index) {
                   time_str(obs->data[0].time,0),obs->n);
         }
 #endif
-        /* update rtk server (skip update_ssr for UBX/SBF L6D: ret=10 means
-         * "L6 payload ready for CLAS redirect", not "SSR message decoded") */
-        if (ret > 0 && !(ret == 10 && (svr->format[index] == STRFMT_UBX || svr->format[index] == STRFMT_SEPT))) {
+        /* update rtk server (skip update_ssr for UBX/SBF L6 frame-ready codes:
+         * ret=10 means "L6D payload ready for CLAS redirect" and ret=16 means
+         * "L6D payload ready for MADOCA-PPP iono", neither is a decoded SSR) */
+        if (ret > 0 &&
+            !((ret == 10 || ret == 16) && (svr->format[index] == STRFMT_UBX || svr->format[index] == STRFMT_SEPT))) {
             update_svr(svr, ret, obs, nav, ephsat, ephset, sbsmsg, index, fobs);
         }
         /* redirect L6 payload to CLAS decoder (UBX/L6E/SBF → CLAS path) */
@@ -563,6 +565,51 @@ static int decoderaw(rtksvr_t* svr, int index) {
             if (max_cret > 0) {
                 trace(NULL, 2, "L6 redirect: max_cret=%d ch=%d nframe=%d havebit=%d nbit=%d\n", max_cret, ch,
                       svr->clas->l6buf[ch].nframe, svr->clas->l6buf[ch].havebit, svr->clas->l6buf[ch].nbit);
+            }
+        }
+        /* route an L6D MADOCA-PPP ionospheric frame (SBF/UBX, ret==16) to the
+         * per-PRN iono decoder; on a completed message copy the decoded region
+         * into nav.pppiono->re[rid], exactly as update_qzssl6d() does in
+         * mrtk_postpos.c. PRN 200/201 carry the wide-area iono augmentation
+         * (197 reserved for test); the L6 header PRN is at frame byte 4. */
+        if (svr->mdciono && ret == 16 && (svr->format[index] == STRFMT_UBX || svr->format[index] == STRFMT_SEPT)) {
+            int prn = svr->rtcm[index].buff[4];
+            int j = (prn == 200) ? 0 : (prn == 201) ? 1 : (prn == 197) ? 2 : -1;
+            if (j >= 0) {
+                int k, a, s;
+                /* lazily anchor the GPST week from the freshest stream time so a
+                 * recorded-stream replay decodes in the correct week (live RT
+                 * falls back to wall-clock in adjweek() otherwise). */
+                if (svr->mdciono[0].time.time == 0) {
+                    gtime_t t = svr->raw[index].time.time ? svr->raw[index].time : svr->raw[0].time;
+                    if (t.time) {
+                        int m;
+                        init_miono(t);
+                        for (m = 0; m < MIONO_MAX_PRN; m++) {
+                            svr->mdciono[m].time = t;
+                            svr->mdciono[m].nbyte = 0;
+                            svr->mdciono[m].re.rvalid = 0;
+                            strncpy(svr->mdciono[m].opt, svr->rtk.opt.pppopt, sizeof(svr->mdciono[m].opt) - 1);
+                        }
+                    }
+                }
+                if (svr->mdciono[0].time.time) { /* feed only once the week is anchored */
+                    for (k = 0; k < 250; k++) {
+                        if (input_qzssl6d(&svr->mdciono[j], svr->rtcm[index].buff[k]) == 10 &&
+                            svr->mdciono[j].re.rvalid) {
+                            int rid = svr->mdciono[j].rid;
+                            svr->nav.pppiono->re[rid] = svr->mdciono[j].re;
+                            svr->mdciono[j].re.rvalid = 0;
+                            for (a = 0; a < MIONO_MAX_ANUM; a++) {
+                                svr->mdciono[j].re.area[a].avalid = 0;
+                                for (s = 0; s < MAXSAT; s++) {
+                                    svr->mdciono[j].re.area[a].sat[s].t0.time = 0;
+                                }
+                            }
+                            trace(NULL, 3, "L6D iono: prn=%d rid=%d index=%d\n", prn, rid, index);
+                        }
+                    }
+                }
             }
         }
         /* route a staged Galileo HAS page (any SBF stream slot) to the HAS
@@ -1026,6 +1073,7 @@ extern int rtksvrinit(rtksvr_t* svr) {
     svr->bl_reset = 10.0;
     svr->clas = NULL;
     svr->has = NULL;
+    svr->mdciono = NULL;
     rtk_initlock(&svr->lock);
 
     return 1;
@@ -1056,6 +1104,14 @@ extern void rtksvrfree(rtksvr_t* svr) {
         has_free(svr->has);
         svr->has = NULL;
     }
+    if (svr->mdciono) {
+        free(svr->mdciono);
+        svr->mdciono = NULL;
+    }
+    /* pppiono is allocated by rtksvrstart only for RT MADOCA-PPP PPP-AR/IONO;
+     * rtksvrfree frees nav arrays individually (it does not call freenav). */
+    free(svr->nav.pppiono);
+    svr->nav.pppiono = NULL;
 }
 /* lock/unlock rtk server ------------------------------------------------------
  * lock/unlock rtk server
@@ -1237,6 +1293,24 @@ extern int rtksvrstart(rtksvr_t* svr, int cycle, int buffsize, int* strs, char**
         svr->has = has_new();
         if (!svr->has) {
             tracet(NULL, 1, "rtksvrstart: HAS context alloc error\n");
+        }
+    }
+
+    /* initialize MADOCA-PPP L6D ionospheric augmentation contexts for real-time
+     * PPP-AR/IONO (correction = qzs-madoca, ionosphere = est-stec,
+     * iono_correction = on). The per-PRN contexts decode L6D PRN 200/201 iono
+     * into nav.pppiono, mirroring update_qzssl6d() in mrtk_postpos.c. The GPST
+     * week anchor (init_miono) is set lazily from the first observation time in
+     * decoderaw(), the same pattern CLAS uses for week_ref. */
+    if (prcopt->correction == CORR_QZS_MADOCA && prcopt->ionocorr && prcopt->ionoopt == IONOOPT_EST && !svr->mdciono) {
+        svr->mdciono = (mdcl6d_t*)calloc(MIONO_MAX_PRN, sizeof(mdcl6d_t));
+        if (svr->mdciono && !svr->nav.pppiono) {
+            svr->nav.pppiono = (pppiono_t*)calloc(1, sizeof(pppiono_t));
+        }
+        if (!svr->mdciono || !svr->nav.pppiono) {
+            tracet(NULL, 1, "rtksvrstart: MADOCA iono context alloc error\n");
+            free(svr->mdciono);
+            svr->mdciono = NULL; /* fall back to plain PPP-AR (ppp_iono no-ops) */
         }
     }
 


### PR DESCRIPTION
## Summary

Brings **PPP-AR/IONO** (MADOCA-PPP L6D wide-area ionospheric augmentation) to the real-time path (`mrtk run`). Previously this mode was **post-processing only**: L6E SSR was decoded in real time, but the **L6D wide-area iono augmentation (QZS PRN 200/201)** was never wired into the RT server, so `ionosphere = est-stec` + `iono_correction = on` ran as plain PPP-AR without the iono constraint.

**SBF-first** (mosaic-G5): a single SBF stream carries observations, L6E SSR (QZSRawL6E 4271) and L6D iono (QZSRawL6D 4270, PRN 200/201) in one slot — no extra stream slot needed.

Closes #223.

## What changed

- **`mrtk_rcv_septentrio.c`** — in the `Source=1` (L6D) branch, return a dedicated code **16** for PRN 200/201/197 (MADOCA iono) instead of 10 (CLAS redirect). The discriminator is the **PRN**: 200/201 carry the iono "Technology Demonstration" and are disjoint from CLAS (193–199) per IS-QZSS-MDC-004 Table 3-1.
- **`rtksvr_t`** — add per-PRN `mdciono` contexts (`MIONO_MAX_PRN`) and allocate `nav.pppiono`, gated on `correction = qzs-madoca` + `iono_correction` + `ionosphere = est-stec`; free both in `rtksvrfree` (pppiono was never freed in the RT path before).
- **`decoderaw`** — on `ret==16`, feed the L6D frame to `input_qzssl6d` and copy the decoded region into `nav.pppiono->re[rid]`, mirroring `update_qzssl6d()` in `mrtk_postpos.c`. The GPST week is anchored lazily from the first stream time (the CLAS `week_ref` pattern) so recorded-stream replay decodes in the correct week. The `update_svr` skip guard is extended to `ret==16`.
- **`conf/madocalib/rtkrcv_madoca_pppar_iono.toml`** — real-time single-SBF sample.
- **docs** — real-time PPP-AR/IONO subsection in the MADOCA-PPP quickstart.

`resolve_correction()` needs no change — it already permits `qzs-madoca` + `est-stec` + `iono_correction`.

## Why no CLAS regression

In MADOCA-PPP mode `svr->clas == NULL`, so the new path never touches CLAS. In CLAS mode `svr->mdciono == NULL`, and PRN 200/201 were already rejected by the CLAS decoder (they are not CLAS PRNs), so routing them to code 16 instead of 10 changes nothing functionally on the sensitive L6D path (#197/#205/#218).

## Validation

- **Offline decode** (`G5P3173a.sbf`, mosaic-G5): 3660 L6D iono frames → 366 complete decodes → `nav.pppiono` regions {1,3,4} populated (100% valid), alongside 89 L6E SSR satellites from the same stream.
- **Regression**: `ctest` 97/98. The single failure is the pre-existing LAPACK-tolerance `madocalib_pppar_ion_check` (3D RMS 1.62 cm vs 0.5 cm tol, fix-rate delta +0.00%); the post-processing iono path is unchanged. The `rtkrcv_rt` perennial passed this run.
- **Live real-device** (mosaic-G5 over TCP, Tokyo): the new path fires in real time (trace `L6D iono: prn=200 rid=1/3/4`), L6E SSR age ≈ 1 s, and **PPP-AR/IONO reached a fixed solution (Q=1) ~57 s after start**, holding continuous Q=1 at **sdn ≈ 1.2 cm / sde ≈ 1.2 cm / sdu ≈ 3.4 cm** (ns=30). The fast fix is the L6D iono augmentation working as intended.
- Build clean; clang-format 21.1.6 / taplo 0.10.0 clean.

## Follow-up (separate PR)

- **u-blox D9C path** — apply the same `return 16` in `decode_rxmqzssl6()` (`mrtk_rcv_ublox.c`, `msg==0` / PRN 200/201) and reuse the rtksvr block. Planned **together with #86** (UBX MADOCA-PPP L6E correction input in `mrtk run`), since both complete the D9C real-time MADOCA path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)