### PR TITLE
fix(clas): correction-stream timing sync with claslib (pre-read, equal-epoch mask, ssr2osr refresh, BackupCSSR)

### DIFF
--- a/include/mrtklib/mrtk_clas.h
+++ b/include/mrtklib/mrtk_clas.h
@@ -713,6 +713,16 @@ void clas_bank_init(clas_ctx_t* ctx, int ch);
 int clas_bank_get_close(const clas_ctx_t* ctx, gtime_t time, int network, int ch, clas_corr_t* corr);
 
 /**
+ * @brief Save/restore the latest usable CSSR snapshot for short correction gaps.
+ *
+ * Mirrors claslib's BackupCSSR/BackupGrid path. The backup is considered valid
+ * while its latest global correction time is within 180 s of the observation.
+ */
+int clas_backup_valid(const clas_ctx_t* ctx, gtime_t obstime, int l6mrg);
+void clas_backup_current(clas_ctx_t* ctx, const clas_grid_t* grid, int l6mrg);
+void clas_restore_backup(clas_ctx_t* ctx, gtime_t time, clas_grid_t* grid, int l6mrg);
+
+/**
  * @brief Apply global corrections (orbit/clock/bias) to nav_t.ssr[].
  * @param[in,out] nav   Navigation data
  * @param[in]     corr  Merged correction snapshot

--- a/include/mrtklib/mrtk_clas.h
+++ b/include/mrtklib/mrtk_clas.h
@@ -752,6 +752,7 @@ int clas_read_grid_def(clas_ctx_t* ctx, const char* file);
  * @param[in]     ch    L6 channel index (0..CLAS_CH_NUM-1)
  */
 void clas_check_grid_status(clas_ctx_t* ctx, const clas_corr_t* corr, int ch);
+void clas_check_grid_status_time(clas_ctx_t* ctx, gtime_t time, int ch);
 
 /**
  * @brief Get L6 facility ID from message ID byte.

--- a/src/clas/mrtk_clas.c
+++ b/src/clas/mrtk_clas.c
@@ -1184,6 +1184,93 @@ extern int clas_bank_get_close(const clas_ctx_t* ctx, gtime_t time, int network,
     return 0;
 }
 
+static gtime_t backup_cssr_time(const clas_corr_t* corr) {
+    gtime_t time = corr->clock_time;
+
+    if (timediff(corr->orbit_time, time) > 0.0) {
+        time = corr->orbit_time;
+    }
+    if (timediff(corr->bias_time, time) > 0.0) {
+        time = corr->bias_time;
+    }
+    return time;
+}
+
+extern int clas_backup_valid(const clas_ctx_t* ctx, gtime_t obstime, int l6mrg) {
+    int ch, nch = l6mrg ? SSR_CH_NUM : 1;
+
+    if (!ctx) {
+        return 0;
+    }
+    if (nch > CLAS_CH_NUM) {
+        nch = CLAS_CH_NUM;
+    }
+    for (ch = 0; ch < nch; ch++) {
+        if (ctx->backup[ch].use && timediff(obstime, backup_cssr_time(&ctx->backup[ch])) <= 180.0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+extern void clas_backup_current(clas_ctx_t* ctx, const clas_grid_t* grid, int l6mrg) {
+    int ch, nch = l6mrg ? SSR_CH_NUM : 1;
+
+    if (!ctx || !grid) {
+        return;
+    }
+    if (nch > CLAS_CH_NUM) {
+        nch = CLAS_CH_NUM;
+    }
+    for (ch = 0; ch < nch; ch++) {
+        memcpy(&ctx->backup[ch], &ctx->current[ch], sizeof(clas_corr_t));
+        memcpy(&ctx->backup_grid[ch], grid, sizeof(clas_grid_t));
+        init_grid_index(&ctx->backup[ch]);
+    }
+}
+
+extern void clas_restore_backup(clas_ctx_t* ctx, gtime_t time, clas_grid_t* grid, int l6mrg) {
+    clas_clock_bank_t* clock;
+    int i, ch, nch = l6mrg ? SSR_CH_NUM : 1;
+
+    if (!ctx || !grid) {
+        return;
+    }
+    if (nch > CLAS_CH_NUM) {
+        nch = CLAS_CH_NUM;
+    }
+    for (ch = 0; ch < nch; ch++) {
+        clas_bank_ctrl_t* bank = ctx->bank[ch];
+        if (!bank || !bank->use || !ctx->backup[ch].use) {
+            continue;
+        }
+        if (timediff(time, backup_cssr_time(&ctx->backup[ch])) > 180.0) {
+            continue;
+        }
+        memcpy(&ctx->current[ch], &ctx->backup[ch], sizeof(clas_corr_t));
+        memcpy(grid, &ctx->backup_grid[ch], sizeof(clas_grid_t));
+        init_grid_index(&ctx->current[ch]);
+
+        if ((clock = get_close_clock(bank, time, ctx->current[ch].orbit_time, grid->network, 30.0)) &&
+            timediff(ctx->current[ch].clock_time, clock->time) != 0.0) {
+            ctx->current[ch].clock_time = clock->time;
+            for (i = 0; i < MAXSAT; i++) {
+                if (clock->prn[i] != 0) {
+                    ctx->current[ch].time[i][1] = clock->time;
+                    ctx->current[ch].prn[i][1] = clock->prn[i];
+                    ctx->current[ch].udi[i][1] = clock->udi[i];
+                    ctx->current[ch].iod[i][1] = clock->iod[i];
+                    ctx->current[ch].c0[i] = clock->c0[i];
+                    ctx->current[ch].flag[i] |= 0x02;
+                } else {
+                    ctx->current[ch].flag[i] &= ~0x02;
+                    ctx->current[ch].prn[i][1] = 0;
+                }
+            }
+        }
+    }
+}
+
 /*============================================================================
  * Grid Status Check (from upstream cssr.c:check_cssr_grid_status)
  *===========================================================================*/

--- a/src/clas/mrtk_clas.c
+++ b/src/clas/mrtk_clas.c
@@ -616,7 +616,8 @@ static int get_bias_save_point(clas_bias_bank_t* bias, int prn, int mode) {
  * Read from ctx->dec_ssr[] (intermediate decoder buffer) instead of nav->ssr_ch[][]
  *===========================================================================*/
 
-static void check_cssr_changed_facility(clas_bank_ctrl_t* bank, int facility) {
+static void check_cssr_changed_facility(clas_ctx_t* ctx, int ch, int facility) {
+    clas_bank_ctrl_t* bank = ctx->bank[ch];
     if (bank->Facility != facility) {
         trace(NULL, 4, "bank clear: facility changed %d->%d\n", bank->Facility + 1, facility + 1);
         memset(&bank->LatestTrop, 0, sizeof(clas_latest_trop_t));
@@ -1190,7 +1191,7 @@ extern int clas_bank_get_close(const clas_ctx_t* ctx, gtime_t time, int network,
 extern void clas_check_grid_status(clas_ctx_t* ctx, const clas_corr_t* corr, int ch) {
     int i, valid, network, nvalid = 0;
 
-    if (!corr->use) {
+    if (!ctx || ch < 0 || ch >= CLAS_CH_NUM || !corr || !corr->use) {
         return;
     }
 
@@ -1205,6 +1206,10 @@ extern void clas_check_grid_status(clas_ctx_t* ctx, const clas_corr_t* corr, int
             ctx->grid_stat[ch][network][i] = 0;
         }
         return;
+    }
+
+    if (ctx->bank[ch] && ctx->bank[ch]->fastfix[network] && timediff(corr->update_time, corr->trop_time) >= 0.0) {
+        ctx->bank[ch]->fastfix[network] = 0;
     }
 
     for (i = 0; i < corr->gridnum && i < CLAS_MAX_GP; i++) {
@@ -1225,6 +1230,67 @@ extern void clas_check_grid_status(clas_ctx_t* ctx, const clas_corr_t* corr, int
     /* clear remaining grid points */
     for (i = corr->gridnum; i < CLAS_MAX_GP; i++) {
         ctx->grid_stat[ch][network][i] = 0;
+    }
+}
+
+extern void clas_check_grid_status_time(clas_ctx_t* ctx, gtime_t time, int ch) {
+    clas_bank_ctrl_t* bank;
+    clas_orbit_bank_t* orbit;
+    clas_trop_bank_t* trop;
+    int i, j, k, valid, network, preliminary, nvalid;
+
+    if (!ctx || ch < 0 || ch >= CLAS_CH_NUM || !(bank = ctx->bank[ch]) || !bank->use) {
+        return;
+    }
+
+    for (i = 0; i < CLAS_MAX_NETWORK - 1; i++) {
+        preliminary = i + 1;
+        network = preliminary;
+        orbit = NULL;
+        trop = NULL;
+
+        for (j = 0; j < 2; j++) {
+            orbit = get_close_orbit(bank, time, (j == 0) ? preliminary : 0, 180.0);
+            if (orbit) {
+                network = orbit->network ? orbit->network : preliminary;
+                break;
+            }
+        }
+        if (orbit && !(trop = get_close_trop(bank, time, orbit->time, network, 30.0, 1)) && bank->fastfix[network]) {
+            trop = get_close_trop(bank, time, orbit->time, network, 30.0, 0);
+        }
+
+        if (!orbit || !trop) {
+            for (j = 0; j < CLAS_MAX_GP; j++) {
+                ctx->grid_stat[ch][preliminary][j] = 0;
+            }
+            continue;
+        }
+        if (bank->fastfix[network] && timediff(time, trop->time) >= 0.0) {
+            bank->fastfix[network] = 0;
+        }
+
+        nvalid = 0;
+        for (j = 0; j < trop->gridnum[i] && j < CLAS_MAX_GP; j++) {
+            if (trop->total[i][j] == CSSR_INVALID_VALUE || trop->wet[i][j] == CSSR_INVALID_VALUE) {
+                ctx->grid_stat[ch][network][j] = 0;
+                continue;
+            }
+            for (k = 0, valid = trop->satnum[i][j]; k < trop->satnum[i][j]; k++) {
+                if (trop->iono[i][j][k] == CSSR_INVALID_VALUE) {
+                    valid--;
+                }
+            }
+            ctx->grid_stat[ch][network][j] = (valid >= 8) ? 1 : 0;
+            if (valid >= 8) {
+                nvalid++;
+            }
+        }
+        for (; j < CLAS_MAX_GP; j++) {
+            ctx->grid_stat[ch][network][j] = 0;
+        }
+        trace(NULL, 4, "grid_status_time: ch=%d net=%d fastfix=%d gridnum=%d nvalid=%d\n", ch, network,
+              bank->fastfix[network], trop->gridnum[i], nvalid);
     }
 }
 
@@ -1780,7 +1846,7 @@ static int decode_cssr_oc(clas_ctx_t* ctx, int ch, clas_l6buf_t* l6, int i0) {
         ssr->update = 1;
     }
 
-    check_cssr_changed_facility(ctx->bank[ch], cssr->l6facility);
+    check_cssr_changed_facility(ctx, ch, cssr->l6facility);
     set_cssr_bank_orbit(ctx, ch, l6->time, 0);
     l6->nbit = i;
     return sync ? 0 : 10;
@@ -1832,7 +1898,7 @@ static int decode_cssr_cc(clas_ctx_t* ctx, int ch, clas_l6buf_t* l6, int i0) {
         ssr->update = 1;
     }
 
-    check_cssr_changed_facility(ctx->bank[ch], cssr->l6facility);
+    check_cssr_changed_facility(ctx, ch, cssr->l6facility);
     set_cssr_bank_clock(ctx, ch, l6->time, 0);
     l6->nbit = i;
     return sync ? 0 : 10;
@@ -1894,7 +1960,7 @@ static int decode_cssr_cb(clas_ctx_t* ctx, int ch, clas_l6buf_t* l6, int i0) {
         ssr->nsig = nsig[k];
     }
 
-    check_cssr_changed_facility(ctx->bank[ch], cssr->l6facility);
+    check_cssr_changed_facility(ctx, ch, cssr->l6facility);
     set_cssr_bank_cbias(ctx, ch, l6->time, 0, 0);
     l6->nbit = i;
     return sync ? 0 : 10;
@@ -1958,7 +2024,7 @@ static int decode_cssr_pb(clas_ctx_t* ctx, int ch, clas_l6buf_t* l6, int i0) {
         ssr->nsig = nsig[k];
     }
 
-    check_cssr_changed_facility(ctx->bank[ch], cssr->l6facility);
+    check_cssr_changed_facility(ctx, ch, cssr->l6facility);
     set_cssr_bank_pbias(ctx, ch, l6->time, 0, 0);
     l6->nbit = i;
     return sync ? 0 : 10;
@@ -2072,11 +2138,11 @@ static int decode_cssr_bias(clas_ctx_t* ctx, int ch, clas_l6buf_t* l6, int i0) {
     }
 
     if (cbflag) {
-        check_cssr_changed_facility(ctx->bank[ch], cssr->l6facility);
+        check_cssr_changed_facility(ctx, ch, cssr->l6facility);
         set_cssr_bank_cbias(ctx, ch, l6->time, netflag ? network : 0, cssr->iod);
     }
     if (pbflag) {
-        check_cssr_changed_facility(ctx->bank[ch], cssr->l6facility);
+        check_cssr_changed_facility(ctx, ch, cssr->l6facility);
         set_cssr_bank_pbias(ctx, ch, l6->time, netflag ? network : 0, cssr->iod);
     }
     l6->nbit = i;
@@ -2305,7 +2371,7 @@ static int decode_cssr_grid(clas_ctx_t* ctx, int ch, clas_l6buf_t* l6, int i0) {
     ssrn->update[0] = 1;
     ctx->updateac = 1;
 
-    check_cssr_changed_facility(ctx->bank[ch], cssr->l6facility);
+    check_cssr_changed_facility(ctx, ch, cssr->l6facility);
     set_cssr_latest_trop(ctx->bank[ch], ssrn->t0[0], ssrn, inet);
     set_cssr_bank_trop(ctx, ch, ssrn->t0[0], ssrn, inet);
 
@@ -2440,7 +2506,7 @@ static int decode_cssr_combo(clas_ctx_t* ctx, int ch, clas_l6buf_t* l6, int i0) 
         }
     }
 
-    check_cssr_changed_facility(ctx->bank[ch], cssr->l6facility);
+    check_cssr_changed_facility(ctx, ch, cssr->l6facility);
     if (flg_net) {
         ctx->bank[ch]->separation |= (1 << (netid - 1));
     }
@@ -2654,7 +2720,7 @@ static int decode_cssr_atmos(clas_ctx_t* ctx, int ch, clas_l6buf_t* l6, int i0) 
     ssrn->update[0] = 1;
     ctx->updateac = 1;
 
-    check_cssr_changed_facility(ctx->bank[ch], cssr->l6facility);
+    check_cssr_changed_facility(ctx, ch, cssr->l6facility);
     set_cssr_latest_trop(ctx->bank[ch], ssrn->t0[0], ssrn, inet);
     set_cssr_bank_trop(ctx, ch, ssrn->t0[0], ssrn, inet);
 

--- a/src/clas/mrtk_clas_osr.c
+++ b/src/clas/mrtk_clas_osr.c
@@ -1604,9 +1604,13 @@ int clas_ssr2osr(rtk_t* rtk, obsd_t* obs, int n, nav_t* nav, clas_osrd_t* osr, i
         return 0;
     }
 
-    /* fetch corrections from bank */
-    if (grid->network > 0 && grid->network != corr->network) {
-        if (clas_bank_get_close(clas, obs[0].time, grid->network, ch, corr) != 0) {
+    /* re-fetch corrections closest to observation time each epoch,
+     * falling back to L6 buffer time if obs lookup fails. current[ch] is a
+     * bank snapshot, not a live decode target, so a fetch gated on network
+     * change would keep serving the first correction set until it ages out. */
+    if (grid->network > 0) {
+        if (clas_bank_get_close(clas, obs[0].time, grid->network, ch, corr) != 0 &&
+            clas_bank_get_close(clas, clas->l6buf[ch].time, grid->network, ch, corr) != 0) {
             trace(NULL, 2, "clas_ssr2osr: bank lookup failed\n");
             free(rs);
             free(dts);

--- a/src/pos/mrtk_postpos.c
+++ b/src/pos/mrtk_postpos.c
@@ -522,6 +522,21 @@ static void update_stat(gtime_t time) {
     }
     trace(NULL, 3, "update_stat: %s %s\n", time_str(time, 3), tstr);
 }
+
+static int clas_has_orbit_bank(const clas_ctx_t* ctx, int ch) {
+    int i;
+
+    if (!ctx || ch < 0 || ch >= CLAS_CH_NUM || !ctx->bank[ch]) {
+        return 0;
+    }
+    for (i = 0; i < CLAS_BANK_NUM; i++) {
+        if (ctx->bank[ch]->OrbitBank[i].use) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 /* update CLAS L6 corrections -----------------------------------------------*/
 static void update_clas(gtime_t time) {
     int ch, ret;
@@ -560,23 +575,19 @@ static void update_clas(gtime_t time) {
             continue;
         }
 
-        /* read CSSR until current observation time */
-        while (timediff(clas_ctx->l6buf[ch].time, time) < 1E-3) {
+        /* Read CSSR through the correction set whose mask time is at the
+         * observation epoch, then stop at the next future mask boundary. */
+        for (;;) {
+            if (clas_ctx->l6buf[ch].subtype == CSSR_TYPE_MASK && timediff(clas_ctx->l6buf[ch].time, time) > 0.0 &&
+                clas_has_orbit_bank(clas_ctx, ch)) {
+                break;
+            }
             ret = clas_input_cssrf(clas_ctx, fp_clas[ch], ch);
             if (ret < -1) {
                 break; /* EOF */
             }
-            if (ret == 10) {
-                int net = clas_ctx->grid[ch].network;
-                if (net > 0) {
-                    /* normal: merge bank for known network */
-                    if (clas_bank_get_close(clas_ctx, clas_ctx->l6buf[ch].time, net, ch, &clas_ctx->current[ch]) == 0) {
-                        clas_update_global(&navs, &clas_ctx->current[ch], ch);
-                        clas_check_grid_status(clas_ctx, &clas_ctx->current[ch], ch);
-                    }
-                }
-            }
         }
+        clas_check_grid_status_time(clas_ctx, time, ch);
         /* bootstrap: when network is unknown, scan all networks to
          * populate grid_stat so clas_get_grid_index() can determine
          * the correct network from the rover position.
@@ -587,7 +598,7 @@ static void update_clas(gtime_t time) {
             int net;
             if (tmp_corr) {
                 for (net = 1; net < CLAS_MAX_NETWORK; net++) {
-                    if (clas_bank_get_close(clas_ctx, clas_ctx->l6buf[ch].time, net, ch, tmp_corr) == 0) {
+                    if (clas_bank_get_close(clas_ctx, time, net, ch, tmp_corr) == 0) {
                         clas_check_grid_status(clas_ctx, tmp_corr, ch);
                         /* apply global corrections (orbit/clock/bias) from any
                          * successful network — these are shared across networks */

--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -2111,7 +2111,7 @@ extern int ppp_rtk_na(const prcopt_t* opt) { return NR_RTK(opt); }
  * double-differencing with CLAS grid corrections (STEC, ZWD) and iterative
  * Kalman filter with LAMBDA integer ambiguity resolution.
  *
- * Simplified single-channel version (no l6mrg, no backup CSSR).
+ * Uses CLAS grid corrections with a short CSSR backup fallback matching claslib.
  *
  * @param[in,out] rtk  RTK control/result struct
  * @param[in]     obs  Observation data for epoch
@@ -2129,7 +2129,7 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
     int i, j, k, f, l, nv, nvtmp, info, nf = rtk->opt.nf, sati;
     int stat = (rtk->opt.mode <= PMODE_DGPS) ? SOLQ_DGPS : SOLQ_FLOAT;
     int vflg[MAXOBS * NFREQ * 4 + 1], nb, svh[MAXOBS];
-    int nn;
+    int nn, use_backup = 0;
     double cpc_[MAXSAT * NFREQ];
     gtime_t pt0_[MAXSAT];
 
@@ -2197,22 +2197,27 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
     corr = &clas->current[0];
     ecef2pos(rtk->x, pos);
     if ((nn = clas_get_grid_index(clas, pos, grid, opt->gridsel, obs[0].time)) <= 0) {
-        trace(NULL, 2, "ppp_rtk_pos: no valid grid\n");
-        free(azel);
-        free(e);
-        free(y);
-        free(rs);
-        free(dts);
-        free(var);
-        rtk->sol.stat = SOLQ_SINGLE;
-        return;
+        if (!clas_backup_valid(clas, obs[0].time, opt->l6mrg)) {
+            trace(NULL, 2, "ppp_rtk_pos: no valid grid\n");
+            free(azel);
+            free(e);
+            free(y);
+            free(rs);
+            free(dts);
+            free(var);
+            rtk->sol.stat = SOLQ_SINGLE;
+            return;
+        }
+        clas_restore_backup(clas, obs[0].time, grid, opt->l6mrg);
+        use_backup = 1;
     }
 
-    /* fetch and apply corrections for all active channels */
+    /* fetch corrections for all active channels, or restore a short-gap backup */
     {
         int nch = opt->l6mrg ? SSR_CH_NUM : 1;
         int ch;
-        for (ch = 0; ch < nch; ch++) {
+        int fetch_failed = 0;
+        for (ch = 0; ch < nch && !use_backup; ch++) {
             /* re-fetch corrections closest to observation time,
              * falling back to L6 buffer time if obs lookup fails */
             if (grid->network > 0) {
@@ -2223,10 +2228,29 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
                 }
                 if (bgrc != 0) {
                     trace(NULL, 3, "ppp_rtk_pos: bank lookup failed ch=%d\n", ch);
-                    continue;
+                    fetch_failed = 1;
+                    break;
                 }
                 clas_check_grid_status(clas, &clas->current[ch], ch);
             }
+        }
+        if (fetch_failed) {
+            if (!clas_backup_valid(clas, obs[0].time, opt->l6mrg)) {
+                free(azel);
+                free(e);
+                free(y);
+                free(rs);
+                free(dts);
+                free(var);
+                rtk->sol.stat = SOLQ_SINGLE;
+                return;
+            }
+            clas_restore_backup(clas, obs[0].time, grid, opt->l6mrg);
+            use_backup = 1;
+        } else if (!use_backup) {
+            clas_backup_current(clas, grid, opt->l6mrg);
+        }
+        for (ch = 0; ch < nch; ch++) {
             clas_update_global(nav, &clas->current[ch], ch);
             clas_update_local(nav, &clas->current[ch], ch);
         }


### PR DESCRIPTION
Part 3/5 of the #225 sync series — stacked on the part-2 PR.

Three commits aligning when the CLAS engine reads and serves CSSR correction sets:
- **Pre-read + equal-epoch mask boundary**: read CSSR through the correction set whose mask time equals the observation epoch, stop at the first future mask; bootstrap grid status by network scan on the first epoch (matches claslib postpos timing; fixes one-epoch-stale correction selection and a startup epoch lost to an empty grid).
- **ssr2osr per-epoch bank refresh**: the bank snapshot was fetched only on network change, so `mrtk ssr2osr` served the first correction set until it aged out (~60 s) and output stopped; regression caught by claslib_ssr2osr_check.
- **BackupCSSR/BackupGrid port**: bridge short correction gaps (≤180 s) with the last usable snapshot instead of dropping epochs to single. This is the largest single contributor on the #225 storm benchmark: +118 fixed epochs (89.44 % → 93.54 %), confirmed by a 5-cell ablation.

Validation: claslib label 34/34 incl. RT replay and F5 absolute checks; storm-day deterministic reproduction byte-verified at the series tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)