### PR TITLE
fix(clas): measurement-model parity with claslib (PCV slots, obs layout, QZSS L1 priority, CPC persistence)

### DIFF
--- a/apps/rnx2rtkp/rnx2rtkp.c
+++ b/apps/rnx2rtkp/rnx2rtkp.c
@@ -317,6 +317,7 @@ int mrtk_post(int argc, char** argv) {
             apply_claslib_ppprtk_obsdef();
         }
     }
+    mrtk_use_claslib_qzs_l1_priority(prcopt.correction == CORR_QZS_CLAS);
     ret = postpos(ctx, ts, te, tint, 0.0, &prcopt, &solopt, &filopt, infile, n, outfile, "", "");
 
     if (!ret) {

--- a/apps/rnx2rtkp/rnx2rtkp.c
+++ b/apps/rnx2rtkp/rnx2rtkp.c
@@ -313,6 +313,9 @@ int mrtk_post(int argc, char** argv) {
      * and all other correction sources keep the legacy behaviour unchanged. */
     if (prcopt.correction != CORR_IGS) {
         apply_pppsig(prcopt.pppsig);
+        if (prcopt.correction == CORR_QZS_CLAS) {
+            apply_claslib_ppprtk_obsdef();
+        }
     }
     ret = postpos(ctx, ts, te, tint, 0.0, &prcopt, &solopt, &filopt, infile, n, outfile, "", "");
 

--- a/include/mrtklib/mrtk_clas.h
+++ b/include/mrtklib/mrtk_clas.h
@@ -627,6 +627,7 @@ typedef struct {
 
     /* nav_t update flag (signals positioning engine to refresh) */
     int updateac;
+    int filreset;
 
     /* Current channel index for decoding */
     int chidx;

--- a/include/mrtklib/mrtk_nav.h
+++ b/include/mrtklib/mrtk_nav.h
@@ -564,6 +564,11 @@ void reset_obsdef(void);
  */
 void apply_pppsig(const int* pppsig);
 
+/**
+ * @brief Apply the upstream claslib PPP-RTK observation slot layout.
+ */
+void apply_claslib_ppprtk_obsdef(void);
+
 /*============================================================================
  * Navigation Data I/O Functions
  *===========================================================================*/

--- a/include/mrtklib/mrtk_obs.h
+++ b/include/mrtklib/mrtk_obs.h
@@ -234,6 +234,15 @@ mrtk_band_t mrtk_rinex_freq_to_band(int sys, int rinex_freq_id);
 const uint8_t* mrtk_get_signal_priority(int sys, mrtk_band_t band);
 
 /**
+ * @brief Toggle the claslib-compatible QZSS L1 signal priority (C>S>L>X>Z).
+ *
+ * Enable only for CLAS processing; upstream claslib and MADOCALIB disagree on
+ * the QZSS L1 order, so the claslib order must not affect other engines.
+ * @param[in] on  1: claslib order, 0: MRTK default order
+ */
+void mrtk_use_claslib_qzs_l1_priority(int on);
+
+/**
  * @brief Convert physical band to base carrier frequency (Hz).
  * @param[in] band  Physical frequency band
  * @return Base carrier frequency (Hz), 0.0 on error.

--- a/src/clas/mrtk_clas_osr.c
+++ b/src/clas/mrtk_clas_osr.c
@@ -98,10 +98,8 @@ static int code_on_same_freq(int sys, uint8_t code1, uint8_t code2) {
 }
 
 static int claslib_pcv_slot(int f) {
-    static const int pcv_slot[NFREQ] = {0, 4, 11};
-
-    if (f < 0 || NFREQ <= f) return f;
-    return pcv_slot[f];
+    /* claslib compacts ANTEX frequency numbers {1,2,5} into OSR slots {0,1,2}. */
+    return f;
 }
 
 /** Frequency pair selection modes (upstream claslib rtklib.h) */

--- a/src/clas/mrtk_clas_osr.c
+++ b/src/clas/mrtk_clas_osr.c
@@ -1443,10 +1443,8 @@ int clas_osr_zdres(const obsd_t* obs, int n, const double* rs, const double* dts
                     if (f > 0 && !(f & qj)) {
                         continue;
                     }
-                    /* GAL has no L2 band — skip only if slot f is
-                     * actually L2 (freq_num==2). When obsdef places E5a
-                     * at slot 1 (e.g. signals=["E1C","E5Q"]), do NOT skip. */
-                    if (satsys(sat, NULL) == SYS_GAL && code2freq_num(obs_copy[i].code[f]) == 2) {
+                    /* Keep CLAS PPP-RTK Galileo slots aligned with upstream: slot 1 is not used. */
+                    if (f == 1 && (satsys(sat, NULL) == SYS_GAL)) {
                         continue;
                     }
                     if (j == 0 && (osr[i].pbias[f] == CLAS_CSSRINVALID)) {

--- a/src/clas/mrtk_clas_osr.c
+++ b/src/clas/mrtk_clas_osr.c
@@ -97,8 +97,15 @@ static int code_on_same_freq(int sys, uint8_t code1, uint8_t code2) {
     return (f1 >= 0 && f1 == f2);
 }
 
-static int claslib_pcv_slot(int f) {
-    /* claslib compacts ANTEX frequency numbers {1,2,5} into OSR slots {0,1,2}. */
+static int pcv_slot_has_data(const pcv_t* pcv, int slot) {
+    return pcv && 0 <= slot && slot < NFREQPCV && (norm(pcv->off[slot], 3) > 0.0 || norm(pcv->var[slot], 19) > 0.0);
+}
+
+static int claslib_pcv_slot(const pcv_t* pcv, int f) {
+    /* claslib compacts ANTEX frequency numbers {1,2,5} into OSR slots {0,1,2}.
+     * Its reader ignores the constellation prefix, so C02 can overwrite the
+     * compact L2 slot after G02/J02 in multi-GNSS receiver ANTEX entries. */
+    if (f == 1 && pcv_slot_has_data(pcv, 4)) return 4;
     return f;
 }
 
@@ -694,7 +701,7 @@ int clas_osr_corrmeas(const obsd_t* obs, nav_t* nav, const double* pos, const do
     }
 
     for (i = 0; i < nf; i++) {
-        int ant_idx = claslib_pcv_slot(i);
+        int ant_idx = claslib_pcv_slot(&opt->pcvr[0], i);
         osr->wupL[i] = lam[i] * ssat.phw;
         osr->antr[i] = (0 <= ant_idx && ant_idx < NFREQPCV) ? dant[ant_idx] : 0.0;
     }

--- a/src/clas/mrtk_clas_osr.c
+++ b/src/clas/mrtk_clas_osr.c
@@ -63,7 +63,7 @@
 /* PPP-RTK state index macros (duplicated from mrtk_ppp_rtk.c) */
 #define NF_RTK(opt) ((opt)->nf)
 #define NP_RTK(opt) ((opt)->dynamics == 0 ? 3 : 9)
-#define NI_RTK(opt) ((opt)->ionoopt != IONOOPT_EST ? 0 : MAXSAT)
+#define NI_RTK(opt) (((opt)->ionoopt == IONOOPT_EST || (opt)->ionoopt == IONOOPT_EST_ADPT) ? MAXSAT : 0)
 static inline int NT_RTK(const prcopt_t* opt) {
     if (opt->tropopt < TROPOPT_EST) return 0;
     if (opt->tropopt < TROPOPT_ESTG) return 1;
@@ -95,6 +95,13 @@ static int code_on_same_freq(int sys, uint8_t code1, uint8_t code2) {
     f1 = code2freq_idx(sys, code1);
     f2 = code2freq_idx(sys, code2);
     return (f1 >= 0 && f1 == f2);
+}
+
+static int claslib_pcv_slot(int f) {
+    static const int pcv_slot[NFREQ] = {0, 4, 11};
+
+    if (f < 0 || NFREQ <= f) return f;
+    return pcv_slot[f];
 }
 
 /** Frequency pair selection modes (upstream claslib rtklib.h) */
@@ -689,8 +696,9 @@ int clas_osr_corrmeas(const obsd_t* obs, nav_t* nav, const double* pos, const do
     }
 
     for (i = 0; i < nf; i++) {
+        int ant_idx = claslib_pcv_slot(i);
         osr->wupL[i] = lam[i] * ssat.phw;
-        osr->antr[i] = dant[i];
+        osr->antr[i] = (0 <= ant_idx && ant_idx < NFREQPCV) ? dant[ant_idx] : 0.0;
     }
     osr->iono = stec;
 
@@ -883,24 +891,23 @@ int clas_osr_satcorr_update(gtime_t time, gtime_t teph, int sat, const prcopt_t*
               tow, sc->prevtow, orb_tow, sat, sc->previode, sc->prevsis, -dclk, orbit);
     }
 
-    /* detect orbit-update boundary: orbit epoch has advanced since prevsis was saved.
-     *
-     * In canonical CLAS data the orbit and clock update simultaneously (orb==clk).
-     * In some datasets (e.g. ST12) the orbit epoch always leads the clock by 5s, so
-     * orb==clk never happens.  We therefore trigger on orbit-epoch advancement rather
-     * than requiring orb_tow == clk_tow.  prev_orb_tow tracks the last seen orbit
-     * epoch; when it changes we have crossed a 30s correction boundary.
-     */
-    if (sc->prevtow != -1 && sc->prev_orb_tow != -1 && orb_tow != sc->prev_orb_tow && /* orbit epoch just advanced */
-        sc->currtow != orb_tow) { /* not yet computed for this orbit epoch */
+    if (sc->prevtow != -1 && timediff(ssr->t0[0], ssr->t0[1]) == 0.0 &&
+        sc->currtow != time2gpst(ssr->t0[1], NULL)) {
+        if (time2gpst(ssr->t0[1], NULL) < sc->prevtow &&
+            (time2gpst(ssr->t0[1], NULL) + 3600 * 24 * 7) - sc->prevtow != 5.0) {
+            sc->prev_orb_tow = orb_tow;
+            return 1;
+        }
+        if (time2gpst(ssr->t0[1], NULL) - sc->prevtow != 5.0) {
+            sc->prev_orb_tow = orb_tow;
+            return 1;
+        }
         sc->currsis = (-dclk + orbit) - sc->prevsis;
-        sc->currtow = orb_tow;
+        sc->currtow = time2gpst(ssr->t0[1], NULL);
         trace(NULL, 4,
-              "currsis: tow=%.1f orb_tow=%.1f clk_tow=%.1f sat=%2d "
+              "currsis: tow=%.1f clk_tow=%.1f orb_tow=%.1f sat=%2d "
               "currsis=%f clk=%f orb=%f\n",
-              tow, orb_tow, time2gpst(ssr->t0[1], NULL), sat, sc->currsis, -dclk, orbit);
-        /* reset prevtow so the 25s boundary can fire fresh next cycle */
-        sc->prevtow = -1;
+              tow, sc->currtow, orb_tow, sat, sc->currsis, -dclk, orbit);
     }
     sc->prev_orb_tow = orb_tow;
     return 1;
@@ -1000,22 +1007,25 @@ static void clas_osr_adjust_r_dts(double* retr, double* retdts, gtime_t teph, in
         }
     }
 
-    if (ephpos(dts_time, teph, sat, nav, sc->previode, rs, dts, &var, &svh0)) {
-        if (!normv3(rs + 3, ea)) {
-            return;
-        }
-        cross3(rs, rs + 3, rc);
-        if (!normv3(rc, ec)) {
-            return;
-        }
-        cross3(ea, ec, er);
-
-        /* satellite antenna offset correction */
-        for (i = 0; i < 3; i++) {
-            rs[i] += -(er[i] * ssr->deph[0] + ea[i] * ssr->deph[1] + ec[i] * ssr->deph[2]);
-        }
-        *retr = geodist(rs, rr, e);
+    if (!ephpos(dts_time, teph, sat, nav, sc->previode, rs, dts, &var, &svh0)) {
+        trace(NULL, 2, "adjust_r_dts: old ephemeris unavailable tow=%.1f sat=%d iode=%d\n", time2gpst(teph, NULL),
+              sat, sc->previode);
+        return;
     }
+    if (!normv3(rs + 3, ea)) {
+        return;
+    }
+    cross3(rs, rs + 3, rc);
+    if (!normv3(rc, ec)) {
+        return;
+    }
+    cross3(ea, ec, er);
+
+    /* satellite antenna offset correction */
+    for (i = 0; i < 3; i++) {
+        rs[i] += -(er[i] * ssr->deph[0] + ea[i] * ssr->deph[1] + ec[i] * ssr->deph[2]);
+    }
+    *retr = geodist(rs, rr, e);
     *retdts = dts[0] + ssr->dclk[0] / CLIGHT;
     trace(NULL, 2, "adjust_r_dts: tow=%.1f sat=%d r=%.8f dts=%.8f\n", time2gpst(teph, NULL), sat, *retr, *retdts);
 }
@@ -1261,40 +1271,6 @@ int clas_osr_zdres(const obsd_t* obs, int n, const double* rs, const double* dts
         tmp_r = -1.0;
         tmp_dts = 0.0;
 
-        /* δBIAS discontinuity compensation (IS-QZSS-L6-005 5.5.3.2).
-         * Compute SSR range correction (-dclk + orbit·LOS) and detect
-         * orbit correction epoch transitions.  The delta is applied to
-         * CPC/PRC in the frequency loop below. */
-        {
-            const ssr_t* ssr_sat = &nav->ssr_ch[ch][sat - 1];
-            double orb_tow_cur = time2gpst(ssr_sat->t0[0], NULL);
-            double ssr_range_cur = 0.0, delta_ssr = 0.0;
-            double er_v[3], ea_v[3], ec_v[3], rc_v[3], deph_ecef[3];
-            int kk;
-
-            /* RAC basis vectors from satellite position & velocity */
-            if (normv3(rs + i * 6 + 3, ea_v)) {
-                cross3(rs + i * 6, rs + i * 6 + 3, rc_v);
-                if (normv3(rc_v, ec_v)) {
-                    cross3(ea_v, ec_v, er_v);
-
-                    /* orbit correction in ECEF */
-                    for (kk = 0; kk < 3; kk++) {
-                        deph_ecef[kk] =
-                            er_v[kk] * ssr_sat->deph[0] + ea_v[kk] * ssr_sat->deph[1] + ec_v[kk] * ssr_sat->deph[2];
-                    }
-                    /* range correction: -dclk + orbit_ecef · LOS */
-                    ssr_range_cur = -ssr_sat->dclk[0] + dot(deph_ecef, e + i * 3, 3);
-
-                    /* detect orbit epoch change and compute delta */
-                    if (osr_ctx->prev_ssr_orb_tow[sat - 1] > 0.0 && orb_tow_cur != osr_ctx->prev_ssr_orb_tow[sat - 1]) {
-                        delta_ssr = ssr_range_cur - osr_ctx->prev_ssr_range[sat - 1];
-                    }
-                    osr_ctx->prev_ssr_range[sat - 1] = ssr_range_cur;
-                    osr_ctx->prev_ssr_orb_tow[sat - 1] = orb_tow_cur;
-                }
-            }
-
             for (j = 0; j < nf; j++) {
                 f = j;
 
@@ -1313,12 +1289,6 @@ int clas_osr_zdres(const obsd_t* obs, int n, const double* rs, const double* dts
                 osr[i].CPC[j] = osr[i].trop + osr[i].relatv + osr[i].antr[f] - fi * fi * FREQ2 / FREQ1 * osr[i].iono +
                                 osr[i].pbias[j] + osr[i].wupL[f] + osr[i].compL[j];
 
-                /* apply δBIAS compensation for orbit correction transition */
-                if (delta_ssr != 0.0) {
-                    osr[i].CPC[j] -= delta_ssr;
-                    osr[i].PRC[j] -= delta_ssr;
-                }
-
                 /* SIS/IODE adjustment */
                 iodeflag = 0;
                 if (!opt->posopt[9]) {
@@ -1333,6 +1303,7 @@ int clas_osr_zdres(const obsd_t* obs, int n, const double* rs, const double* dts
                     if (tmp_r < 0.0) {
                         gtime_t dtsat = timeadd(obs_copy[i].time, -obs_copy[i].P[0] / CLIGHT);
                         tmp_r = r;
+                        tmp_dts = dts[i * 2];
                         clas_osr_adjust_r_dts(&tmp_r, &tmp_dts, obs_copy[i].time, sat, nav, rr, dtsat, ch, osr_ctx);
                     }
                     modl[j] = tmp_r - CLIGHT * tmp_dts + osr[i].CPC[j];
@@ -1359,7 +1330,8 @@ int clas_osr_zdres(const obsd_t* obs, int n, const double* rs, const double* dts
                 }
 
                 /* cycle slip detection on phase bias update */
-                if (fabs(timediff(nav->ssr_ch[ch][sat - 1].t0[5], osr_ctx->pt0tmp[sat - 1])) > 0.0 &&
+                if (!nav->filreset &&
+                    fabs(timediff(nav->ssr_ch[ch][sat - 1].t0[5], osr_ctx->pt0tmp[sat - 1])) > 0.0 &&
                     fabs(timediff(nav->ssr_ch[ch][sat - 1].t0[5], osr_ctx->pt0tmp[sat - 1])) < 120.0) {
                     dcpc = osr[i].orb - osr[i].clk + osr[i].CPC[j] - osr_ctx->cpctmp[j * MAXSAT + sat - 1];
                     if (dcpc >= 95.0 * lam[f] && dcpc < 105.0 * lam[f]) {
@@ -1390,7 +1362,6 @@ int clas_osr_zdres(const obsd_t* obs, int n, const double* rs, const double* dts
                 }
                 osr_ctx->cpctmp[j * MAXSAT + sat - 1] = osr[i].orb - osr[i].clk + osr[i].CPC[j];
             }
-        } /* end δBIAS compensation block */
 
         /* ISB correction */
         if (opt->isb == ISBOPT_TABLE) {

--- a/src/clas/mrtk_clas_osr.c
+++ b/src/clas/mrtk_clas_osr.c
@@ -896,8 +896,7 @@ int clas_osr_satcorr_update(gtime_t time, gtime_t teph, int sat, const prcopt_t*
               tow, sc->prevtow, orb_tow, sat, sc->previode, sc->prevsis, -dclk, orbit);
     }
 
-    if (sc->prevtow != -1 && timediff(ssr->t0[0], ssr->t0[1]) == 0.0 &&
-        sc->currtow != time2gpst(ssr->t0[1], NULL)) {
+    if (sc->prevtow != -1 && timediff(ssr->t0[0], ssr->t0[1]) == 0.0 && sc->currtow != time2gpst(ssr->t0[1], NULL)) {
         if (time2gpst(ssr->t0[1], NULL) < sc->prevtow &&
             (time2gpst(ssr->t0[1], NULL) + 3600 * 24 * 7) - sc->prevtow != 5.0) {
             sc->prev_orb_tow = orb_tow;
@@ -1013,8 +1012,8 @@ static void clas_osr_adjust_r_dts(double* retr, double* retdts, gtime_t teph, in
     }
 
     if (!ephpos(dts_time, teph, sat, nav, sc->previode, rs, dts, &var, &svh0)) {
-        trace(NULL, 2, "adjust_r_dts: old ephemeris unavailable tow=%.1f sat=%d iode=%d\n", time2gpst(teph, NULL),
-              sat, sc->previode);
+        trace(NULL, 2, "adjust_r_dts: old ephemeris unavailable tow=%.1f sat=%d iode=%d\n", time2gpst(teph, NULL), sat,
+              sc->previode);
         return;
     }
     if (!normv3(rs + 3, ea)) {
@@ -1276,97 +1275,96 @@ int clas_osr_zdres(const obsd_t* obs, int n, const double* rs, const double* dts
         tmp_r = -1.0;
         tmp_dts = 0.0;
 
-            for (j = 0; j < nf; j++) {
-                f = j;
+        for (j = 0; j < nf; j++) {
+            f = j;
 
-                fi = (lam[0] > 0.0) ? lam[f] / lam[0] : 0.0;
+            fi = (lam[0] > 0.0) ? lam[f] / lam[0] : 0.0;
 
-                if (osr[i].pbias[j] == CLAS_CSSRINVALID || osr[i].cbias[j] == CLAS_CSSRINVALID) {
-                    /* ENA_PPP_RTK path: skip invalid biases */
-                    continue;
-                }
-
-                /* pseudorange correction */
-                osr[i].PRC[j] = osr[i].trop + osr[i].relatv + osr[i].antr[f] + fi * fi * FREQ2 / FREQ1 * osr[i].iono +
-                                osr[i].cbias[j];
-
-                /* carrier-phase correction */
-                osr[i].CPC[j] = osr[i].trop + osr[i].relatv + osr[i].antr[f] - fi * fi * FREQ2 / FREQ1 * osr[i].iono +
-                                osr[i].pbias[j] + osr[i].wupL[f] + osr[i].compL[j];
-
-                /* SIS/IODE adjustment */
-                iodeflag = 0;
-                if (!opt->posopt[9]) {
-                    osr[i].CPC[j] = clas_osr_adjust_cpc(obs_copy[i].time, sat, &nav->ssr_ch[ch][sat - 1], f,
-                                                        osr[i].CPC[j], &osr[i].sis, &iodeflag, ch, osr_ctx);
-                    osr[i].PRC[j] = clas_osr_adjust_prc(obs_copy[i].time, sat, &nav->ssr_ch[ch][sat - 1], f,
-                                                        osr[i].PRC[j], &osr[i].sis, &iodeflag, ch, osr_ctx);
-                }
-
-                /* compute model values, adjusting r/dts on IODE change */
-                if (iodeflag) {
-                    if (tmp_r < 0.0) {
-                        gtime_t dtsat = timeadd(obs_copy[i].time, -obs_copy[i].P[0] / CLIGHT);
-                        tmp_r = r;
-                        tmp_dts = dts[i * 2];
-                        clas_osr_adjust_r_dts(&tmp_r, &tmp_dts, obs_copy[i].time, sat, nav, rr, dtsat, ch, osr_ctx);
-                    }
-                    modl[j] = tmp_r - CLIGHT * tmp_dts + osr[i].CPC[j];
-                    modl[nftmp + j] = tmp_r - CLIGHT * tmp_dts + osr[i].PRC[j];
-                    osr[i].CPC[j] += tmp_r - CLIGHT * tmp_dts - (r - CLIGHT * dts[i * 2]);
-                    osr[i].PRC[j] += tmp_r - CLIGHT * tmp_dts - (r - CLIGHT * dts[i * 2]);
-                } else {
-                    modl[j] = r - CLIGHT * dts[i * 2] + osr[i].CPC[j];
-                    modl[nftmp + j] = r - CLIGHT * dts[i * 2] + osr[i].PRC[j];
-                }
-
-                osr[i].p[j] = modl[nftmp + j];
-                osr[i].c[j] = modl[j];
-
-                /* repair cycle slip of pbias */
-                tow = time2gpst(obs_copy[i].time, NULL);
-                /* getorbitclock from satcorr state */
-                if (tow == osr_ctx->satcorr[ch][sat - 1].tow) {
-                    osr[i].orb = osr_ctx->satcorr[ch][sat - 1].orb;
-                    osr[i].clk = osr_ctx->satcorr[ch][sat - 1].clk;
-                } else {
-                    osr[i].orb = 0.0;
-                    osr[i].clk = 0.0;
-                }
-
-                /* cycle slip detection on phase bias update */
-                if (!nav->filreset &&
-                    fabs(timediff(nav->ssr_ch[ch][sat - 1].t0[5], osr_ctx->pt0tmp[sat - 1])) > 0.0 &&
-                    fabs(timediff(nav->ssr_ch[ch][sat - 1].t0[5], osr_ctx->pt0tmp[sat - 1])) < 120.0) {
-                    dcpc = osr[i].orb - osr[i].clk + osr[i].CPC[j] - osr_ctx->cpctmp[j * MAXSAT + sat - 1];
-                    if (dcpc >= 95.0 * lam[f] && dcpc < 105.0 * lam[f]) {
-                        osr_ctx->pbias_ofst[j * MAXSAT + sat - 1] -= 100.0;
-                        /* PPP-RTK (y != NULL): correct the ambiguity filter state.
-                         * VRS/OSR (y == NULL): rtk->x has no ambiguity slots, so
-                         * the offset is instead applied to the emitted carrier
-                         * phase in clas_ssr2osr() — see upstream cssr2osr.c L342. */
-                        if (y) {
-                            x[IB_RTK(sat, f, opt)] -= 100.0;
-                        }
-                        trace(NULL, 2,
-                              "pbias slip detected t=%s sat=%2d f=%1d "
-                              "dcpc[cycle]=%.1f\n",
-                              time_str(obs_copy[i].time, 0), sat, f, lam[f] > 0.0 ? dcpc / lam[f] : 0.0);
-                    } else if (dcpc <= -95.0 * lam[f] && dcpc > -105.0 * lam[f]) {
-                        osr_ctx->pbias_ofst[j * MAXSAT + sat - 1] += 100.0;
-                        if (y) {
-                            x[IB_RTK(sat, f, opt)] += 100.0;
-                        }
-                        trace(NULL, 2,
-                              "pbias slip detected t=%s sat=%2d f=%1d "
-                              "dcpc[cycle]=%.1f\n",
-                              time_str(obs_copy[i].time, 0), sat, f, lam[f] > 0.0 ? dcpc / lam[f] : 0.0);
-                    }
-                } else {
-                    osr_ctx->pbias_ofst[j * MAXSAT + sat - 1] = 0.0;
-                }
-                osr_ctx->cpctmp[j * MAXSAT + sat - 1] = osr[i].orb - osr[i].clk + osr[i].CPC[j];
+            if (osr[i].pbias[j] == CLAS_CSSRINVALID || osr[i].cbias[j] == CLAS_CSSRINVALID) {
+                /* ENA_PPP_RTK path: skip invalid biases */
+                continue;
             }
+
+            /* pseudorange correction */
+            osr[i].PRC[j] =
+                osr[i].trop + osr[i].relatv + osr[i].antr[f] + fi * fi * FREQ2 / FREQ1 * osr[i].iono + osr[i].cbias[j];
+
+            /* carrier-phase correction */
+            osr[i].CPC[j] = osr[i].trop + osr[i].relatv + osr[i].antr[f] - fi * fi * FREQ2 / FREQ1 * osr[i].iono +
+                            osr[i].pbias[j] + osr[i].wupL[f] + osr[i].compL[j];
+
+            /* SIS/IODE adjustment */
+            iodeflag = 0;
+            if (!opt->posopt[9]) {
+                osr[i].CPC[j] = clas_osr_adjust_cpc(obs_copy[i].time, sat, &nav->ssr_ch[ch][sat - 1], f, osr[i].CPC[j],
+                                                    &osr[i].sis, &iodeflag, ch, osr_ctx);
+                osr[i].PRC[j] = clas_osr_adjust_prc(obs_copy[i].time, sat, &nav->ssr_ch[ch][sat - 1], f, osr[i].PRC[j],
+                                                    &osr[i].sis, &iodeflag, ch, osr_ctx);
+            }
+
+            /* compute model values, adjusting r/dts on IODE change */
+            if (iodeflag) {
+                if (tmp_r < 0.0) {
+                    gtime_t dtsat = timeadd(obs_copy[i].time, -obs_copy[i].P[0] / CLIGHT);
+                    tmp_r = r;
+                    tmp_dts = dts[i * 2];
+                    clas_osr_adjust_r_dts(&tmp_r, &tmp_dts, obs_copy[i].time, sat, nav, rr, dtsat, ch, osr_ctx);
+                }
+                modl[j] = tmp_r - CLIGHT * tmp_dts + osr[i].CPC[j];
+                modl[nftmp + j] = tmp_r - CLIGHT * tmp_dts + osr[i].PRC[j];
+                osr[i].CPC[j] += tmp_r - CLIGHT * tmp_dts - (r - CLIGHT * dts[i * 2]);
+                osr[i].PRC[j] += tmp_r - CLIGHT * tmp_dts - (r - CLIGHT * dts[i * 2]);
+            } else {
+                modl[j] = r - CLIGHT * dts[i * 2] + osr[i].CPC[j];
+                modl[nftmp + j] = r - CLIGHT * dts[i * 2] + osr[i].PRC[j];
+            }
+
+            osr[i].p[j] = modl[nftmp + j];
+            osr[i].c[j] = modl[j];
+
+            /* repair cycle slip of pbias */
+            tow = time2gpst(obs_copy[i].time, NULL);
+            /* getorbitclock from satcorr state */
+            if (tow == osr_ctx->satcorr[ch][sat - 1].tow) {
+                osr[i].orb = osr_ctx->satcorr[ch][sat - 1].orb;
+                osr[i].clk = osr_ctx->satcorr[ch][sat - 1].clk;
+            } else {
+                osr[i].orb = 0.0;
+                osr[i].clk = 0.0;
+            }
+
+            /* cycle slip detection on phase bias update */
+            if (!nav->filreset && fabs(timediff(nav->ssr_ch[ch][sat - 1].t0[5], osr_ctx->pt0tmp[sat - 1])) > 0.0 &&
+                fabs(timediff(nav->ssr_ch[ch][sat - 1].t0[5], osr_ctx->pt0tmp[sat - 1])) < 120.0) {
+                dcpc = osr[i].orb - osr[i].clk + osr[i].CPC[j] - osr_ctx->cpctmp[j * MAXSAT + sat - 1];
+                if (dcpc >= 95.0 * lam[f] && dcpc < 105.0 * lam[f]) {
+                    osr_ctx->pbias_ofst[j * MAXSAT + sat - 1] -= 100.0;
+                    /* PPP-RTK (y != NULL): correct the ambiguity filter state.
+                     * VRS/OSR (y == NULL): rtk->x has no ambiguity slots, so
+                     * the offset is instead applied to the emitted carrier
+                     * phase in clas_ssr2osr() — see upstream cssr2osr.c L342. */
+                    if (y) {
+                        x[IB_RTK(sat, f, opt)] -= 100.0;
+                    }
+                    trace(NULL, 2,
+                          "pbias slip detected t=%s sat=%2d f=%1d "
+                          "dcpc[cycle]=%.1f\n",
+                          time_str(obs_copy[i].time, 0), sat, f, lam[f] > 0.0 ? dcpc / lam[f] : 0.0);
+                } else if (dcpc <= -95.0 * lam[f] && dcpc > -105.0 * lam[f]) {
+                    osr_ctx->pbias_ofst[j * MAXSAT + sat - 1] += 100.0;
+                    if (y) {
+                        x[IB_RTK(sat, f, opt)] += 100.0;
+                    }
+                    trace(NULL, 2,
+                          "pbias slip detected t=%s sat=%2d f=%1d "
+                          "dcpc[cycle]=%.1f\n",
+                          time_str(obs_copy[i].time, 0), sat, f, lam[f] > 0.0 ? dcpc / lam[f] : 0.0);
+                }
+            } else {
+                osr_ctx->pbias_ofst[j * MAXSAT + sat - 1] = 0.0;
+            }
+            osr_ctx->cpctmp[j * MAXSAT + sat - 1] = osr[i].orb - osr[i].clk + osr[i].CPC[j];
+        }
 
         /* ISB correction */
         if (opt->isb == ISBOPT_TABLE) {

--- a/src/core/mrtk_toml.c
+++ b/src/core/mrtk_toml.c
@@ -98,6 +98,9 @@ static const toml_map_t toml_mapping[] = {
     {"ambiguity_resolution.thresholds", "alpha", "pos2-aralpha"},
     {"ambiguity_resolution.thresholds", "elevation_mask", "pos2-arelmask"},
     {"ambiguity_resolution.thresholds", "hold_elevation", "pos2-elmaskhold"},
+    {"ambiguity_resolution.thresholds", "max_pdop_ar", "pos2-maxpdopar"},
+    {"ambiguity_resolution.thresholds", "max_pdop_hold", "pos2-maxpdophold"},
+    {"ambiguity_resolution.thresholds", "reference_dop", "pos2-refdop"},
 
     /* ── ambiguity_resolution.counters ─────────────────────────────────────── */
     {"ambiguity_resolution.counters", "lock_count", "pos2-arlockcnt"},

--- a/src/data/mrtk_nav.c
+++ b/src/data/mrtk_nav.c
@@ -476,6 +476,26 @@ extern void apply_pppsig(const int* pppsig) {
             break;
     }
 }
+
+/* apply upstream claslib PPP-RTK slot layout ---------------------------------
+ * claslib/RTKLIB uses abstract frequency slots from obsfreqs[]:
+ *   GPS: L1, L2, L5
+ *   GAL: E1, unused L2 slot, E5a, E6, E5b, E5ab
+ *   QZS: L1, L2, L5, L6
+ * MRTK's normal obsdef is physical-band oriented (GAL E5a and QZS L5 at slot 1).
+ * For QZSS CLAS PPP-RTK, keep the post-processing path slot-compatible with
+ * upstream so cssr2osr's GAL slot-1 skip and QZS L2 default select the same
+ * ambiguities as claslib.
+ *-----------------------------------------------------------------------------*/
+extern void apply_claslib_ppprtk_obsdef(void) {
+    static const int fn_gps_clas[MAXFREQ] = {1, 2, 5, 0, 0, 0, 0};
+    static const int fn_gal_clas[MAXFREQ] = {1, 0, 5, 6, 7, 8, 0};
+    static const int fn_qzs_clas[MAXFREQ] = {1, 2, 5, 6, 0, 0, 0};
+
+    set_obsdef(SYS_GPS, fn_gps_clas);
+    set_obsdef(SYS_GAL, fn_gal_clas);
+    set_obsdef(SYS_QZS, fn_qzs_clas);
+}
 /* convert frequency index to frequency number --------------------------------
  * args   : int    sys        I   satellite system
  *          int    freq_idx   I   frequency index (0,1,2,...)

--- a/src/data/mrtk_obs.c
+++ b/src/data/mrtk_obs.c
@@ -891,6 +891,20 @@ extern mrtk_band_t mrtk_rinex_freq_to_band(int sys, int rinex_freq_id) {
     return MRTK_BAND_UNKNOWN;
 }
 
+/* claslib-compatible QZSS L1 priority ("CSLXZ"), applied only while CLAS
+ * processing is active: upstream claslib and MADOCALIB genuinely disagree on
+ * the QZSS L1 order, so the claslib order must not leak into other engines
+ * (it moves MADOCA-PPP solutions by centimetres against their references). */
+static const uint8_t QZS_L1_PRIORITY_CLASLIB[MRTK_MAX_SIG_PRIORITY] = {
+    CODE_L1C, CODE_L1S, CODE_L1L, CODE_L1X, CODE_L1Z,
+};
+static int qzs_l1_claslib = 0;
+
+/* mrtk_use_claslib_qzs_l1_priority: toggle claslib QZSS L1 signal priority ---
+ * args   : int on  I  1: claslib order (C>S>L>X>Z), 0: MRTK default order
+ *----------------------------------------------------------------------------*/
+extern void mrtk_use_claslib_qzs_l1_priority(int on) { qzs_l1_claslib = on; }
+
 /* mrtk_get_signal_priority: get priority-ordered code list -------------------
  * look up the priority-ordered observation code list for a (system, band) pair
  * args   : int         sys   I  satellite system (SYS_???)
@@ -902,6 +916,9 @@ extern const uint8_t* mrtk_get_signal_priority(int sys, mrtk_band_t band) {
 
     if (band == MRTK_BAND_UNKNOWN || band >= MRTK_BAND_MAX) {
         return NULL;
+    }
+    if (qzs_l1_claslib && sys == SYS_QZS && band == MRTK_BAND_QZS_L1) {
+        return QZS_L1_PRIORITY_CLASLIB;
     }
     for (i = 0; i < (int)(sizeof(SIG_PRIORITY_TABLE) / sizeof(SIG_PRIORITY_TABLE[0])); i++) {
         if (SIG_PRIORITY_TABLE[i].sys == sys && SIG_PRIORITY_TABLE[i].priority.band == band) {

--- a/src/pos/mrtk_options.c
+++ b/src/pos/mrtk_options.c
@@ -46,6 +46,7 @@ static char signals_[1024];
 
 /* system options table ------------------------------------------------------*/
 #define SWTOPT "0:off,1:on"
+#define ISBOPT "0:off,1:table,1:on"
 #define SEEDOPT "0:off,1:cn0+tdcp,2:cn0+tdcp+robust"
 #define MODOPT                                                                                                    \
     "0:single,1:dgps,2:kinematic,3:static,4:movingbase,5:fixed,6:ppp-kine,7:ppp-static,8:ppp-fixed,9:ppp-rtk,10:" \
@@ -79,6 +80,7 @@ static char signals_[1024];
 #define COMOPT "0:off,1:ssr,2:meas"
 #define ARALPHAOPT "0:0.1%,1:0.5%,2:1%,3:5%,4:10%,5:20%"
 #define PSHFTOPT "0:off,1:table"
+#define DOPOPT "0:zd,1:sd"
 #define SATCB "0:auto,1:ssr,2:bia,3:dcb"
 #define SATPB "0:auto,1:ssr,2:bia,3:fcb"
 #define CORROPT "-1:auto,0:none,1:igs,2:igs-rts,3:qzs-madoca,4:gal-has,5:bds-b2b,6:qzs-clas"
@@ -166,6 +168,9 @@ opt_t sysopts[] = {
     {"pos2-qzsarmode", 3, (void*)&prcopt_.qzsmodear, SWTOPT},
     {"pos2-aralpha", 3, (void*)&prcopt_.alphaar, ARALPHAOPT},
     {"pos2-arminamb", 0, (void*)&prcopt_.minamb, ""},
+    {"pos2-maxpdopar", 1, (void*)&prcopt_.maxpdopar, ""},
+    {"pos2-maxpdophold", 1, (void*)&prcopt_.maxpdophold, ""},
+    {"pos2-refdop", 3, (void*)&prcopt_.refdop, DOPOPT},
     {"pos2-armaxdelsat", 0, (void*)&prcopt_.armaxdelsat, ""},
     {"pos2-varholdamb", 1, (void*)&prcopt_.varholdamb, "cyc^2"},
     {"pos2-arthres5", 1, (void*)&prcopt_.thresar[5], ""},
@@ -190,7 +195,7 @@ opt_t sysopts[] = {
     {"pos2-afgainpva", 1, (void*)&prcopt_.afgainpva, ""},
     {"pos2-phasshft", 3, (void*)&prcopt_.phasshft, PSHFTOPT},
     {"pos2-rectype", 2, (void*)prcopt_.rectype[1], ""},
-    {"pos2-isb", 3, (void*)&prcopt_.isb, SWTOPT},
+    {"pos2-isb", 3, (void*)&prcopt_.isb, ISBOPT},
 
     {"out-solformat", 3, (void*)&solopt_.posf, SOLOPT},
     {"out-outhead", 3, (void*)&solopt_.outhead, SWTOPT},

--- a/src/pos/mrtk_options.c
+++ b/src/pos/mrtk_options.c
@@ -50,7 +50,7 @@ static char signals_[1024];
 #define MODOPT                                                                                                    \
     "0:single,1:dgps,2:kinematic,3:static,4:movingbase,5:fixed,6:ppp-kine,7:ppp-static,8:ppp-fixed,9:ppp-rtk,10:" \
     "ssr2osr,11:ssr2osr-fixed,12:vrs-rtk"
-#define FRQOPT "1:l1,2:l1+2,3:l1+2+3,4:l1+2+3+4,5:l1+2+3+4+5"
+#define FRQOPT "1:l1,2:l1+2,2:l1+l2,3:l1+2+3,3:l1+l2+l5,4:l1+2+3+4,4:l1+l2+l5+l6,5:l1+2+3+4+5,5:l1+l2+l5+l6+l7"
 #define FRQOPT2 "1:l1,2:l1+l2,3:l1+l5,4:l1+l2+l5,5:l1+l5(l2)"
 #define TYPOPT "0:forward,1:backward,2:combined"
 #define IONOPT "0:off,1:brdc,2:sbas,3:dual-freq,4:est-stec,5:ionex-tec,6:qzs-brdc,9:est-adaptive"

--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -158,7 +158,7 @@ static struct {
     int refsat[NFREQ * 2 * MAXREF * 6 + 1];
     int refsat2[NFREQ * 2 * 6 + 1];
 
-    /* CPC/pt0 persistent state from zdres */
+    /* CPC/pt0 persistent state from zdres (CPC is freq-major: f * MAXSAT + sat-1) */
     double cpc[MAXSAT * NFREQ];
     gtime_t pt0[MAXSAT];
 
@@ -183,6 +183,32 @@ static struct {
 
     int initialized;
 } prtk_ctx;
+
+static void load_ppp_osr_cpc(clas_osr_ctx_t* ctx, const double* cpc, const gtime_t* pt0) {
+    int f, i;
+
+    for (f = 0; f < NFREQ; f++) {
+        for (i = 0; i < MAXSAT; i++) {
+            ctx->cpctmp[f * MAXSAT + i] = cpc[f * MAXSAT + i];
+        }
+    }
+    for (i = 0; i < MAXSAT; i++) {
+        ctx->pt0tmp[i] = pt0[i];
+    }
+}
+
+static void save_ppp_osr_cpc(const clas_osr_ctx_t* ctx, double* cpc, gtime_t* pt0) {
+    int f, i;
+
+    for (f = 0; f < NFREQ; f++) {
+        for (i = 0; i < MAXSAT; i++) {
+            cpc[f * MAXSAT + i] = ctx->cpctmp[f * MAXSAT + i];
+        }
+    }
+    for (i = 0; i < MAXSAT; i++) {
+        pt0[i] = ctx->pt0tmp[i];
+    }
+}
 
 /*============================================================================
  * Helper: satellite-specific wavelength
@@ -2427,7 +2453,7 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
             for (j = 0; j < MAXSAT; j++) {
                 pt0_[j] = prtk_ctx.pt0[j];
                 for (f = 0; f < NFREQ; f++) {
-                    cpc_[j * NFREQ + f] = prtk_ctx.cpc[j * NFREQ + f];
+                    cpc_[f * MAXSAT + j] = prtk_ctx.cpc[f * MAXSAT + j];
                 }
             }
 
@@ -2435,8 +2461,10 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
             for (j = 0; j < 3; j++) {
                 pbslip[j] = xp[j];
             }
+            load_ppp_osr_cpc(&prtk_ctx.osr_ctx, cpc_, pt0_);
             nvtmp = clas_osr_zdres(obs, n, rs, dts, var, svh, nav, pbslip, y, e, azel, rtk, 1, &prtk_ctx.osr_ctx, grid,
                                    corr, rtk->ssat, &rtk->opt, &rtk->sol, NULL, 0);
+            save_ppp_osr_cpc(&prtk_ctx.osr_ctx, cpc_, pt0_);
 
             if (!nvtmp) {
                 trace(NULL, 2, "rover initial position error\n");
@@ -2461,8 +2489,10 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
             }
 
             /* recompute zero-difference residuals (postfit) */
+            load_ppp_osr_cpc(&prtk_ctx.osr_ctx, cpc_, pt0_);
             nvtmp = clas_osr_zdres(obs, n, rs, dts, var, svh, nav, xp, y, e, azel, rtk, 0, &prtk_ctx.osr_ctx, grid,
                                    corr, rtk->ssat, &rtk->opt, &rtk->sol, NULL, 0);
+            save_ppp_osr_cpc(&prtk_ctx.osr_ctx, cpc_, pt0_);
 
             if (nvtmp) {
                 nv = ddres(rtk, nav, xp, NULL, Pp, obs, y, e, azel, n, v, NULL, R, vflg, k);
@@ -2648,8 +2678,10 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
 
         if (nb > 1) {
             /* recompute zdres with fixed solution */
+            load_ppp_osr_cpc(&prtk_ctx.osr_ctx, cpc_, pt0_);
             nvtmp = clas_osr_zdres(obs, n, rs, dts, var, svh, nav, xa, y, e, azel, rtk, 0, &prtk_ctx.osr_ctx, grid,
                                    corr, rtk->ssat, &rtk->opt, &rtk->sol, NULL, 0);
+            save_ppp_osr_cpc(&prtk_ctx.osr_ctx, cpc_, pt0_);
             if (nvtmp) {
                 /* post-fix DD residuals */
                 nv = ddres(rtk, nav, xa, NULL, NULL, obs, y, e, azel, n, v, NULL, R, vflg, k);
@@ -2775,7 +2807,7 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
     for (j = 0; j < MAXSAT; j++) {
         prtk_ctx.pt0[j] = pt0_[j];
         for (f = 0; f < NFREQ; f++) {
-            prtk_ctx.cpc[j * NFREQ + f] = cpc_[j * NFREQ + f];
+            prtk_ctx.cpc[f * MAXSAT + j] = cpc_[f * MAXSAT + j];
         }
     }
 

--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -364,7 +364,10 @@ static void initx(rtk_t* rtk, double xi, double var, int i) {
  */
 static void udpos_ppp(rtk_t* rtk, const obsd_t* obs, int n, double tt) {
     double *F, *FP, *xp, pos[3], Q[9] = {0}, Qv[9], var = 0.0;
-    int i, j, nx;
+    double *Fx, *Pxx, *Pxi, *Pxb, *Pxi_, *Pxb_, *xp_;
+    double prnpos_h, prnpos_v;
+    double ki;
+    int i, j, nx, na, ni, nb;
 
     (void)obs;
     (void)n;
@@ -418,9 +421,116 @@ static void udpos_ppp(rtk_t* rtk, const obsd_t* obs, int n, double tt) {
         return;
     }
 
-    /* state transition of position/velocity/acceleration */
-    if (rtk->opt.dynamics) {
-        /* x=Fx, P=FPF' for pos/vel/acc */
+    /* state transition of position/velocity/acceleration. For PPP-RTK iono
+     * states, keep the same joint pos/iono/bias covariance propagation as
+     * claslib: pos evolves by F, iono decays by ki, and cross-covariances are
+     * transformed consistently. */
+    if (NI_RTK(&rtk->opt) > 0) {
+        F = eye(nx);
+
+        if (rtk->opt.dynamics) {
+            for (i = 0; i < 6; i++) {
+                F[i + (i + 3) * nx] = tt;
+            }
+            for (i = 0; i < 3; i++) {
+                F[i + (i + 6) * nx] = SQR(tt) / 2.0;
+            }
+        }
+
+        na = NP_RTK(&rtk->opt);
+        ni = NI_RTK(&rtk->opt);
+        nb = nx - na - ni;
+        ki = rtk->opt.stats_tconstiono > 0.0 ? exp(-tt / rtk->opt.stats_tconstiono) : 1.0;
+
+        Fx = mat(na, na);
+        xp = mat(na, 1);
+        xp_ = mat(na, 1);
+        FP = mat(na, na);
+        Pxx = mat(na, na);
+        Pxi = mat(na, ni);
+        Pxi_ = mat(na, ni);
+        Pxb = mat(na, nb);
+        Pxb_ = mat(na, nb);
+
+        for (i = 0; i < na; i++) {
+            for (j = 0; j < na; j++) {
+                Pxx[i + j * na] = rtk->P[i + j * nx];
+            }
+        }
+        for (i = 0; i < na; i++) {
+            for (j = 0; j < ni; j++) {
+                Pxi_[i + j * na] = 0.5 * (rtk->P[i + (na + j) * nx] + rtk->P[na + j + i * nx]);
+            }
+        }
+        for (i = 0; i < na; i++) {
+            for (j = 0; j < nb; j++) {
+                Pxb_[i + j * na] = 0.5 * (rtk->P[i + (na + ni + j) * nx] + rtk->P[na + ni + j + i * nx]);
+            }
+        }
+        for (i = 0; i < na; i++) {
+            for (j = 0; j < na; j++) {
+                Fx[i + j * na] = F[i + j * nx];
+            }
+            xp_[i] = rtk->x[i];
+        }
+
+        matmul("NN", na, 1, na, 1.0, Fx, xp_, 0.0, xp);
+        for (i = 0; i < na; i++) {
+            rtk->x[i] = xp[i];
+        }
+        for (i = 0; i < ni; i++) {
+            rtk->x[na + i] *= ki;
+        }
+
+        matmul("NN", na, na, na, 1.0, Fx, Pxx, 0.0, FP);
+        matmul("NT", na, na, na, 1.0, FP, Fx, 0.0, Pxx);
+        for (i = 0; i < na; i++) {
+            for (j = 0; j < na; j++) {
+                rtk->P[i + j * nx] = Pxx[i + j * na];
+            }
+        }
+
+        matmul("NN", na, ni, na, ki, Fx, Pxi_, 0.0, Pxi);
+        for (i = 0; i < na; i++) {
+            for (j = 0; j < ni; j++) {
+                rtk->P[i + (na + j) * nx] = rtk->P[(na + j) + i * nx] = Pxi[i + j * na];
+            }
+        }
+
+        matmul("NN", na, nb, na, 1.0, Fx, Pxb_, 0.0, Pxb);
+        for (i = 0; i < na; i++) {
+            for (j = 0; j < nb; j++) {
+                rtk->P[i + (na + ni + j) * nx] = rtk->P[(na + ni + j) + i * nx] = Pxb[i + j * na];
+            }
+        }
+
+        for (i = 0; i < ni; i++) {
+            for (j = 0; j < ni; j++) {
+                rtk->P[(na + i) + (na + j) * nx] *= ki * ki;
+            }
+        }
+        for (i = 0; i < ni; i++) {
+            for (j = 0; j < nb; j++) {
+                rtk->P[(na + i) + (na + ni + j) * nx] *= ki;
+            }
+        }
+        for (i = 0; i < nb; i++) {
+            for (j = 0; j < ni; j++) {
+                rtk->P[(na + ni + i) + (na + j) * nx] *= ki;
+            }
+        }
+
+        free(Pxx);
+        free(Pxi);
+        free(Pxb);
+        free(Pxi_);
+        free(Pxb_);
+        free(Fx);
+        free(xp_);
+        free(F);
+        free(FP);
+        free(xp);
+    } else if (rtk->opt.dynamics) {
         F = eye(9);
         xp = mat(9, 1);
         FP = mat(nx, nx);
@@ -432,11 +542,9 @@ static void udpos_ppp(rtk_t* rtk, const obsd_t* obs, int n, double tt) {
             F[i + (i + 6) * 9] = SQR(tt) / 2.0;
         }
 
-        /* x=F*x */
         matmul("NN", 9, 1, 9, 1.0, F, rtk->x, 0.0, xp);
         matcpy(rtk->x, xp, 9, 1);
 
-        /* P=F*P */
         matcpy(FP, rtk->P, nx, nx);
         for (j = 0; j < nx; j++) {
             for (i = 0; i < 6; i++) {
@@ -444,7 +552,6 @@ static void udpos_ppp(rtk_t* rtk, const obsd_t* obs, int n, double tt) {
             }
         }
 
-        /* P=FP*F' */
         matcpy(rtk->P, FP, nx, nx);
         for (j = 0; j < nx; j++) {
             for (i = 0; i < 6; i++) {
@@ -470,8 +577,10 @@ static void udpos_ppp(rtk_t* rtk, const obsd_t* obs, int n, double tt) {
         }
     } else {
         /* process noise added to position */
-        Q[0] = Q[4] = SQR(rtk->opt.prn[5]) * fabs(tt);
-        Q[8] = SQR(rtk->opt.prn[6]) * fabs(tt);
+        prnpos_h = rtk->opt.stats_prnposith != 0.0 ? rtk->opt.stats_prnposith : rtk->opt.prn[5];
+        prnpos_v = rtk->opt.stats_prnpositv != 0.0 ? rtk->opt.stats_prnpositv : rtk->opt.prn[6];
+        Q[0] = Q[4] = SQR(prnpos_h) * fabs(tt);
+        Q[8] = SQR(prnpos_v) * fabs(tt);
         ecef2pos(rtk->x, pos);
         covecef(pos, Q, Qv);
         for (i = 0; i < 3; i++) {
@@ -559,29 +668,6 @@ static void udion(rtk_t* rtk, double tt, double bl, const obsd_t* obs, int ns) {
             }
         }
     }
-    /* ionosphere Gauss-Markov (AR1) decay toward zero: x_I*=ki and scale the
-     * iono rows/cols of P by ki (diagonal by ki^2). Upstream applies this as
-     * part of udpos_ppp's joint state transition with ki=exp(-tt/beta); MRTK's
-     * split udpos/udion path had dropped it (the time-constant value was parsed
-     * into stats_tconstiono but read by no positioning engine). Applying it as
-     * a scalar scale here is equivalent. */
-    {
-        double tconst = rtk->opt.stats_tconstiono;
-        if (tconst > 0.0) {
-            double ki = exp(-tt / tconst);
-            for (i = 1; i <= MAXSAT; i++) {
-                j = II_RTK(i, &rtk->opt);
-                if (rtk->x[j] == 0.0) {
-                    continue;
-                }
-                rtk->x[j] *= ki;
-                for (k = 0; k < rtk->nx; k++) {
-                    rtk->P[j + k * rtk->nx] *= ki;
-                    rtk->P[k + j * rtk->nx] *= ki;
-                }
-            }
-        }
-    }
     for (i = 0; i < ns; i++) {
         j = II_RTK(obs[i].sat, &rtk->opt);
         if (rtk->x[j] == 0.0) {
@@ -622,78 +708,6 @@ static void udion(rtk_t* rtk, double tt, double bl, const obsd_t* obs, int ns) {
  * @param[in]     obs Observation data
  * @param[in]     n   Number of observations
  */
-/* detect cycle slip by Doppler/phase rate comparison (demo5, single-receiver) */
-static void detslp_dop(rtk_t* rtk, const obsd_t* obs, int n, const nav_t* nav) {
-    (void)nav;
-    int i, f, sat, ndop = 0, nf = rtk->opt.nf < NFREQ ? rtk->opt.nf : NFREQ;
-    double dph, dpt, tt, mean_dop = 0.0;
-    double dopdif[MAXOBS][NFREQ] = {{0}}, tts[MAXOBS][NFREQ] = {{0}};
-
-    if (rtk->opt.thresdop <= 0.0) {
-        return; /* disabled */
-    }
-
-    for (i = 0; i < n && i < MAXOBS; i++) {
-        sat = obs[i].sat;
-        for (f = 0; f < nf; f++) {
-            if (obs[i].L[f] == 0.0 || obs[i].D[f] == 0.0 || rtk->ssat[sat - 1].ph[0][f] == 0.0) {
-                continue;
-            }
-            tt = timediff(obs[i].time, rtk->ssat[sat - 1].pt[0][f]);
-            if (fabs(tt) < DTTOL) {
-                continue;
-            }
-            dph = (obs[i].L[f] - rtk->ssat[sat - 1].ph[0][f]) / tt;
-            dpt = -obs[i].D[f];
-            dopdif[i][f] = dph - dpt;
-            tts[i][f] = tt;
-            if (fabs(dopdif[i][f]) < 3.0 * rtk->opt.thresdop) {
-                mean_dop += dopdif[i][f];
-                ndop++;
-            }
-        }
-    }
-    if (ndop == 0) {
-        return;
-    }
-    mean_dop /= ndop;
-
-    for (i = 0; i < n && i < MAXOBS; i++) {
-        sat = obs[i].sat;
-        for (f = 0; f < nf; f++) {
-            if (dopdif[i][f] == 0.0) {
-                continue;
-            }
-            if (fabs(dopdif[i][f] - mean_dop) > rtk->opt.thresdop) {
-                rtk->ssat[sat - 1].slip[f] |= 1;
-                trace(NULL, 3, "ppprtk detslp_dop: sat=%2d F=%d dL=%.3f off=%.3f tt=%.2f\n", sat, f + 1,
-                      dopdif[i][f] - mean_dop, mean_dop, tts[i][f]);
-            }
-        }
-    }
-}
-/* detect cycle slip by observation code change (demo5, single-receiver) */
-static void detslp_code(rtk_t* rtk, const obsd_t* obs, int n) {
-    int i, f, sat, nf = rtk->opt.nf < NFREQ ? rtk->opt.nf : NFREQ;
-    for (i = 0; i < n && i < MAXOBS; i++) {
-        sat = obs[i].sat;
-        for (f = 0; f < nf; f++) {
-            uint8_t code = obs[i].code[f];
-            if (code == CODE_NONE) {
-                continue;
-            }
-            uint8_t ccode = rtk->ssat[sat - 1].codeprev[f][0];
-            if (code != ccode) {
-                rtk->ssat[sat - 1].codeprev[f][0] = code;
-                if (ccode != CODE_NONE) {
-                    rtk->ssat[sat - 1].slip[f] |= 1;
-                    trace(NULL, 3, "ppprtk detslp_code: sat=%2d F=%d %s->%s\n", sat, f + 1, code2obs(ccode),
-                          code2obs(code));
-                }
-            }
-        }
-    }
-}
 static void detslp_ll(rtk_t* rtk, const obsd_t* obs, int n) {
     int i, j;
 
@@ -818,12 +832,6 @@ static void udbias_ppp(rtk_t* rtk, double tt, const obsd_t* obs, int n, const na
 
     /* detect cycle slip by geometry-free phase jump */
     detslp_gf(rtk, obs, n, nav);
-
-    /* detect cycle slip by Doppler rate (demo5) */
-    detslp_dop(rtk, obs, n, nav);
-
-    /* detect cycle slip by observation code change (demo5) */
-    detslp_code(rtk, obs, n);
 
     for (f = 0; f < nf; f++) {
         /* reset phase-bias if expire obs outage counter */
@@ -1104,13 +1112,22 @@ static int residual_test(rtk_t* rtk, const int* vflg, const double* v, const dou
     for (i = 0; i < MAXSAT; i++) {
         for (k = 1; k < nf; k++) {
             int qi = 0, qj = k;
-            gamma = SQR(lam_carr[qj]) / SQR(lam_carr[qi]);
+            double q0, q1, lami, lamj;
+
             if (resp[i * nf + qi] == 0.0 || resp[i * nf + qj] == 0.0) {
                 continue;
             }
+            lami = sat_lambda(i + 1, qi, NULL);
+            lamj = sat_lambda(i + 1, qj, NULL);
+            if (lami <= 0.0 || lamj <= 0.0) {
+                continue;
+            }
+            gamma = SQR(lamj) / SQR(lami);
+            q0 = resp[i * nf + qi];
+            q1 = resp[i * nf + qj];
             vvf_ = FREQ1 / FREQ2 * (resc[i * nf + qi] - resc[i * nf + qj]) / (1.0 - gamma);
             vv0_ = (gamma * resc[i * nf + qi] - resc[i * nf + qj]) / (gamma - 1.0);
-            sig2 = resp[i * nf + qi] > resp[i * nf + qj] ? resp[i * nf + qi] : resp[i * nf + qj];
+            sig2 = q0 > q1 ? q0 : q1;
 
             /* dispersive term validation */
             if ((inno1 > 0.0) && (vvf_ * vvf_ > inno1 * inno1 * sig2)) {
@@ -1152,20 +1169,13 @@ static int residual_test(rtk_t* rtk, const int* vflg, const double* v, const dou
         (void)stype;
 
         /* validate individual residuals */
-        /* D2: inflate threshold 10x for newly-initialized phase bias (demo5) */
-        double inno0_eff = inno0;
-        if (type == 0 && rtk->opt.std[0] > 0.0) {
-            int ib = IB_RTK(sat2, freq, &rtk->opt);
-            if (rtk->P[ib + ib * rtk->nx] == SQR(rtk->opt.std[0])) {
-                inno0_eff *= 10.0;
-            }
-        }
-        if (!Q[i + i * m] || inno0 == 0 || (v[i] * v[i] < Q[i + i * m] * inno0_eff * inno0_eff)) {
+        double qdiag = Q[i + i * m];
+        if (!qdiag || inno0 == 0 || (v[i] * v[i] < qdiag * inno0 * inno0)) {
             if (type == 0) {
                 if (!rtk->ssat[sat2 - 1].vsat[freq]) {
                     continue;
                 }
-                vv += v[i] * v[i] / Q[i + i * m];
+                vv += v[i] * v[i] / qdiag;
                 cnt++;
             }
             ns[type < 1 ? freq : freq * type + nf]++;
@@ -1177,7 +1187,7 @@ static int residual_test(rtk_t* rtk, const int* vflg, const double* v, const dou
             trace(NULL, 2,
                   "meas update outlier detected "
                   "(sat=%2d %s%d v=%6.3f sig=%6.3f outc=%2d)\n",
-                  sat2, stype, freq + 1, v[i], sqrt(Q[i + i * m]), rtk->ssat[sat2 - 1].outc[freq]);
+                  sat2, stype, freq + 1, v[i], sqrt(qdiag), rtk->ssat[sat2 - 1].outc[freq]);
         }
     }
 
@@ -1543,7 +1553,11 @@ static int ddres(rtk_t* rtk, const nav_t* nav, double* x, double* pbslip, const 
                 }
 
                 /* DD residual */
-                v[nv] = y[f + i * nf * 2] - y[f + j * nf * 2];
+                double yi = y[f + i * nf * 2];
+                double yj = y[f + j * nf * 2];
+                double raw = yi - yj;
+                double ion = 0.0, trop = 0.0, amb = 0.0;
+                v[nv] = raw;
 
                 /* partial derivatives by rover position */
                 if (H) {
@@ -1558,7 +1572,8 @@ static int ddres(rtk_t* rtk, const nav_t* nav, double* x, double* pbslip, const 
                     fj = lamj / lam_carr[0];
                     didxi = (f < nf ? -1.0 : 1.0) * fi * fi * im[i];
                     didxj = (f < nf ? -1.0 : 1.0) * fj * fj * im[j];
-                    v[nv] -= didxi * x[II_RTK(sati, opt)] - didxj * x[II_RTK(satj, opt)];
+                    ion = didxi * x[II_RTK(sati, opt)] - didxj * x[II_RTK(satj, opt)];
+                    v[nv] -= ion;
                     if (H) {
                         Hi[II_RTK(sati, opt)] = didxi;
                         Hi[II_RTK(satj, opt)] = -didxj;
@@ -1567,7 +1582,8 @@ static int ddres(rtk_t* rtk, const nav_t* nav, double* x, double* pbslip, const 
 
                 /* DD tropospheric delay term */
                 if (opt->tropopt == TROPOPT_EST || opt->tropopt == TROPOPT_ESTG) {
-                    v[nv] -= (tropu[i] - tropu[j]);
+                    trop = tropu[i] - tropu[j];
+                    v[nv] -= trop;
                     for (k = 0; k < (opt->tropopt < TROPOPT_ESTG ? 1 : 3); k++) {
                         if (!H) {
                             continue;
@@ -1578,7 +1594,8 @@ static int ddres(rtk_t* rtk, const nav_t* nav, double* x, double* pbslip, const 
 
                 /* DD phase-bias term */
                 if (f < nf) {
-                    v[nv] -= lami * x[IB_RTK(sati, f, opt)] - lamj * x[IB_RTK(satj, f, opt)];
+                    amb = lami * x[IB_RTK(sati, f, opt)] - lamj * x[IB_RTK(satj, f, opt)];
+                    v[nv] -= amb;
                     if (H) {
                         Hi[IB_RTK(sati, f, opt)] = lami;
                         Hi[IB_RTK(satj, f, opt)] = -lamj;
@@ -1879,6 +1896,65 @@ static void elsort(rtk_t* rtk, const obsd_t* obs, int* isat, double* el, int n) 
     }
 }
 
+/* compute single-difference PDOP */
+static double sddop(const rtk_t* rtk, const double* H, const int* vflg, double elmask, int nv) {
+    double *H_, Q[9], dop = 1000.0;
+    int i, cnt, freq, type, sat;
+
+    H_ = mat(3, nv);
+    for (i = cnt = 0; i < nv; i++) {
+        sat = (vflg[i] >> 8) & 0xFF;
+        type = (vflg[i] >> 4) & 0xF;
+        freq = vflg[i] & 0xF;
+        if (freq > 0 || type > 0 || rtk->ssat[sat - 1].vsat[0] == 0 || rtk->ssat[sat - 1].azel[1] <= elmask) {
+            continue;
+        }
+        H_[cnt * 3] = H[i * rtk->nx];
+        H_[cnt * 3 + 1] = H[i * rtk->nx + 1];
+        H_[cnt * 3 + 2] = H[i * rtk->nx + 2];
+        cnt++;
+    }
+    matmul("NT", 3, 3, cnt, 1.0, H_, H_, 0.0, Q);
+    if (cnt > 0 && !matinv(Q, 3)) {
+        dop = sqrt(Q[0] + Q[4] + Q[8]);
+    }
+    free(H_);
+
+    return dop;
+}
+
+/* compute zero-difference PDOP */
+static double zddop(const rtk_t* rtk, const double* azel, const obsd_t* obs, double elmask, int n) {
+    double *azel_, dop[4];
+    int i, j;
+
+    azel_ = mat(2, n);
+    for (i = j = 0; i < n; i++) {
+        if (rtk->ssat[obs[i].sat - 1].vsat[0] == 0) {
+            continue;
+        }
+        azel_[j * 2] = azel[i * 2];
+        azel_[j * 2 + 1] = azel[i * 2 + 1];
+        j++;
+    }
+    dops(j, azel_, elmask, dop);
+    free(azel_);
+
+    return dop[1];
+}
+
+/* compute PDOP for AR gates */
+static double calpdop(const rtk_t* rtk, const double* H, const double* azel, const int* vflg, const obsd_t* obs,
+                      double elmask, int n, int nv) {
+    switch (rtk->opt.refdop) {
+        case 0:
+            return zddop(rtk, azel, obs, elmask, n);
+        case 1:
+            return sddop(rtk, H, vflg, elmask, nv);
+    }
+    return 0.0;
+}
+
 /*============================================================================
  * LAMBDA integer ambiguity resolution
  *===========================================================================*/
@@ -1892,8 +1968,9 @@ static void elsort(rtk_t* rtk, const obsd_t* obs, int* isat, double* el, int n) 
  */
 static int resamb_LAMBDA(rtk_t* rtk, double* bias, double* xa) {
     int i, j, nb, nc, info, nx = rtk->nx, na = rtk->na;
+    int minamb, alpha = -1;
     int indI[MAXOBS * NFREQ], indJ[MAXOBS * NFREQ];
-    double *D, *y, *b, *db, *Qb, *Qab, *QQ, s[2], thres;
+    double *D, *y, *b, *db, *Qb, *Qab, *QQ, s[2], thres = 0.0, ratio = 0.0;
     double* D_P;
 
     trace(NULL, 3, "resamb_LAMBDA : nx=%d\n", nx);
@@ -1907,19 +1984,17 @@ static int resamb_LAMBDA(rtk_t* rtk, double* bias, double* xa) {
     /* SD-to-DD transformation matrix */
     D = zeros(nx, nx);
     nb = ddmat(rtk, D, indI, indJ);
+    minamb = rtk->opt.minamb > 0 ? rtk->opt.minamb : MINAMB_DEFAULT;
 
     if (nb <= 1) {
         trace(NULL, 2, "no valid double-difference\n");
         free(D);
         return 0;
     }
-    {
-        int minamb = rtk->opt.minamb > 0 ? rtk->opt.minamb : MINAMB_DEFAULT;
-        if (nb < minamb) {
-            trace(NULL, 2, "less than minimum number of ambiguities nb=%2d minamb=%d\n", nb, minamb);
-            free(D);
-            return 0;
-        }
+    if (nb < minamb) {
+        trace(NULL, 2, "less than minimum number of ambiguities nb=%2d minamb=%d\n", nb, minamb);
+        free(D);
+        return 0;
     }
 
     y = mat(na + nb, 1);
@@ -1963,13 +2038,12 @@ static int resamb_LAMBDA(rtk_t* rtk, double* bias, double* xa) {
         }
 
         /* F-test threshold (significance level from config or default) */
-        {
-            int alpha = rtk->opt.alphaar > 0 ? rtk->opt.alphaar : ALPHAAR_DEFAULT;
-            thres = (alpha < 6 && nb - 1 < 60) ? qf[alpha][nb - 1] : 1.5;
-        }
+        alpha = rtk->opt.alphaar > 0 ? rtk->opt.alphaar : ALPHAAR_DEFAULT;
+        thres = (alpha < 6 && nb - 1 < 60) ? qf[alpha][nb - 1] : 1.5;
+        ratio = (s[0] == 0.0) ? 0.0 : s[1] / s[0];
 
         /* validation by ratio-test */
-        if (s[0] <= 0.0 || s[1] / s[0] >= thres) {
+        if (s[0] <= 0.0 || ratio >= thres) {
             for (i = 0; i < na; i++) {
                 rtk->xa[i] = rtk->x[i];
                 for (j = 0; j < na; j++) {
@@ -1990,7 +2064,7 @@ static int resamb_LAMBDA(rtk_t* rtk, double* bias, double* xa) {
                 matmul("NT", na, na, nb, -1.0, QQ, Qab, 1.0, rtk->Pa);
 
                 trace(NULL, 3, "resamb : validation ok (nb=%d ratio=%.2f s=%.2f/%.2f)\n", nb,
-                      (s[0] == 0.0) ? 0.0 : s[1] / s[0], s[1], s[0]);
+                      ratio, s[1], s[0]);
 
                 /* restore SD ambiguities */
                 restamb(rtk, bias, nb, xa);
@@ -2002,7 +2076,7 @@ static int resamb_LAMBDA(rtk_t* rtk, double* bias, double* xa) {
             trace(NULL, 3,
                   "ambiguity validation failed "
                   "(nb=%d thres=%.2f ratio=%.2f s=%.2f/%.2f)\n",
-                  nb, thres, (s[0] == 0.0) ? 0.0 : s[1] / s[0], s[1], s[0]);
+                  nb, thres, ratio, s[1], s[0]);
             nb = 0;
         }
     } else {
@@ -2113,6 +2187,23 @@ extern int ppp_rtk_nx(const prcopt_t* opt) { return NX_RTK(opt); }
 
 extern int ppp_rtk_na(const prcopt_t* opt) { return NR_RTK(opt); }
 
+static void check_clas_facility(nav_t* nav, const clas_ctx_t* clas, const clas_grid_t* grid, const prcopt_t* opt) {
+    static int savefacility[SSR_CH_NUM] = {-1, -1};
+    int ch, nch = opt->l6mrg ? SSR_CH_NUM : 1;
+
+    (void)grid;
+
+    for (ch = 0; ch < nch; ch++) {
+        int facility = clas->current[ch].facility;
+        if (savefacility[ch] != facility) {
+            if (savefacility[ch] != -1) {
+                nav->filreset = 1;
+            }
+            savefacility[ch] = facility;
+        }
+    }
+}
+
 /*============================================================================
  * Public API: PPP-RTK positioning for one epoch
  *===========================================================================*/
@@ -2138,7 +2229,7 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
     clas_corr_t* corr;
     double *v, *H, *R, *Pp, *bias, *xp, *xa, *azel, *e;
     double *y, *rs, *dts, *var, *pbslip;
-    double pos[3];
+    double pos[3], pdop;
     int i, j, k, f, l, nv, nvtmp, info, nf = rtk->opt.nf, sati;
     int stat = (rtk->opt.mode <= PMODE_DGPS) ? SOLQ_DGPS : SOLQ_FLOAT;
     int vflg[MAXOBS * NFREQ * 4 + 1], nb, svh[MAXOBS];
@@ -2200,6 +2291,22 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
         }
         prtk_ctx.float_count = 0;
         prtk_ctx.floatcnt_reset = 1;
+    }
+
+    if (nav->filreset) {
+        trace(NULL, 1, "ppp_rtk_pos: reset filter, tow=%.1f\n", time2gpst(obs[0].time, NULL));
+        if (opt->dynamics) {
+            for (i = 0; i < rtk->nx; i++) {
+                rtk->x[i] = 0.0;
+            }
+        } else {
+            for (i = NP_RTK(opt); i < rtk->nx; i++) {
+                rtk->x[i] = 0.0;
+            }
+        }
+        rtk->sol.stat = SOLQ_FLOAT;
+        nav->filreset = 0;
+        stat = SOLQ_FLOAT;
     }
 
     /* temporal update of states */
@@ -2268,6 +2375,7 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
             clas_update_local(nav, &clas->current[ch], ch);
         }
         corr = &clas->current[0];
+        check_clas_facility(nav, clas, grid, opt);
 
         /* dual-channel: merge freshest orbit/clock into ch=0 for satposs */
         if (opt->l6mrg) {
@@ -2304,6 +2412,13 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
     pbslip = zeros(rtk->nx, 1);
 
     matcpy(xp, rtk->x, rtk->nx, 1);
+
+    if ((rtk->opt.ionoopt == IONOOPT_EST_ADPT || rtk->opt.prnadpt) && prtk_ctx.Qp &&
+        prtk_ctx.Qp_nx == rtk->nx) {
+        for (i = 0; i < rtk->nx * rtk->nx; i++) {
+            prtk_ctx.Qp[i] = 0.0;
+        }
+    }
 
     v = mat(nv, 1);
     R = mat(nv, nv);
@@ -2381,35 +2496,36 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
         }
     }
 
+    /* Upstream updates adaptive process noise from the epoch-local prefit Qp
+     * before deciding whether the float state itself is accepted. Keep the same
+     * ordering so rejection-heavy storm windows do not freeze the Q history. */
+    if (rtk->opt.ionoopt == IONOOPT_EST_ADPT && prtk_ctx.Qp) {
+        for (i = 0; i < n; i++) {
+            j = II_RTK(obs[i].sat, &rtk->opt);
+            if (j < prtk_ctx.Qp_nx) {
+                rtk->Q[j + j * rtk->nx] =
+                    rtk->opt.forgetion * rtk->Q[j + j * rtk->nx] +
+                    (1.0 - rtk->opt.forgetion) * SQR(rtk->opt.afgainion) * prtk_ctx.Qp[j + j * prtk_ctx.Qp_nx];
+            }
+        }
+    }
+    if (rtk->opt.prnadpt && prtk_ctx.Qp) {
+        int np = NP_RTK(&rtk->opt);
+        for (i = 0; i < np; i++) {
+            for (j = 0; j < np; j++) {
+                if (i < prtk_ctx.Qp_nx && j < prtk_ctx.Qp_nx) {
+                    rtk->Q[i + j * rtk->nx] =
+                        rtk->opt.forgetpva * rtk->Q[i + j * rtk->nx] +
+                        (1.0 - rtk->opt.forgetpva) * SQR(rtk->opt.afgainpva) * prtk_ctx.Qp[i + j * prtk_ctx.Qp_nx];
+                }
+            }
+        }
+    }
+
     if (stat != SOLQ_NONE) {
         /* update state and covariance matrix */
         matcpy(rtk->x, xp, rtk->nx, 1);
         matcpy(rtk->P, Pp, rtk->nx, rtk->nx);
-
-        /* adaptive process noise update for ionosphere (uses Qp = K*v*(K*v)') */
-        if (rtk->opt.ionoopt == IONOOPT_EST_ADPT && prtk_ctx.Qp) {
-            for (i = 0; i < n; i++) {
-                j = II_RTK(obs[i].sat, &rtk->opt);
-                if (j < prtk_ctx.Qp_nx) {
-                    rtk->Q[j + j * rtk->nx] =
-                        rtk->opt.forgetion * rtk->Q[j + j * rtk->nx] +
-                        (1.0 - rtk->opt.forgetion) * SQR(rtk->opt.afgainion) * prtk_ctx.Qp[j + j * prtk_ctx.Qp_nx];
-                }
-            }
-        }
-        /* adaptive process noise update for pos/vel/acc (uses Qp = K*v*(K*v)') */
-        if (rtk->opt.prnadpt && prtk_ctx.Qp) {
-            int np = NP_RTK(&rtk->opt);
-            for (i = 0; i < np; i++) {
-                for (j = 0; j < np; j++) {
-                    if (i < prtk_ctx.Qp_nx && j < prtk_ctx.Qp_nx) {
-                        rtk->Q[i + j * rtk->nx] =
-                            rtk->opt.forgetpva * rtk->Q[i + j * rtk->nx] +
-                            (1.0 - rtk->opt.forgetpva) * SQR(rtk->opt.afgainpva) * prtk_ctx.Qp[i + j * prtk_ctx.Qp_nx];
-                    }
-                }
-            }
-        }
 
         /* update ambiguity control struct */
         rtk->sol.ns = 0;
@@ -2444,7 +2560,9 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
     }
 
     /* resolve integer ambiguity by LAMBDA */
-    if (stat != SOLQ_NONE) {
+    nb = 0;
+    pdop = calpdop(rtk, H, azel, vflg, obs, rtk->opt.elmaskar, n, nv);
+    if (stat != SOLQ_NONE && (rtk->opt.maxpdopar == 0.0 || pdop <= rtk->opt.maxpdopar)) {
         /* B2: position variance gate — skip AR if filter not yet converged */
         {
             double posvar = 0.0;
@@ -2485,7 +2603,9 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
                     for (f = 0; f < nf2; f++) {
                         rtk->ssat[sati - 1].vsat[f] = 0;
                     }
-                    if ((nb = resamb_LAMBDA(rtk, bias, xa)) > 1) {
+                    pdop = calpdop(rtk, H, azel, vflg, obs, rtk->opt.elmaskar, n, nv);
+                    if ((rtk->opt.maxpdopar == 0.0 || pdop <= rtk->opt.maxpdopar) &&
+                        (nb = resamb_LAMBDA(rtk, bias, xa)) > 1) {
                         trace(NULL, 2, "PAR OK: excluded sat=%2d el=%.1f nb=%d ratio=%.2f\n", sati, el[i] * R2D, nb,
                               rtk->sol.ratio);
                         break;
@@ -2548,7 +2668,9 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
 
                     if (prtk_ctx.chisq < thres_hold) {
                         /* hold integer ambiguity */
-                        if (++rtk->nfix >= rtk->opt.minfix && rtk->opt.modear == ARMODE_FIXHOLD) {
+                        pdop = calpdop(rtk, H, azel, vflg, obs, rtk->opt.elmaskhold, n, nv);
+                        if (++rtk->nfix >= rtk->opt.minfix && rtk->opt.modear == ARMODE_FIXHOLD &&
+                            (rtk->opt.maxpdophold == 0.0 || pdop <= rtk->opt.maxpdophold)) {
                             holdamb(rtk, xa);
                         }
                     }

--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -2084,8 +2084,7 @@ static int resamb_LAMBDA(rtk_t* rtk, double* bias, double* xa) {
                 matmul("NN", na, nb, nb, 1.0, Qab, Qb, 0.0, QQ);
                 matmul("NT", na, na, nb, -1.0, QQ, Qab, 1.0, rtk->Pa);
 
-                trace(NULL, 3, "resamb : validation ok (nb=%d ratio=%.2f s=%.2f/%.2f)\n", nb,
-                      ratio, s[1], s[0]);
+                trace(NULL, 3, "resamb : validation ok (nb=%d ratio=%.2f s=%.2f/%.2f)\n", nb, ratio, s[1], s[0]);
 
                 /* restore SD ambiguities */
                 restamb(rtk, bias, nb, xa);
@@ -2434,8 +2433,7 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
 
     matcpy(xp, rtk->x, rtk->nx, 1);
 
-    if ((rtk->opt.ionoopt == IONOOPT_EST_ADPT || rtk->opt.prnadpt) && prtk_ctx.Qp &&
-        prtk_ctx.Qp_nx == rtk->nx) {
+    if ((rtk->opt.ionoopt == IONOOPT_EST_ADPT || rtk->opt.prnadpt) && prtk_ctx.Qp && prtk_ctx.Qp_nx == rtk->nx) {
         for (i = 0; i < rtk->nx * rtk->nx; i++) {
             prtk_ctx.Qp[i] = 0.0;
         }

--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -236,7 +236,20 @@ static uint8_t obs_code_for_freq(int sat, int f) {
 static double sat_lambda(int sat, int f, const nav_t* nav) {
     uint8_t code = obs_code_for_freq(sat, f);
     char* obs = code2obs(code);
+    int prn = 0, sys = satsys(sat, &prn);
+    int freq_num = freq_idx2freq_num(sys, f);
+    int fcn = 0;
     double freq = 0.0;
+
+    if (freq_num > 0) {
+        if (sys == SYS_GLO && nav && prn >= 1 && prn <= 32 && nav->glo_fcn[prn - 1] > 0) {
+            fcn = nav->glo_fcn[prn - 1] - 8;
+        }
+        freq = freq_num2freq(sys, freq_num, fcn);
+        if (freq > 0.0) {
+            return CLIGHT / freq;
+        }
+    }
 
     if (!obs || strlen(obs) < 2) {
         return 0.0;
@@ -1577,8 +1590,8 @@ static int ddres(rtk_t* rtk, const nav_t* nav, double* x, double* pbslip, const 
                     rtk->ssat[satj - 1].resc[f] = v[nv];
                     Ri[nv] = varerr(sati, sysi, azel[1 + i * 2], 0, opt);
                     Rj[nv] = varerr(satj, sysj, azel[1 + j * 2], 0, opt);
-                    /* L2 scaling factor */
-                    if (f == 1) {
+                    /* L2 scaling factor; MRTK sigcfg can place E5/L5 at slot 1. */
+                    if (f > 0 && (freq_idx2freq_num(sysi, f) == 2 || freq_idx2freq_num(sysj, f) == 2)) {
                         Ri[nv] *= SQR(2.55 / 1.55);
                         Rj[nv] *= SQR(2.55 / 1.55);
                     }

--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -1112,17 +1112,12 @@ static int residual_test(rtk_t* rtk, const int* vflg, const double* v, const dou
     for (i = 0; i < MAXSAT; i++) {
         for (k = 1; k < nf; k++) {
             int qi = 0, qj = k;
-            double q0, q1, lami, lamj;
+            double q0, q1;
 
             if (resp[i * nf + qi] == 0.0 || resp[i * nf + qj] == 0.0) {
                 continue;
             }
-            lami = sat_lambda(i + 1, qi, NULL);
-            lamj = sat_lambda(i + 1, qj, NULL);
-            if (lami <= 0.0 || lamj <= 0.0) {
-                continue;
-            }
-            gamma = SQR(lamj) / SQR(lami);
+            gamma = SQR(lam_carr[qj]) / SQR(lam_carr[qi]);
             q0 = resp[i * nf + qi];
             q1 = resp[i * nf + qj];
             vvf_ = FREQ1 / FREQ2 * (resc[i * nf + qi] - resc[i * nf + qj]) / (1.0 - gamma);

--- a/tests/utest/t_freqidx.c
+++ b/tests/utest/t_freqidx.c
@@ -35,6 +35,7 @@ static int fails = 0;
 
 /* frequency index for a (system, RINEX obs-code string) pair */
 static int idx(int sys, const char* obs) { return code2freq_idx(sys, obs2code(obs)); }
+static int pri(int sys, const char* obs, const char* opt) { return getcodepri(sys, obs2code(obs), opt); }
 
 int main(void) {
     reset_obsdef(); /* pristine multi-band defaults */
@@ -53,6 +54,17 @@ int main(void) {
     CHECK(idx(SYS_QZS, "5Q") == 1, "QZS L5 -> 1 (was 2 under fixed band order)");
     CHECK(idx(SYS_QZS, "2L") == 2, "QZS L2 -> 2 (was 1 under fixed band order)");
     CHECK(idx(SYS_QZS, "6L") == 3, "QZS L6 -> 3");
+    CHECK(pri(SYS_QZS, "1L", "") > pri(SYS_QZS, "1X", "") && pri(SYS_QZS, "1X", "") > pri(SYS_QZS, "1S", "") &&
+              pri(SYS_QZS, "1S", "") > pri(SYS_QZS, "1C", ""),
+          "QZS L1 default priority keeps MRTK order L>X>S>C");
+    mrtk_use_claslib_qzs_l1_priority(1);
+    CHECK(pri(SYS_QZS, "1C", "") > pri(SYS_QZS, "1S", "") && pri(SYS_QZS, "1S", "") > pri(SYS_QZS, "1L", "") &&
+              pri(SYS_QZS, "1L", "") > pri(SYS_QZS, "1X", "") && pri(SYS_QZS, "1X", "") > pri(SYS_QZS, "1Z", ""),
+          "QZS L1 claslib override follows C>S>L>X>Z");
+    CHECK(pri(SYS_QZS, "1X", "-JL1X") == 15 && pri(SYS_QZS, "1C", "-JL1X") == 0,
+          "QZS L1 priority option -JL1X overrides claslib order");
+    mrtk_use_claslib_qzs_l1_priority(0);
+    CHECK(pri(SYS_QZS, "1L", "") > pri(SYS_QZS, "1C", ""), "QZS L1 priority restored after claslib override off");
 
     /* BDS: B1I=0, B3=1, B2b=2, B1C=3, B2a=4 — obsdef order */
     CHECK(idx(SYS_CMP, "2I") == 0, "BDS B1I -> 0");


### PR DESCRIPTION
Part 4/5 of the #225 sync series — stacked on the part-3 PR.

Seven commits aligning the CLAS PPP-RTK measurement model with claslib:
- claslib PPP-RTK observation slot layout (GPS {L1,L2,L5} / GAL {E1,-,E5a,E6,E5b,E5ab} / QZS {L1,L2,L5,L6}) applied for CLAS only, + `pos1-frequency=l1+l2+l5` alias
- OSR ambiguity index for est-adaptive iono + facility-change filreset guard + upstream SIS boundary rule
- **receiver PCV slot mapping + claslib-compatible ANTEX compaction** — root cause of a recurring ~0.10 m Galileo E5a antenna error that cascaded into ambiguity resets (E34 case in the #225 ledger)
- QZSS L1 priority C>S>L>X>Z as a **CLAS-scoped runtime override**: claslib and MADOCALIB genuinely disagree on this order, and changing the global table moved MADOCA-PPP solutions ~4 cm off their references (caught by madocalib_ppp_check during series validation), so it is enabled only from `mrtk post` while correction=CLAS
- residual wavelength ratio parity; CPC freq-major persistence across zdres passes

Validation: full suite green at series tip (only the two known OpenBLAS env failures, identical on clean develop); madocalib references unaffected; storm-day reproduction byte-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)