### PR TITLE
fix(ppp-rtk): emit all GNSS in the solution-status (.stat) output (was GPS-only)

### DIFF
--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -1569,6 +1569,14 @@ static int ddres(rtk_t* rtk, const nav_t* nav, double* x, double* pbslip, const 
                 if (f < nf) {
                     rtk->ssat[sati - 1].vsat[f] = 1;
                     rtk->ssat[satj - 1].vsat[f] = 1;
+                    /* mark the satellite valid in the solution so the status
+                     * output (outsolstat $SAT, rtkoutstat $ION) reports it.
+                     * vs is otherwise only set by the SPP seed, which can omit
+                     * satellites that the PPP-RTK filter still uses (e.g. a
+                     * Galileo satellite usable on E1 only) -> they were missing
+                     * from the .stat. Mirrors upstream RTKLIB relpos ddres. */
+                    rtk->ssat[sati - 1].vs = 1;
+                    rtk->ssat[satj - 1].vs = 1;
                 }
 
                 vflg[nv++] = (sati << 16) | (satj << 8) | ((f < nf ? 0 : 1) << 4) | (f % nf);


### PR DESCRIPTION
## Summary
For CLAS PPP-RTK, the solution-status output (`.stat` — `$SAT` / `$ION` lines) was **GPS-only**: a satellite used by the PPP-RTK filter but omitted from the SPP seed (e.g. a Galileo satellite usable on **E1 only**, when CLAS corrects E5a but the receiver tracks E5b) never appeared in the status file.

Root cause: the status output gates on `ssat->vs`, which is set **only by the SPP seed** (`mrtk_spp.c`). The CLAS `ddres` set `ssat->vsat[f]` (used in positioning) but **not** `ssat->vs`, so such satellites were silently missing from `.stat`.

## Fix
In `ddres` (`src/pos/mrtk_ppp_rtk.c`), set `ssat->vs = 1` for **both** satellites of each accepted double-difference pair, mirroring upstream RTKLIB `relpos` `ddres`.

- **Status-output only** — `vs` is not a processing gate in the CLAS path, so **positioning is unchanged** (bit/numeric identical).
- After the fix, `.stat` reports all used GNSS (E/G/J) for CLAS PPP-RTK.

## Scope
8-line change, single hunk. No algorithm/tolerance change.

## Testing
- `claslib` regression: **32/32 pass** on current `develop`.
- Change is confined to the solution-status flag; positioning solutions are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
