### PR TITLE
build: opt-in MRTK_DETERMINISTIC_BLAS for bit-reproducible numerics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,20 @@ if(LAPACK_FOUND)
     target_compile_definitions(mrtklib PRIVATE LAPACK)
     target_link_libraries(mrtklib PRIVATE LAPACK::LAPACK)
     if(MRTK_DETERMINISTIC_BLAS)
+        # BLA_VENDOR is only a hint to FindLAPACK: an explicit LAPACK_LIBRARIES/
+        # BLAS_LIBRARIES override can still resolve a non-OpenBLAS provider, and
+        # mrtk_mat.c references openblas_set_num_threads(), which would then
+        # fail at link time with a confusing error. Verify the resolved
+        # libraries actually are OpenBLAS before enabling the pin.
+        string(TOLOWER "${LAPACK_LIBRARIES}" _mrtk_lapack_lower)
+        if(NOT _mrtk_lapack_lower MATCHES "openblas")
+            message(FATAL_ERROR
+                "MRTK_DETERMINISTIC_BLAS=ON requires OpenBLAS, but the resolved "
+                "LAPACK is: ${LAPACK_LIBRARIES}. Remove LAPACK_LIBRARIES/"
+                "BLAS_LIBRARIES overrides or point CMAKE_PREFIX_PATH at an "
+                "OpenBLAS install.")
+        endif()
+        unset(_mrtk_lapack_lower)
         # Force a single thread at load time (mrtk_mat.c constructor) so the
         # reduction order is deterministic; OpenBLAS otherwise threads by default.
         target_compile_definitions(mrtklib PRIVATE MRTK_DETERMINISTIC_BLAS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,11 +158,35 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.22")
     set(BLA_SIZEOF_INTEGER 4 CACHE STRING
         "BLAS/LAPACK integer size (MRTKLIB requires 4)")
 endif()
+
+# Opt-in reproducible-numerics build: pin the BLAS provider to single-threaded
+# OpenBLAS so every run is bit-identical. The default (this option OFF) uses
+# whatever LAPACK CMake finds (Accelerate on macOS, system LAPACK on Linux),
+# which is faster but whose threaded reductions are not run-to-run reproducible.
+# Needed for stable benchmarking/regression of AR-margin (storm-day) cases.
+option(MRTK_DETERMINISTIC_BLAS
+    "Pin BLAS to single-threaded OpenBLAS for bit-reproducible results" OFF)
+if(MRTK_DETERMINISTIC_BLAS)
+    set(BLA_VENDOR OpenBLAS)
+    message(STATUS "MRTK_DETERMINISTIC_BLAS=ON: pinning BLAS provider to OpenBLAS (single-threaded).")
+endif()
+
 find_package(LAPACK)
 if(LAPACK_FOUND)
     target_compile_definitions(mrtklib PRIVATE LAPACK)
     target_link_libraries(mrtklib PRIVATE LAPACK::LAPACK)
+    if(MRTK_DETERMINISTIC_BLAS)
+        # Force a single thread at load time (mrtk_mat.c constructor) so the
+        # reduction order is deterministic; OpenBLAS otherwise threads by default.
+        target_compile_definitions(mrtklib PRIVATE MRTK_DETERMINISTIC_BLAS)
+        message(STATUS "Reproducible numerics: OpenBLAS forced to a single thread at startup.")
+    endif()
     message(STATUS "LAPACK found and enabled for fast matrix operations.")
+elseif(MRTK_DETERMINISTIC_BLAS)
+    message(FATAL_ERROR
+        "MRTK_DETERMINISTIC_BLAS=ON but OpenBLAS LAPACK was not found. "
+        "Install OpenBLAS (e.g. 'brew install openblas') and/or pass "
+        "-DCMAKE_PREFIX_PATH=<openblas-prefix>.")
 else()
     message(WARNING "LAPACK not found. Falling back to internal (slower) matrix math.")
 endif()

--- a/docs/dev/pitfalls-public.md
+++ b/docs/dev/pitfalls-public.md
@@ -49,6 +49,20 @@ documentation and code comments, not as enforcement. Wording like
 If a user reports a crash with `BLA_SIZEOF_INTEGER=4` set, the remediation is
 to pass an explicit LP64 provider via `CMAKE_PREFIX_PATH` or `BLAS_LIBRARIES`.
 
+**Reproducible numerics (`-DMRTK_DETERMINISTIC_BLAS=ON`).** The default build
+links whatever LAPACK CMake finds (Accelerate on macOS, system LAPACK on
+Linux). Threaded BLAS reductions accumulate in a non-deterministic order, so
+results vary at the last ULP run to run; on storm-day PPP-RTK that ULP noise
+can cross the AR ratio threshold and flip fix/float decisions, making
+benchmarks irreproducible. For stable benchmarking/regression, configure with
+`-DMRTK_DETERMINISTIC_BLAS=ON` (needs OpenBLAS, e.g. `brew install openblas`,
+plus `-DCMAKE_PREFIX_PATH=<openblas-prefix>` if not auto-found). It pins the
+provider to OpenBLAS and forces a single thread at load time, so every run is
+bit-identical with no `OPENBLAS_NUM_THREADS` env var required. It is slower
+than the threaded default and does **not** change the algorithm — only
+reduction determinism — so reference tolerances may need re-baselining when
+switching providers.
+
 ### P-03 — `trace()` is compiled out unless `-DTRACE` is defined
 
 The build does not define `TRACE`, so `trace(level, ...)` calls are no-op

--- a/src/core/mrtk_mat.c
+++ b/src/core/mrtk_mat.c
@@ -224,10 +224,17 @@ extern void dgetrs_(const char* trans, const int* n, const int* nrhs, const doub
  * flips fix/float decisions, making benchmarks irreproducible. Forcing a
  * single thread makes every BLAS/LAPACK call bit-reproducible. This runs once
  * at load time for any binary that links mrtklib (CLI and unit tests alike).
- * Opt-in via the MRTK_DETERMINISTIC_BLAS CMake option, which guarantees the
- * linked provider is OpenBLAS (the source of this symbol). */
+ * Opt-in via the MRTK_DETERMINISTIC_BLAS CMake option, whose configure-time
+ * check guarantees the linked provider is OpenBLAS (the source of this
+ * symbol). Silent fallback is not acceptable here — an unpinned thread count
+ * would defeat the option's whole purpose — so unsupported toolchains fail
+ * the build instead. */
+#if defined(__GNUC__) || defined(__clang__)
 extern void openblas_set_num_threads(int num_threads);
 __attribute__((constructor)) static void mrtk_force_single_thread_blas(void) { openblas_set_num_threads(1); }
+#else
+#error "MRTK_DETERMINISTIC_BLAS needs a constructor attribute (GCC/Clang). Set OPENBLAS_NUM_THREADS=1 at runtime instead."
+#endif
 #endif
 
 /* multiply matrix (wrapper of blas dgemm) -------------------------------------

--- a/src/core/mrtk_mat.c
+++ b/src/core/mrtk_mat.c
@@ -217,6 +217,19 @@ extern void dgetri_(const int* n, double* A, const int* lda, const int* ipiv, do
 extern void dgetrs_(const char* trans, const int* n, const int* nrhs, const double* A, const int* lda, const int* ipiv,
                     double* B, const int* ldb, int* info);
 
+#ifdef MRTK_DETERMINISTIC_BLAS
+/* OpenBLAS distributes reductions across threads with a non-deterministic
+ * accumulation order, so multi-threaded results vary at the last ULP run to
+ * run. On storm-day PPP-RTK that ULP noise crosses the AR ratio threshold and
+ * flips fix/float decisions, making benchmarks irreproducible. Forcing a
+ * single thread makes every BLAS/LAPACK call bit-reproducible. This runs once
+ * at load time for any binary that links mrtklib (CLI and unit tests alike).
+ * Opt-in via the MRTK_DETERMINISTIC_BLAS CMake option, which guarantees the
+ * linked provider is OpenBLAS (the source of this symbol). */
+extern void openblas_set_num_threads(int num_threads);
+__attribute__((constructor)) static void mrtk_force_single_thread_blas(void) { openblas_set_num_threads(1); }
+#endif
+
 /* multiply matrix (wrapper of blas dgemm) -------------------------------------
  * multiply matrix by matrix (C=alpha*A*B+beta*C)
  * args   : char   *tr       I  transpose flags ("N":normal,"T":transpose)

--- a/src/core/mrtk_mat.c
+++ b/src/core/mrtk_mat.c
@@ -233,7 +233,7 @@ extern void dgetrs_(const char* trans, const int* n, const int* nrhs, const doub
 extern void openblas_set_num_threads(int num_threads);
 __attribute__((constructor)) static void mrtk_force_single_thread_blas(void) { openblas_set_num_threads(1); }
 #else
-#error "MRTK_DETERMINISTIC_BLAS needs a constructor attribute (GCC/Clang). Set OPENBLAS_NUM_THREADS=1 at runtime instead."
+#error "MRTK_DETERMINISTIC_BLAS needs GCC/Clang; use OPENBLAS_NUM_THREADS=1 at runtime instead."
 #endif
 #endif
 


### PR DESCRIPTION
Part 1/5 of the #225 sync series (merge order: this one first).

Opt-in CMake option that links a deterministic LP64 OpenBLAS (single-thread) instead of Apple Accelerate. Accelerate's non-deterministic FP reductions make storm-day PPP-RTK fix rates scatter run-to-run (the AR ratio test amplifies ULP noise into fix/float flips); this option made the #225 investigation's ±0.1 pp comparisons possible and is intended for benchmarking/CI use. No positioning-code change; default build is unaffected.

Validation: full ctest suite at the series tip — only the two known env failures (madocalib_pppar_check / madocalib_pppar_ion_check reproduce identically on a clean develop with the same OpenBLAS build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)