### PR TITLE
test(harness): fix BSD mktemp suffix collision in run_rtkrcv_test.sh (#194)

### DIFF
--- a/tests/cmake/run_rtkrcv_test.sh
+++ b/tests/cmake/run_rtkrcv_test.sh
@@ -26,7 +26,12 @@ IDLE_TIMEOUT=10
 
 cd "$PROJECT_ROOT"
 
-OUTPUT=$(mktemp /tmp/rtkrcv_ctest_XXXXXX.pos)
+# NB: keep XXXXXX at the END of the template. BSD mktemp (macOS) only substitutes
+# a trailing run of X's; a suffix after XXXXXX yields a literal, fixed path that
+# collides across runs (issue #194). Append the extension by renaming afterwards.
+OUTPUT=$(mktemp /tmp/rtkrcv_ctest_XXXXXX)
+mv "$OUTPUT" "$OUTPUT.pos"
+OUTPUT="$OUTPUT.pos"
 
 # Determine file extension for temp conf (fallback to .conf if no '.')
 CONF_BASENAME=$(basename "$CONF_FILE")
@@ -35,7 +40,11 @@ if [[ "$CONF_BASENAME" == *.* ]]; then
 else
     CONF_EXT="conf"
 fi
-CONF=$(mktemp /tmp/rtkrcv_conf_XXXXXX."${CONF_EXT}")
+# Same trailing-XXXXXX requirement as OUTPUT above (issue #194). The extension
+# matters here: mrtk picks the TOML vs legacy parser from the conf suffix.
+CONF=$(mktemp /tmp/rtkrcv_conf_XXXXXX)
+mv "$CONF" "$CONF.${CONF_EXT}"
+CONF="$CONF.${CONF_EXT}"
 RTKRCV_PID=""
 
 cleanup() {


### PR DESCRIPTION
## Summary

Fixes #194. `tests/cmake/run_rtkrcv_test.sh` created its temp files with `mktemp` templates that placed a suffix **after** the `XXXXXX` placeholder:

- `OUTPUT=$(mktemp /tmp/rtkrcv_ctest_XXXXXX.pos)`
- `CONF=$(mktemp /tmp/rtkrcv_conf_XXXXXX."${CONF_EXT}")`

BSD `mktemp` (macOS) only substitutes a **trailing** run of `X`'s, so it returned the literal, unsubstituted path (`/tmp/rtkrcv_ctest_XXXXXX.pos`). GNU `mktemp` (Linux/CI) substitutes correctly, so this only bit locally on macOS.

## Why it caused spurious failures

All three RT tests (`rtkrcv_rt`, `rtkrcv_rt_clas`, `rtkrcv_rt_clas_2ch`) share the script and thus the **same fixed** temp path. Once a stale file lingered — e.g. a prior run hit `TIMEOUT` and was `SIGKILL`ed so the `trap cleanup EXIT` never ran — every subsequent run died immediately at the `mktemp` line under `set -euo pipefail`:

```
mktemp: mkstemp failed on /tmp/rtkrcv_ctest_XXXXXX.pos: File exists
```

The failure happens **before `mrtk` is ever launched**, so it looks like a positioning/RT regression but is purely a harness artifact — and it self-perpetuates, because `OUTPUT` is never set so `cleanup()` cannot remove the stale file.

## Fix

Use a trailing-`XXXXXX` template and append the extension by renaming afterwards, which works on both BSD and GNU `mktemp`. The conf extension is preserved because `mrtk` selects the TOML vs legacy parser from the conf suffix.

## Verification

- Reproduced on this macOS machine: `mktemp /tmp/..._XXXXXX.pos` → literal path, unsubstituted.
- After fix: temp paths are correctly randomized (`/tmp/rtkrcv_ctest_oE21xX.pos`, `/tmp/rtkrcv_conf_lGIOjH.toml`) and unique across runs.
- `bash -n` syntax check passes.
- Pure test-harness change; no positioning code, algorithm, or tolerance touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)