### PR TITLE
fix(trace): expand time keywords in traceopen filename (#83)

### DIFF
--- a/src/core/mrtk_trace.c
+++ b/src/core/mrtk_trace.c
@@ -29,6 +29,7 @@
 
 #include <stdarg.h>
 #include <stdio.h>
+#include <string.h>
 
 extern void traceopen(mrtk_ctx_t* ctx, const char* file) {
     mrtk_ctx_t* c = CTX(ctx);
@@ -43,10 +44,16 @@ extern void traceopen(mrtk_ctx_t* ctx, const char* file) {
     }
 
     if (file && *file) {
-        /* expand time/station keywords (%Y %m %d %h %M ...) like stream paths do (#83) */
+        /* expand time/station keywords (%Y %m %d %h %M ...) like stream paths do (#83);
+           reppath() does an unbounded strcpy into rpath, so skip expansion for an
+           over-long path rather than overflow the buffer */
         char rpath[MAXSTRPATH];
-        reppath(file, rpath, utc2gpst(timeget()), "", "");
-        c->trace_fp = fopen(rpath, "w");
+        if (strlen(file) < sizeof(rpath)) {
+            reppath(file, rpath, utc2gpst(timeget()), "", "");
+            c->trace_fp = fopen(rpath, "w");
+        } else {
+            c->trace_fp = fopen(file, "w");
+        }
     }
     c->tick_trace = tickget();
 }

--- a/src/core/mrtk_trace.c
+++ b/src/core/mrtk_trace.c
@@ -17,6 +17,7 @@
 
 #include "mrtklib/mrtk_nav.h"
 #include "mrtklib/mrtk_obs.h"
+#include "mrtklib/mrtk_sys.h"
 #include "mrtklib/mrtk_time.h"
 
 /**
@@ -42,7 +43,10 @@ extern void traceopen(mrtk_ctx_t* ctx, const char* file) {
     }
 
     if (file && *file) {
-        c->trace_fp = fopen(file, "w");
+        /* expand time/station keywords (%Y %m %d %h %M ...) like stream paths do (#83) */
+        char rpath[MAXSTRPATH];
+        reppath(file, rpath, utc2gpst(timeget()), "", "");
+        c->trace_fp = fopen(rpath, "w");
     }
     c->tick_trace = tickget();
 }


### PR DESCRIPTION
## Summary

Fixes #83. `traceopen()` passed the trace filename directly to `fopen()` without expanding time/station format specifiers (`%Y %m %d %h %M ...`). Trace files were therefore created with the literal name (e.g. `rtkrcv_%Y%m%d%h%M.trace`), and repeated runs overwrote the same file instead of producing timestamped files.

## Change

- Run the filename through `reppath()` before `fopen()` in the `TRACE`-enabled `traceopen()` ([src/core/mrtk_trace.c](src/core/mrtk_trace.c)), using `utc2gpst(timeget())` as the reference time — the same convention as the stream file-path handling in `src/stream/mrtk_stream.c`.
- Output buffer sized `MAXSTRPATH`.
- Add `#include "mrtklib/mrtk_sys.h"` for the `reppath()` declaration.
- The no-op `#else` variant (TRACE disabled) is unchanged.

## Verification

- `mrtklib` and `mrtk` build cleanly; `clang-format` 21.1.6 reports no diff.
- Standalone test linking the static lib: `traceopen(ctx, "t83_%Y%m%d%h%M.trace")` now creates `t83_202606291038.trace` (expanded to 2026-06-29 10:38) instead of the literal name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)