### PR TITLE
fix(ppp-rtk): wire ionosphere Gauss-Markov decay into CLAS PPP-RTK udion

### DIFF
--- a/include/mrtklib/mrtk_opt.h
+++ b/include/mrtklib/mrtk_opt.h
@@ -279,7 +279,11 @@ typedef struct prcopt_t {         /* processing options type */
     double maxpdopar;   /* maximum PDOP for AR (0:no limit) */
     double maxpdophold; /* maximum PDOP to hold ambiguity (0:no limit) */
     int refdop;         /* reference DOP (0:conventional, 1:single-diff) */
-    double beta;        /* ionosphere time constant for Gauss-Markov (s) */
+    double beta;        /* VRS iono Gauss-Markov time constant (s). NOTE: not
+                           wired to any config key, so it stays 0 (decay off)
+                           unless set programmatically. The PPP-RTK iono decay
+                           uses stats_tconstiono (parsed from stats-tconstiono)
+                           instead; see udion(). */
 
     /* Partial AR and AR filter options (demo5) */
     int minfixsats;     /* min sats for valid AR fix; nb >= minfixsats-1 DD pairs required (0=no minimum) */

--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -546,6 +546,29 @@ static void udion(rtk_t* rtk, double tt, double bl, const obsd_t* obs, int ns) {
             }
         }
     }
+    /* ionosphere Gauss-Markov (AR1) decay toward zero: x_I*=ki and scale the
+     * iono rows/cols of P by ki (diagonal by ki^2). Upstream applies this as
+     * part of udpos_ppp's joint state transition with ki=exp(-tt/beta); MRTK's
+     * split udpos/udion path had dropped it (the time-constant value was parsed
+     * into stats_tconstiono but read by no positioning engine). Applying it as
+     * a scalar scale here is equivalent. */
+    {
+        double tconst = rtk->opt.stats_tconstiono;
+        if (tconst > 0.0) {
+            double ki = exp(-tt / tconst);
+            for (i = 1; i <= MAXSAT; i++) {
+                j = II_RTK(i, &rtk->opt);
+                if (rtk->x[j] == 0.0) {
+                    continue;
+                }
+                rtk->x[j] *= ki;
+                for (k = 0; k < rtk->nx; k++) {
+                    rtk->P[j + k * rtk->nx] *= ki;
+                    rtk->P[k + j * rtk->nx] *= ki;
+                }
+            }
+        }
+    }
     for (i = 0; i < ns; i++) {
         j = II_RTK(obs[i].sat, &rtk->opt);
         if (rtk->x[j] == 0.0) {


### PR DESCRIPTION
Part 2/5 of the #225 sync series — stacked on #244 (base auto-retargets to develop once #244 merges and its branch is deleted).

The est-adaptive ionosphere time constant was parsed but never wired into the udion() state propagation (split parsed-but-unused / used-but-unparsed option plumbing). Aligns the AR(1) decay with claslib.

Validation: claslib regression suite green; storm-day deterministic run improves and is covered by the series-tip byte-verified reproduction (93.54 % fix, see #225 closure comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)