### PR TITLE
fix(l6extract): 2-byte stack overflow in sbf_extract_l6_payload

### DIFF
--- a/apps/l6extract/l6extract.c
+++ b/apps/l6extract/l6extract.c
@@ -196,16 +196,23 @@ static void print_has_stats(void) {
 static void sbf_extract_l6_payload(const uint8_t* block, uint8_t* payload) {
     const uint8_t* p = block + 20; /* offset to data words */
     int i, j;
-    for (i = 0, j = 0; i < 63; i++, j += 4) {
-        /* SBF stores L6 words as 32-bit big-endian values in a
-         * little-endian block. U4() reads 4 bytes as little-endian uint32,
-         * then we extract bytes MSB-first. */
-        uint32_t w = U4(p + i * 4);
+    uint32_t w;
+    /* SBF stores L6 words as 32-bit big-endian values in a little-endian
+     * block. U4() reads 4 bytes as little-endian uint32, then we extract
+     * bytes MSB-first. The data area is 63 x 4-byte words = 252 bytes, but
+     * the L6 payload is only 250 bytes (the final 2 bytes are SBF 4-byte
+     * alignment padding). Unpack the first 62 words fully, then only the top
+     * 2 bytes of word 63 to avoid writing past payload[249]. */
+    for (i = 0, j = 0; i < 62; i++, j += 4) {
+        w = U4(p + i * 4);
         payload[j] = (w >> 24) & 0xFF;
         payload[j + 1] = (w >> 16) & 0xFF;
         payload[j + 2] = (w >> 8) & 0xFF;
         payload[j + 3] = w & 0xFF;
     }
+    w = U4(p + 62 * 4);
+    payload[248] = (w >> 24) & 0xFF;
+    payload[249] = (w >> 16) & 0xFF;
 }
 
 /* ---- SBF Galileo HAS extraction ---- */


### PR DESCRIPTION
## 概要

#118 の修正。`sbf_extract_l6_payload` の2バイトスタックオーバーフロー(undefined behavior)を解消する。

[apps/l6extract/l6extract.c](apps/l6extract/l6extract.c) の展開ループが `i < 63`(63ワード × 4 = **252バイト**)で回り、250バイトの `payload[L6_FRAME_LEN]` バッファに対して `payload[250]` / `payload[251]` を範囲外書き込みしていた。

SBF QZSRawL6 / L6D / L6E のデータ領域は 63 × 4 = 252バイトだが、L6ペイロードは先頭 **250バイト**のみで、末尾2バイトは SBF の4バイトアライメント用パディング。

## 修正内容

先頭62ワードを通常どおり展開(248バイト)し、63ワード目は上位2バイトだけを `payload[248]` / `payload[249]` に書き込む。出力される250バイトは変わらないため、出力はバイト単位で完全に同一で、範囲外書き込み2バイトのみを除去する。

## 検証

- ✅ ビルド成功(エラーなし)
- ✅ 実データ `G5P3173a.sbf` で実行:7 PRN・25620フレーム抽出、全 `.l6` ファイルが250バイトの正確な倍数、スキップ0
- ✅ **バイト単位で完全一致**:修正前バイナリの出力と修正後出力を `cmp` で比較 → 7ファイルすべて identical
- ✅ `ctest`:97 passed / 1 failed。唯一の失敗は既知の `madocalib_pppar_ion_check`(LAPACK-vs-reference 数値差分、CLAUDE.md §7.2、Fix率 +0.00%)。新規失敗なし

## 影響

- 既存テストデータでは出力バイトは元々正しいため、オフライン出力に変化なし
- macOS ARM64 / Linux など stack canary 有効なターゲットでの将来クラッシュリスクを除去
- ASan / UBSan ビルドで即検出される strict UB を解消

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)