### PR TITLE
docs(reference): add local-only ICD & paper reference catalogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,11 @@ upstream/MALIB/
 upstream/demo5/
 upstream/RTKLIB/
 
+# Copyrighted reference specs / vendor guides / papers — keep local only.
+# The provenance catalogs (index.md) ARE tracked; the binaries are not.
+docs/reference/icd/*.pdf
+docs/reference/papers/*.pdf
+
 # PPC benchmark dataset, L6 data, and positioning results (large; download on demand)
 data/benchmark/
 

--- a/docs/reference/icd/index.md
+++ b/docs/reference/icd/index.md
@@ -1,0 +1,117 @@
+# Reference Specifications (ICDs & Vendor Guides)
+
+This page catalogs the interface-control documents (ICDs) and receiver vendor
+guides that MRTKLIB's decoders and positioning engines were implemented against.
+
+!!! warning "The PDFs themselves are **not** in this repository"
+    These documents are copyrighted by their respective issuers and are
+    **kept local only** — `docs/reference/icd/*.pdf` is gitignored and never
+    pushed to the remote. This page (the provenance catalog) **is** tracked.
+    To obtain a copy, download the official version from the **Source** column.
+    Drop the PDF into `docs/reference/icd/` and it will be available locally
+    without being committed.
+
+## Public open ICDs
+
+These are freely published by their issuing authority and can be downloaded by
+anyone from the official source.
+
+| File | Document / Issue | Issuer | Source | Used by |
+|------|------------------|--------|--------|---------|
+| `is-qzss-l6-008.pdf` | IS-QZSS-L6-008 (QZSS L6 signal / CLAS · MADOCA-PPP) | Cabinet Office (QZSS) | <https://qzss.go.jp/en/technical/ps-is-qzss/ps-is-qzss.html> | `src/clas/`, `src/madoca/`, L6 frame decoders |
+| `is-qzss-mdc-004.pdf` | IS-QZSS-MDC-004 (QZSS MADOCA-PPP / CLAS) | Cabinet Office (QZSS) | <https://qzss.go.jp/en/technical/ps-is-qzss/ps-is-qzss.html> | `src/madoca/`, `src/clas/`, `src/pos/mrtk_ppp.c` |
+| `sli-mdc-ion-draft.pdf` | MADOCA L6D wide-area ionosphere (draft) | Cabinet Office (QZSS) | QZSS technical documents (draft distribution) | `src/madoca/mrtk_madoca_iono.c`, `src/pos/mrtk_ppp_iono.c` |
+| `IS-GPS-200N.pdf` | IS-GPS-200N — Navstar GPS Space Segment / Navigation User Interfaces | US SMC / GPS Directorate | <https://www.gps.gov/technical/icwg/> | `src/data/` (ephemeris), RINEX nav |
+| `Galileo_HAS_SIS_ICD_v1.0.pdf` | Galileo HAS SIS ICD, Issue 1.0 (May 2022) | EUSPA / European Union | <https://www.gsc-europa.eu/electronic-library/programme-reference-documents> | `src/has/` |
+| `BeiDou_PPP_B2b_ICD_v1.0.pdf` | BDS-SIS-ICD-PPP-B2b-1.0 | CSNO (China Satellite Navigation Office) | <http://en.beidou.gov.cn/SYSTEMS/ICD/> | `src/pos/` (PPP-B2b) |
+
+## Vendor firmware reference guides
+
+!!! danger "Restricted distribution"
+    Septentrio reference guides are distributed through registered customer
+    accounts and are **not** freely redistributable. Do not post them anywhere
+    public. Obtain them from your own Septentrio account.
+
+| File | Document / Version | Vendor | Source | Used by |
+|------|--------------------|--------|--------|---------|
+| `mosaic-CLAS Firmware v4.15.1 Reference Guide.pdf` | mosaic-CLAS Reference Guide, fw v4.15.1 | Septentrio | Septentrio account (login required) | `docs/hardware/`, two-receiver QZSS L6 (v0.7.1) |
+| `mosaic-G5 Firmware v1.1.0 Reference Guide.pdf` | mosaic-G5 Reference Guide, fw v1.1.0 | Septentrio | Septentrio account (login required) | `docs/hardware/cssr2rtcm3-mosaic-g5.md` |
+
+## Cited by upstream RTKLIB (link-only, not collected)
+
+Standards and ICDs referenced in the `references :` headers of
+`upstream/RTKLIB/src/*` and reused by MALIB / CLASLIB / MADOCALIB. These are
+**not** held locally — download from the official issuer when needed.
+Near-identical versions are folded into one row (the cited editions are listed).
+Vendor receiver protocol specs (u-blox/NovAtel/Septentrio/Javad/… UBX, BINR,
+GREIS, OEM) are intentionally excluded — they are not open standards.
+
+🎯 = collection candidate (actually exercised by MRTKLIB positioning, worth
+holding a local copy). Documents already held above are cross-referenced.
+
+### GNSS signal ICDs
+
+| Document (cited editions) | Issuer | Source | Cited by |
+|---------------------------|--------|--------|----------|
+| IS-GPS-200 — Navstar GPS Space Segment / Navigation User Interfaces (200D 2006, 200K 2019; **200N → held, see above**) | US SMC / GPS Directorate | <https://www.gps.gov/technical/icwg/> | `ephemeris.c`, `rinex.c`, `rcvraw.c` |
+| IS-QZSS — QZSS Navigation Service IS (v1.1 2009, v1.5 2014, PNT IS-QZSS-PN-003 2018) | Cabinet Office (QZSS) | <https://qzss.go.jp/en/technical/ps-is-qzss/ps-is-qzss.html> | `ephemeris.c`, `rcvraw.c`, `qzslex.c`, `sbas.c` |
+| IS-QZSS-MDC — MADOCA-PPP / CLAS (MDC-002 2023; **MDC-004 2025 → held, see above**) 🎯 | Cabinet Office (QZSS) | <https://qzss.go.jp/en/technical/ps-is-qzss/ps-is-qzss.html> | `mdciono.c`, `mdccssr.c`, `ppp.c`, `ppp_ar.c` |
+| European GNSS (Galileo) Open Service SIS ICD (Issue 1 2010, 1.2 2015, 1.3 2016) | EUSPA / EU | <https://www.gsc-europa.eu/electronic-library/programme-reference-documents> | `ephemeris.c` |
+| BeiDou (BDS) SIS ICD — Open Service Signal B1I (v1.0 2012, v3.0 2019) | CSNO | <http://en.beidou.gov.cn/SYSTEMS/ICD/> | `rtkcmn.c`, `ephemeris.c`, `rcvraw.c` |
+| GLONASS ICD — Navigational radiosignal in bands L1, L2 (v5.1 2008) | Russian Space Systems | <https://glonass-iac.ru/en/documents/> | `ephemeris.c`, `rcvraw.c` |
+| ISRO-IRNSS-ICD-SPS-1.1 — IRNSS/NavIC SPS (2017) | ISRO | <https://www.isro.gov.in/> | `rcvraw.c` |
+
+### Augmentation / integrity standards
+
+| Document | Issuer | Source | Cited by |
+|----------|--------|--------|----------|
+| RTCA/DO-229C — MOPS for GPS/WAAS Airborne Equipment (2001) | RTCA | <https://www.rtca.org/> | `ephemeris.c`, `rtkcmn.c`, `sbas.c` |
+
+### RINEX family
+
+| Document (cited editions) | Issuer | Source | Cited by |
+|---------------------------|--------|--------|----------|
+| RINEX — Receiver Independent Exchange Format (2.11, 2.12, 3.00–3.05, 4.00, 4.01) | IGS RINEX WG / RTCM-SC104 | <https://igs.org/wg/rinex/> | `rinex.c` |
+| RINEX clock-information extensions (1998, 3.02 2010, 3.04 2017) | IGS / J.Ray, W.Gurtner | <https://files.igs.org/pub/data/format/> | `rinex.c` |
+
+### RTCM standards & SSR
+
+| Document (cited editions) | Issuer | Source | Cited by |
+|---------------------------|--------|--------|----------|
+| RTCM 10403.x — Differential GNSS Services v3 (10403.1 2006 + Amdt 3/5, 10403.2 2013, 10403.3 2020) 🎯 | RTCM SC-104 | <https://www.rtcm.org/publications> | `rtcm.c`, `ephemeris.c` |
+| RTCM Recommended Standards for DGNSS v2.3 (2001) | RTCM SC-104 | <https://www.rtcm.org/publications> | `rtcm.c` |
+| RTCM Ntrip (Networked Transport via Internet Protocol) v1.0 (2004) | RTCM SC-104 | <https://www.rtcm.org/publications> | `stream.c` |
+| RTCM SC-104 draft/proposal papers — SSR & MSM & ephemeris (012-2009-528/-582, 059-2011-635, 019-2012-689, 163-2012-725, 034-2012-693, 133-2012-709, 122-2012-707.r1, 107-2014-818; "Proposed SSR Messages" 2010; ssr_1_gal_qzss_sbas_dbs_v05 2014) | RTCM SC-104 | <https://www.rtcm.org/> | `rtcm.c`, `ephemeris.c` |
+
+### IGS / GNSS exchange formats
+
+| Document | Issuer | Source | Cited by |
+|----------|--------|--------|----------|
+| SP3 — Extended Standard Product 3 Orbit Format (SP3-c 2007, SP3-d 2016) 🎯 | IGS / S.Hilla | <https://files.igs.org/pub/data/format/sp3d.pdf> | `preceph.c` |
+| ANTEX — The Antenna Exchange Format v1.4 (2010) 🎯 | IGS / Rothacher, Schmid | <https://files.igs.org/pub/data/format/antex14.txt> | `rtkcmn.c` |
+| IONEX — The IONosphere Map Exchange Format v1 (1998) | IGS / Schaer, Gurtner, Feltens | <https://files.igs.org/pub/data/format/ionex1.pdf> | `ionex.c` |
+| SINEX-Bias — Solution INdependent EXchange for GNSS Biases v1.00 (2018) 🎯 | IGS / S.Schaer | <https://files.igs.org/pub/data/format/sinex_bias_100.pdf> | `biassnx.c` |
+| IGS State Space Representation (SSR) Format v1.00 (2020) | IGS | <https://files.igs.org/pub/data/format/igs_ssr_v1.pdf> | `rtcm.c` |
+
+### Timekeeping / reference frames
+
+| Document | Issuer | Source | Cited by |
+|----------|--------|--------|----------|
+| IERS Conventions — IERS Technical Notes 21 (1996), 32 (2003), **36 (2010)** 🎯 | IERS / McCarthy, Petit, Luzum | <https://www.iers.org/IERS/EN/Publications/TechnicalNotes/> | `ppp.c`, `mrtk_tides.c`, `cssr2osr.c` |
+
+### Output / peripheral I/O formats
+
+| Document | Issuer | Source | Cited by |
+|----------|--------|--------|----------|
+| NMEA 0183 v4.10 (2012) + Talker Identifier Mnemonics (2019) | NMEA | <https://www.nmea.org/> | `solution.c` |
+| OGC KML 2.2 (07-147r2, 2008) | Open Geospatial Consortium | <https://www.ogc.org/standard/kml/> | `convkml.c` |
+| GPX — The GPS Exchange Format | TopoGrafix | <https://www.topografix.com/gpx.asp> | `convgpx.c` |
+| ESRI Shapefile Technical Description (1998) | ESRI | <https://www.esri.com/> | `gis.c` |
+| BINEX — Binary Exchange Format | UNAVCO | <https://binex.unavco.org/> | `binex.c` |
+
+## Adding a new specification
+
+1. Download the official PDF and place it in `docs/reference/icd/`.
+2. Add a row to the appropriate table above: filename, full title + issue/version,
+   issuer, official source URL, and which MRTKLIB modules cite it.
+3. Commit **only** `index.md` — the PDF is gitignored automatically.

--- a/docs/reference/papers/index.md
+++ b/docs/reference/papers/index.md
@@ -1,0 +1,140 @@
+# Reference Papers
+
+This page catalogs the academic papers and technical articles that MRTKLIB's
+algorithms are built on — both those **inherited from upstream RTKLIB** (cited
+in the original source headers) and those **newly introduced by MRTKLIB** for
+features that have no upstream equivalent (e.g. the SPP robust / TDCP work).
+
+!!! warning "The PDFs themselves are **not** in this repository"
+    Most papers are copyrighted (journal / conference proceedings) and are
+    **kept local only** — `docs/reference/papers/*.pdf` is gitignored and never
+    pushed to the remote. This page (the bibliography) **is** tracked. To read a
+    paper, follow the **Source** link; if you have a redistributable copy, drop
+    it in `docs/reference/papers/` for local reference (open-access papers can
+    stay link-only — the tracked citation is the deliverable).
+
+Interface-control documents and standards (RINEX, RTCM, IS-GPS/QZSS, IERS
+Conventions, ANTEX/IONEX/SP3, …) are **not** listed here — they live in
+[Specifications (ICDs)](../icd/index.md). DOIs marked _(confirm)_ are inferred
+from the citation text and should be verified before formal use.
+
+A 📄 `filename.pdf` marker means a local copy is held next to this file
+(`author-year-keyword.pdf` convention; gitignored). Entries without a marker are
+link-only — follow the Source column.
+
+---
+
+## A. Inherited from upstream RTKLIB
+
+Cited in the `references :` headers of `upstream/RTKLIB/src/*` (and reused
+verbatim by MALIB / CLASLIB / MADOCALIB, which add no new academic papers).
+
+### Ambiguity resolution (`lambda.c`)
+
+| Paper | Source | Cited by |
+|-------|--------|----------|
+| Teunissen, P.J.G. (1995). "The least-squares ambiguity decorrelation adjustment: a method for fast GPS ambiguity estimation." *J. Geodesy* 70:65–82. | DOI [10.1007/BF00863419](https://doi.org/10.1007/BF00863419) | `lambda.c`, `mrtk_lambda.h` |
+| Chang, X.-W.; Yang, X.; Zhou, T. (2005). "MLAMBDA: A modified LAMBDA method for integer least-squares estimation." *J. Geodesy* 79:552–565. 📄 `chang-2005-mlambda.pdf` | DOI [10.1007/s00190-005-0004-x](https://doi.org/10.1007/s00190-005-0004-x) | `lambda.c`, `mrtk_lambda.h` |
+
+### Tropospheric mapping functions (`rtkcmn.c`)
+
+| Paper | Source | Cited by |
+|-------|--------|----------|
+| Boehm, J.; Niell, A.; Tregoning, P.; Schuh, H. (2006). "Global Mapping Function (GMF): A new empirical mapping function based on numerical weather model data." *Geophys. Res. Lett.* 33, L07304. 📄 `boehm-2006-global-mapping-function-gmf.pdf` | DOI [10.1029/2005GL025546](https://doi.org/10.1029/2005GL025546) | `rtkcmn.c` |
+| Niell, A.E. (1996). "Global mapping functions for the atmosphere delay at radio wavelengths." *J. Geophys. Res.* 101(B2):3227–3246. 📄 `niell-1996-global-mapping-functions.pdf` | DOI [10.1029/95JB03048](https://doi.org/10.1029/95JB03048) | `rtkcmn.c` |
+| MacMillan, D.S. et al. (1997). "Atmospheric gradients and the VLBI terrestrial and celestial reference frames." *Geophys. Res. Lett.* 24(4):453–456. 📄 `macmillan-1997-atmospheric-gradients-vlbi.pdf` | DOI [10.1029/97GL00143](https://doi.org/10.1029/97GL00143) | `ppp.c`, `mrtk_ppp_rtk.c` |
+
+### Satellite attitude / antenna modeling (`ppp.c`)
+
+| Paper | Source | Cited by |
+|-------|--------|----------|
+| Kouba, J. (2009). "A simplified yaw-attitude model for eclipsing GPS satellites." *GPS Solutions* 13:1–12. 📄 `kouba-2009-yaw-attitude-eclipsing-gps.pdf` | DOI [10.1007/s10291-008-0092-1](https://doi.org/10.1007/s10291-008-0092-1) | `ppp.c` |
+| Dilssner, F. (2010). "GPS IIF-1 satellite antenna phase center and attitude modeling." *Inside GNSS*, Sep 2010. | Free article (insidegnss.com) | `ppp.c` |
+| Dilssner, F.; Springer, T.; Gienger, G.; Dow, J. (2011). "The GLONASS-M satellite yaw-attitude model." *Advances in Space Research* 47(1):160–171. 📄 `dilssner-2011-glonass-m-yaw-attitude.pdf` | DOI [10.1016/j.asr.2010.09.007](https://doi.org/10.1016/j.asr.2010.09.007) | `ppp.c` |
+
+### Ionosphere (`ionex.c`)
+
+| Paper | Source | Cited by |
+|-------|--------|----------|
+| Schaer, S.; Markus, R.; Gerhard, B.; Timon, A.S. (1996). "Daily Global Ionosphere Maps based on GPS Carrier Phase Data Routinely Produced by CODE Analysis Center." *Proc. IGS Analysis Center Workshop*. 📄 `schaer-1996-code-global-ionosphere-maps.pdf` | IGS proceedings (no DOI) | `ionex.c` |
+
+### Estimation theory (`rtkcmn.c`, `ppp_ar.c`)
+
+| Paper | Source | Cited by |
+|-------|--------|----------|
+| Gelb, A. (ed.) (1974). *Applied Optimal Estimation*. MIT Press. | Book (ISBN 0-262-57048-3) | `rtkcmn.c` |
+| Okumura, H. (1991). 『C言語による最新アルゴリズム事典』 (Dictionary of algorithms in C). Software Technology. | Book (和書) | `ppp_ar.c` |
+
+### Astrodynamics, geoid & orbit propagation (`ppp.c`, `geoid.c`, `tle.c`)
+
+| Paper | Source | Cited by |
+|-------|--------|----------|
+| Vallado, D.A. (2004). *Fundamentals of Astrodynamics and Applications*, 2nd ed. Space Technology Library. | Book | `ppp.c`, `tle.c` |
+| Lemoine, F.G. et al. — EGM96: The NASA GSFC and NIMA Joint Geopotential Model. NASA/TP-1998-206861. | NASA report | `geoid.c` |
+| Pavlis, N.K. et al. (2008/2012). "The development and evaluation of the Earth Gravitational Model 2008 (EGM2008)." *J. Geophys. Res.* 📄 `pavlis-2012-egm2008.pdf` | DOI [10.1029/2011JB008916](https://doi.org/10.1029/2011JB008916) | `geoid.c` |
+| Hoots, F.R.; Roehrich, R.L. (1980). "Spacetrack Report No.3: Models for Propagation of NORAD Element Sets." | Spacetrack report (SGP4) | `tle.c` |
+| Vallado, D.A.; Crawford, P.; Hujsak, R.; Kelso, T.S. (2006). "Revisiting Spacetrack Report #3." AIAA 2006-6753. | DOI [10.2514/6.2006-6753](https://doi.org/10.2514/6.2006-6753) | `tle.c` |
+
+### PPP processing guide (semi-formal, but a primary reference)
+
+| Paper | Source | Cited by |
+|-------|--------|----------|
+| Kouba, J. (2009, rev.). "A Guide to using International GNSS Service (IGS) products." | Free PDF (IGS) | `ppp.c`, `mrtk_tides.c`, `cssr2osr.c` |
+
+---
+
+## B. Introduced by MRTKLIB
+
+References for features MRTKLIB added with no upstream RTKLIB equivalent. The
+SPP-accuracy set is maintainer-verified against publisher records (May 2026) —
+see [`docs/design/spp-accuracy.md`](../../design/spp-accuracy.md) §9.
+
+### SPP robust estimation — IGG-III (#116 P2; `mrtk_spp.c`)
+
+| Paper | Source | Role |
+|-------|--------|------|
+| Yang, Y.; He, H.; Xu, G. (2001). "Adaptively robust filtering for kinematic geodetic positioning." *J. Geodesy* 75:109–116. 📄 `yang-2001-adaptively-robust-filtering.pdf` | DOI [10.1007/s001900000157](https://doi.org/10.1007/s001900000157) | Primary — IGG-III equivalent-weight scheme implemented in `igg3_weight()` |
+| Wang, L.; She, J.; Cui, B. et al. (2025). "Mitigating Integrity Risk in SBAS Positioning Using Enhanced IGG III Robust Estimation." *Remote Sensing* 17(17):3067. 📄 `wang-2025-enhanced-igg3-robust-sbas.pdf` | DOI [10.3390/rs17173067](https://doi.org/10.3390/rs17173067) | Corroborating application |
+
+### Robust scale — MAD (#116 P2)
+
+| Paper | Source | Role |
+|-------|--------|------|
+| Rousseeuw, P.J.; Croux, C. (1993). "Alternatives to the Median Absolute Deviation." *JASA* 88(424):1273–1283. | DOI [10.1080/01621459.1993.10476408](https://doi.org/10.1080/01621459.1993.10476408) | MADn robust scale for the standardized residual |
+| Huber, P.J. (1981). *Robust Statistics*. Wiley. | Book | Foundation for robust scale + IRLS |
+| Blewitt, G. et al. (2016). "MIDAS robust trend estimator for accurate GPS station velocities without step detection." *JGR Solid Earth* 121. 📄 `blewitt-2016-midas-robust-trend-estimator.pdf` | DOI [10.1002/2015JB012552](https://doi.org/10.1002/2015JB012552) _(confirm)_ | Operational MAD-scaled robust GNSS |
+
+### TDCP velocity estimation (#116; `mrtk_rtkpos.c`)
+
+| Paper | Source | Role |
+|-------|--------|------|
+| Van Graas, F.; Soloviev, A. (2004). "Precise Velocity Estimation Using a Stand-Alone GPS Receiver." *NAVIGATION* 51(4):283–292. 📄 `vangraas-2004-precise-velocity-estimation.pdf` | DOI [10.1002/j.2161-4296.2004.tb00359.x](https://doi.org/10.1002/j.2161-4296.2004.tb00359.x) | Primary — TDCP velocity |
+| Serrano, L. et al. (2004). "A GPS Velocity Sensor: How Accurate Can It Be? — A First Look." *Proc. ION NTM 2004*, pp. 875–885. | [PDF](http://gauss.gge.unb.ca/papers.pdf/ionntm2004.serrano.pdf) | Primary |
+| Freda, P.; Angrisano, A.; Gaglione, S.; Troisi, S. (2015). "Time-differenced carrier phases technique for precise GNSS velocity estimation." *GPS Solutions* 19(2):335–341. 📄 `freda-2015-tdcp-velocity.pdf` | DOI [10.1007/s10291-014-0425-1](https://doi.org/10.1007/s10291-014-0425-1) | Primary |
+
+### Doppler / TDCP fused in an EKF (#116 P6, design)
+
+| Paper | Source | Role |
+|-------|--------|------|
+| "Doppler measurement integration for kinematic real-time GPS positioning." *Applied Geomatics* 2(4):155–162 (2010). | DOI [10.1007/s12518-010-0031-z](https://doi.org/10.1007/s12518-010-0031-z) | Doppler-in-EKF precedent |
+| "The Design a TDCP-Smoothed GNSS/Odometer Integration Scheme … and Robust Regression." *Remote Sensing* 12(16):2550 (2020). | DOI [10.3390/rs12162550](https://doi.org/10.3390/rs12162550) | Template for robust-WLS + TDCP-EKF hybrid |
+| "A Doppler enhanced TDCP algorithm based on terrain adaptive and robust Kalman filter using a stand-alone receiver." *J. Navigation* (CUP). | [Article](https://www.cambridge.org/core/journals/journal-of-navigation/article/abs/doppler-enhanced-tdcp-algorithm-based-on-terrain-adaptive-and-robust-kalman-filter-using-a-standalone-receiver/6A77A5FAE63FB107348D85F16FB1E908) _(vol/year confirm)_ | Corroborating |
+
+### Carrier smoothing & clock-jump (#116 P5/P6 lineage)
+
+| Paper | Source | Role |
+|-------|--------|------|
+| Hatch, R. (1982). "The Synergism of GPS Code and Carrier Measurements." *Proc. 3rd Int. Geodetic Symp. on Satellite Doppler Positioning*, vol. 2, pp. 1213–1231. | Proceedings | Origin of position-domain smoothing TDCP generalises |
+| Everett, T.; Taylor, T.; Lee, D.-K.; Akos, D.M. (2022). "Optimizing the Use of RTKLIB for Smartphone-Based GNSS Measurements." *Sensors* 22(10):3825. 📄 `everett-2022-optimizing-rtklib-smartphone.pdf` | DOI [10.3390/s22103825](https://doi.org/10.3390/s22103825) | demo5 clock-jump lineage |
+
+---
+
+## Adding a paper
+
+1. If you have a redistributable copy, place the PDF in `docs/reference/papers/`
+   with a stable `author-year-keyword.pdf` filename.
+2. Add a row to the relevant section (A = upstream-inherited, B = MRTKLIB-new):
+   full citation, DOI/source link, and which module/algorithm cites it.
+3. Commit **only** `index.md` — any PDF is gitignored automatically.
+4. New algorithm work should cite its references in the source header's
+   `references :` block **and** add a row here.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,8 @@ nav:
     - Benchmark (GSDC smartphone): reference/benchmark-gsdc.md
     - Real-Time CLAS: reference/rtkrcv-clas-realtime.md
     - Test Methodology: reference/test-accuracy-methodology.md
+    - Specifications (ICDs): reference/icd/index.md
+    - Reference Papers: reference/papers/index.md
   - Design:
     - Positioning Configuration Model: design/configuration.md
   - Releases:


### PR DESCRIPTION
## Summary

Catalog the reference material MRTKLIB is built on, while keeping the
copyrighted PDFs out of the remote. The PDFs live under
`docs/reference/{icd,papers}/` but are **gitignored** — only the provenance
catalogs (`index.md`) are tracked. No PDF is included in this PR.

## What's added

- **`docs/reference/icd/index.md`** — held ICDs / vendor guides (8 local PDFs,
  incl. IS-QZSS-L6-008 and IS-GPS-200N) **plus** all standards & ICDs cited by
  upstream RTKLIB as link-only rows: IS-GPS-200, IS-QZSS, Galileo OS SIS,
  BeiDou, GLONASS, RINEX, RTCM/SSR, SP3/ANTEX/IONEX/SINEX-Bias, IERS
  Conventions TN-21/32/36, NMEA, … Vendor receiver protocol specs are excluded;
  collection candidates are marked 🎯.
- **`docs/reference/papers/index.md`** — academic papers in two parts:
  **A** inherited from upstream RTKLIB (LAMBDA/MLAMBDA, GMF/NMF, yaw-attitude,
  GIM, …) and **B** introduced by MRTKLIB (IGG-III robust, MAD scale, TDCP,
  Doppler-EKF, clock-jump). 14 collected PDFs follow an `author-year-keyword`
  filename convention and are flagged with a 📄 held-locally indicator.
- **`.gitignore`** — ignore `docs/reference/{icd,papers}/*.pdf`.
- **`mkdocs.yml`** — add both catalogs to the Reference nav.

## Privacy / licensing

Copyrighted PDFs are kept local only and are not pushed. What becomes public is
the bibliography text (citations, DOIs, official source links, filenames) — the
same surface as any reference list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)