### PR TITLE
fix(spp): CLAS seed SPP sync with claslib (GAL IFLC slot, residual exclusion)

### DIFF
--- a/include/mrtklib/mrtk_opt.h
+++ b/include/mrtklib/mrtk_opt.h
@@ -316,6 +316,10 @@ typedef struct prcopt_t {         /* processing options type */
      * SEEDENH_BASE (C/N0 + TDCP): a net win on kinematic data and inert on the
      * static regression suite. Set SEEDENH_OFF to restore prior seed behaviour. */
     int enhanced_spp_seed; /* a-priori SPP seed profile (SEEDENH_???) */
+
+    /* SPP large-residual exclusion (upstream CLAS sync, appended for ABI stability) */
+    double rejethres; /* pseudorange residual rejection threshold (m, <0:off, 0:CLAS seed auto) */
+    int rejeminsat;   /* minimum valid satellites before residual rejection */
 } prcopt_t;
 
 /* enhanced_spp_seed profiles (applied to the PPP-RTK/VRS a-priori SPP seed only).

--- a/include/mrtklib/mrtk_opt.h
+++ b/include/mrtklib/mrtk_opt.h
@@ -319,7 +319,7 @@ typedef struct prcopt_t {         /* processing options type */
 
     /* SPP large-residual exclusion (upstream CLAS sync, appended for ABI stability) */
     double rejethres; /* pseudorange residual rejection threshold (m, <0:off, 0:CLAS seed auto) */
-    int rejeminsat;   /* minimum valid satellites before residual rejection */
+    int rejeminsat;   /* SPP residual rejection runs only when valid sats exceed this (nv > rejeminsat, as upstream) */
 } prcopt_t;
 
 /* enhanced_spp_seed profiles (applied to the PPP-RTK/VRS a-priori SPP seed only).

--- a/src/clas/mrtk_clas_osr.c
+++ b/src/clas/mrtk_clas_osr.c
@@ -896,8 +896,7 @@ int clas_osr_satcorr_update(gtime_t time, gtime_t teph, int sat, const prcopt_t*
               tow, sc->prevtow, orb_tow, sat, sc->previode, sc->prevsis, -dclk, orbit);
     }
 
-    if (sc->prevtow != -1 && timediff(ssr->t0[0], ssr->t0[1]) == 0.0 &&
-        sc->currtow != time2gpst(ssr->t0[1], NULL)) {
+    if (sc->prevtow != -1 && timediff(ssr->t0[0], ssr->t0[1]) == 0.0 && sc->currtow != time2gpst(ssr->t0[1], NULL)) {
         if (time2gpst(ssr->t0[1], NULL) < sc->prevtow &&
             (time2gpst(ssr->t0[1], NULL) + 3600 * 24 * 7) - sc->prevtow != 5.0) {
             sc->prev_orb_tow = orb_tow;
@@ -1013,8 +1012,8 @@ static void clas_osr_adjust_r_dts(double* retr, double* retdts, gtime_t teph, in
     }
 
     if (!ephpos(dts_time, teph, sat, nav, sc->previode, rs, dts, &var, &svh0)) {
-        trace(NULL, 2, "adjust_r_dts: old ephemeris unavailable tow=%.1f sat=%d iode=%d\n", time2gpst(teph, NULL),
-              sat, sc->previode);
+        trace(NULL, 2, "adjust_r_dts: old ephemeris unavailable tow=%.1f sat=%d iode=%d\n", time2gpst(teph, NULL), sat,
+              sc->previode);
         return;
     }
     if (!normv3(rs + 3, ea)) {
@@ -1276,97 +1275,96 @@ int clas_osr_zdres(const obsd_t* obs, int n, const double* rs, const double* dts
         tmp_r = -1.0;
         tmp_dts = 0.0;
 
-            for (j = 0; j < nf; j++) {
-                f = j;
+        for (j = 0; j < nf; j++) {
+            f = j;
 
-                fi = (lam[0] > 0.0) ? lam[f] / lam[0] : 0.0;
+            fi = (lam[0] > 0.0) ? lam[f] / lam[0] : 0.0;
 
-                if (osr[i].pbias[j] == CLAS_CSSRINVALID || osr[i].cbias[j] == CLAS_CSSRINVALID) {
-                    /* ENA_PPP_RTK path: skip invalid biases */
-                    continue;
-                }
-
-                /* pseudorange correction */
-                osr[i].PRC[j] = osr[i].trop + osr[i].relatv + osr[i].antr[f] + fi * fi * FREQ2 / FREQ1 * osr[i].iono +
-                                osr[i].cbias[j];
-
-                /* carrier-phase correction */
-                osr[i].CPC[j] = osr[i].trop + osr[i].relatv + osr[i].antr[f] - fi * fi * FREQ2 / FREQ1 * osr[i].iono +
-                                osr[i].pbias[j] + osr[i].wupL[f] + osr[i].compL[j];
-
-                /* SIS/IODE adjustment */
-                iodeflag = 0;
-                if (!opt->posopt[9]) {
-                    osr[i].CPC[j] = clas_osr_adjust_cpc(obs_copy[i].time, sat, &nav->ssr_ch[ch][sat - 1], f,
-                                                        osr[i].CPC[j], &osr[i].sis, &iodeflag, ch, osr_ctx);
-                    osr[i].PRC[j] = clas_osr_adjust_prc(obs_copy[i].time, sat, &nav->ssr_ch[ch][sat - 1], f,
-                                                        osr[i].PRC[j], &osr[i].sis, &iodeflag, ch, osr_ctx);
-                }
-
-                /* compute model values, adjusting r/dts on IODE change */
-                if (iodeflag) {
-                    if (tmp_r < 0.0) {
-                        gtime_t dtsat = timeadd(obs_copy[i].time, -obs_copy[i].P[0] / CLIGHT);
-                        tmp_r = r;
-                        tmp_dts = dts[i * 2];
-                        clas_osr_adjust_r_dts(&tmp_r, &tmp_dts, obs_copy[i].time, sat, nav, rr, dtsat, ch, osr_ctx);
-                    }
-                    modl[j] = tmp_r - CLIGHT * tmp_dts + osr[i].CPC[j];
-                    modl[nftmp + j] = tmp_r - CLIGHT * tmp_dts + osr[i].PRC[j];
-                    osr[i].CPC[j] += tmp_r - CLIGHT * tmp_dts - (r - CLIGHT * dts[i * 2]);
-                    osr[i].PRC[j] += tmp_r - CLIGHT * tmp_dts - (r - CLIGHT * dts[i * 2]);
-                } else {
-                    modl[j] = r - CLIGHT * dts[i * 2] + osr[i].CPC[j];
-                    modl[nftmp + j] = r - CLIGHT * dts[i * 2] + osr[i].PRC[j];
-                }
-
-                osr[i].p[j] = modl[nftmp + j];
-                osr[i].c[j] = modl[j];
-
-                /* repair cycle slip of pbias */
-                tow = time2gpst(obs_copy[i].time, NULL);
-                /* getorbitclock from satcorr state */
-                if (tow == osr_ctx->satcorr[ch][sat - 1].tow) {
-                    osr[i].orb = osr_ctx->satcorr[ch][sat - 1].orb;
-                    osr[i].clk = osr_ctx->satcorr[ch][sat - 1].clk;
-                } else {
-                    osr[i].orb = 0.0;
-                    osr[i].clk = 0.0;
-                }
-
-                /* cycle slip detection on phase bias update */
-                if (!nav->filreset &&
-                    fabs(timediff(nav->ssr_ch[ch][sat - 1].t0[5], osr_ctx->pt0tmp[sat - 1])) > 0.0 &&
-                    fabs(timediff(nav->ssr_ch[ch][sat - 1].t0[5], osr_ctx->pt0tmp[sat - 1])) < 120.0) {
-                    dcpc = osr[i].orb - osr[i].clk + osr[i].CPC[j] - osr_ctx->cpctmp[j * MAXSAT + sat - 1];
-                    if (dcpc >= 95.0 * lam[f] && dcpc < 105.0 * lam[f]) {
-                        osr_ctx->pbias_ofst[j * MAXSAT + sat - 1] -= 100.0;
-                        /* PPP-RTK (y != NULL): correct the ambiguity filter state.
-                         * VRS/OSR (y == NULL): rtk->x has no ambiguity slots, so
-                         * the offset is instead applied to the emitted carrier
-                         * phase in clas_ssr2osr() — see upstream cssr2osr.c L342. */
-                        if (y) {
-                            x[IB_RTK(sat, f, opt)] -= 100.0;
-                        }
-                        trace(NULL, 2,
-                              "pbias slip detected t=%s sat=%2d f=%1d "
-                              "dcpc[cycle]=%.1f\n",
-                              time_str(obs_copy[i].time, 0), sat, f, lam[f] > 0.0 ? dcpc / lam[f] : 0.0);
-                    } else if (dcpc <= -95.0 * lam[f] && dcpc > -105.0 * lam[f]) {
-                        osr_ctx->pbias_ofst[j * MAXSAT + sat - 1] += 100.0;
-                        if (y) {
-                            x[IB_RTK(sat, f, opt)] += 100.0;
-                        }
-                        trace(NULL, 2,
-                              "pbias slip detected t=%s sat=%2d f=%1d "
-                              "dcpc[cycle]=%.1f\n",
-                              time_str(obs_copy[i].time, 0), sat, f, lam[f] > 0.0 ? dcpc / lam[f] : 0.0);
-                    }
-                } else {
-                    osr_ctx->pbias_ofst[j * MAXSAT + sat - 1] = 0.0;
-                }
-                osr_ctx->cpctmp[j * MAXSAT + sat - 1] = osr[i].orb - osr[i].clk + osr[i].CPC[j];
+            if (osr[i].pbias[j] == CLAS_CSSRINVALID || osr[i].cbias[j] == CLAS_CSSRINVALID) {
+                /* ENA_PPP_RTK path: skip invalid biases */
+                continue;
             }
+
+            /* pseudorange correction */
+            osr[i].PRC[j] =
+                osr[i].trop + osr[i].relatv + osr[i].antr[f] + fi * fi * FREQ2 / FREQ1 * osr[i].iono + osr[i].cbias[j];
+
+            /* carrier-phase correction */
+            osr[i].CPC[j] = osr[i].trop + osr[i].relatv + osr[i].antr[f] - fi * fi * FREQ2 / FREQ1 * osr[i].iono +
+                            osr[i].pbias[j] + osr[i].wupL[f] + osr[i].compL[j];
+
+            /* SIS/IODE adjustment */
+            iodeflag = 0;
+            if (!opt->posopt[9]) {
+                osr[i].CPC[j] = clas_osr_adjust_cpc(obs_copy[i].time, sat, &nav->ssr_ch[ch][sat - 1], f, osr[i].CPC[j],
+                                                    &osr[i].sis, &iodeflag, ch, osr_ctx);
+                osr[i].PRC[j] = clas_osr_adjust_prc(obs_copy[i].time, sat, &nav->ssr_ch[ch][sat - 1], f, osr[i].PRC[j],
+                                                    &osr[i].sis, &iodeflag, ch, osr_ctx);
+            }
+
+            /* compute model values, adjusting r/dts on IODE change */
+            if (iodeflag) {
+                if (tmp_r < 0.0) {
+                    gtime_t dtsat = timeadd(obs_copy[i].time, -obs_copy[i].P[0] / CLIGHT);
+                    tmp_r = r;
+                    tmp_dts = dts[i * 2];
+                    clas_osr_adjust_r_dts(&tmp_r, &tmp_dts, obs_copy[i].time, sat, nav, rr, dtsat, ch, osr_ctx);
+                }
+                modl[j] = tmp_r - CLIGHT * tmp_dts + osr[i].CPC[j];
+                modl[nftmp + j] = tmp_r - CLIGHT * tmp_dts + osr[i].PRC[j];
+                osr[i].CPC[j] += tmp_r - CLIGHT * tmp_dts - (r - CLIGHT * dts[i * 2]);
+                osr[i].PRC[j] += tmp_r - CLIGHT * tmp_dts - (r - CLIGHT * dts[i * 2]);
+            } else {
+                modl[j] = r - CLIGHT * dts[i * 2] + osr[i].CPC[j];
+                modl[nftmp + j] = r - CLIGHT * dts[i * 2] + osr[i].PRC[j];
+            }
+
+            osr[i].p[j] = modl[nftmp + j];
+            osr[i].c[j] = modl[j];
+
+            /* repair cycle slip of pbias */
+            tow = time2gpst(obs_copy[i].time, NULL);
+            /* getorbitclock from satcorr state */
+            if (tow == osr_ctx->satcorr[ch][sat - 1].tow) {
+                osr[i].orb = osr_ctx->satcorr[ch][sat - 1].orb;
+                osr[i].clk = osr_ctx->satcorr[ch][sat - 1].clk;
+            } else {
+                osr[i].orb = 0.0;
+                osr[i].clk = 0.0;
+            }
+
+            /* cycle slip detection on phase bias update */
+            if (!nav->filreset && fabs(timediff(nav->ssr_ch[ch][sat - 1].t0[5], osr_ctx->pt0tmp[sat - 1])) > 0.0 &&
+                fabs(timediff(nav->ssr_ch[ch][sat - 1].t0[5], osr_ctx->pt0tmp[sat - 1])) < 120.0) {
+                dcpc = osr[i].orb - osr[i].clk + osr[i].CPC[j] - osr_ctx->cpctmp[j * MAXSAT + sat - 1];
+                if (dcpc >= 95.0 * lam[f] && dcpc < 105.0 * lam[f]) {
+                    osr_ctx->pbias_ofst[j * MAXSAT + sat - 1] -= 100.0;
+                    /* PPP-RTK (y != NULL): correct the ambiguity filter state.
+                     * VRS/OSR (y == NULL): rtk->x has no ambiguity slots, so
+                     * the offset is instead applied to the emitted carrier
+                     * phase in clas_ssr2osr() — see upstream cssr2osr.c L342. */
+                    if (y) {
+                        x[IB_RTK(sat, f, opt)] -= 100.0;
+                    }
+                    trace(NULL, 2,
+                          "pbias slip detected t=%s sat=%2d f=%1d "
+                          "dcpc[cycle]=%.1f\n",
+                          time_str(obs_copy[i].time, 0), sat, f, lam[f] > 0.0 ? dcpc / lam[f] : 0.0);
+                } else if (dcpc <= -95.0 * lam[f] && dcpc > -105.0 * lam[f]) {
+                    osr_ctx->pbias_ofst[j * MAXSAT + sat - 1] += 100.0;
+                    if (y) {
+                        x[IB_RTK(sat, f, opt)] += 100.0;
+                    }
+                    trace(NULL, 2,
+                          "pbias slip detected t=%s sat=%2d f=%1d "
+                          "dcpc[cycle]=%.1f\n",
+                          time_str(obs_copy[i].time, 0), sat, f, lam[f] > 0.0 ? dcpc / lam[f] : 0.0);
+                }
+            } else {
+                osr_ctx->pbias_ofst[j * MAXSAT + sat - 1] = 0.0;
+            }
+            osr_ctx->cpctmp[j * MAXSAT + sat - 1] = osr[i].orb - osr[i].clk + osr[i].CPC[j];
+        }
 
         /* ISB correction */
         if (opt->isb == ISBOPT_TABLE) {

--- a/src/core/mrtk_toml.c
+++ b/src/core/mrtk_toml.c
@@ -127,6 +127,8 @@ static const toml_map_t toml_mapping[] = {
     {"rejection", "non_dispersive", "pos2-rejionno3"},
     {"rejection", "hold_chi_square", "pos2-rejionno4"},
     {"rejection", "fix_chi_square", "pos2-rejionno5"},
+    {"rejection", "spp_residual", "pos2-rejethres"},
+    {"rejection", "spp_min_sats", "pos2-rejeminsat"},
     {"rejection", "gdop", "pos2-rejgdop"},
     {"rejection", "pseudorange_diff", "pos2-rejdiffpse"},
     {"rejection", "position_error_count", "pos2-poserrcnt"},

--- a/src/pos/mrtk_opt.c
+++ b/src/pos/mrtk_opt.c
@@ -86,6 +86,8 @@ const prcopt_t prcopt_default = {
     0, /* pppsatcb,pppsatpb,unbias,maxbiasdt */
     .correction = CORR_AUTO,
     .enhanced_spp_seed = SEEDENH_BASE, /* default on: C/N0 + TDCP a-priori seed (PPP-RTK/VRS) */
+    .rejethres = 0.0,                  /* standalone SPP off; CLAS seed applies upstream auto-default */
+    .rejeminsat = 7,
 };
 const solopt_t solopt_default = {
     /* defaults solution output options */

--- a/src/pos/mrtk_options.c
+++ b/src/pos/mrtk_options.c
@@ -147,6 +147,8 @@ opt_t sysopts[] = {
     {"pos2-syncsol", 3, (void*)&prcopt_.syncsol, SWTOPT},
     {"pos2-slipthres", 1, (void*)&prcopt_.thresslip, "m"},
     {"pos2-thresdop", 1, (void*)&prcopt_.thresdop, "cyc/s"},
+    {"pos2-rejethres", 1, (void*)&prcopt_.rejethres, "m"},
+    {"pos2-rejeminsat", 0, (void*)&prcopt_.rejeminsat, ""},
     {"pos2-rejionno", 1, (void*)&prcopt_.maxinno, "m"},
     {"pos2-rejgdop", 1, (void*)&prcopt_.maxgdop, ""},
     {"pos2-niter", 0, (void*)&prcopt_.niter, ""},

--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -2084,8 +2084,7 @@ static int resamb_LAMBDA(rtk_t* rtk, double* bias, double* xa) {
                 matmul("NN", na, nb, nb, 1.0, Qab, Qb, 0.0, QQ);
                 matmul("NT", na, na, nb, -1.0, QQ, Qab, 1.0, rtk->Pa);
 
-                trace(NULL, 3, "resamb : validation ok (nb=%d ratio=%.2f s=%.2f/%.2f)\n", nb,
-                      ratio, s[1], s[0]);
+                trace(NULL, 3, "resamb : validation ok (nb=%d ratio=%.2f s=%.2f/%.2f)\n", nb, ratio, s[1], s[0]);
 
                 /* restore SD ambiguities */
                 restamb(rtk, bias, nb, xa);
@@ -2434,8 +2433,7 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
 
     matcpy(xp, rtk->x, rtk->nx, 1);
 
-    if ((rtk->opt.ionoopt == IONOOPT_EST_ADPT || rtk->opt.prnadpt) && prtk_ctx.Qp &&
-        prtk_ctx.Qp_nx == rtk->nx) {
+    if ((rtk->opt.ionoopt == IONOOPT_EST_ADPT || rtk->opt.prnadpt) && prtk_ctx.Qp && prtk_ctx.Qp_nx == rtk->nx) {
         for (i = 0; i < rtk->nx * rtk->nx; i++) {
             prtk_ctx.Qp[i] = 0.0;
         }

--- a/src/pos/mrtk_rtkpos.c
+++ b/src/pos/mrtk_rtkpos.c
@@ -2717,6 +2717,16 @@ extern int rtkpos(mrtk_ctx_t* ctx, rtk_t* rtk, const obsd_t* obs, int n, nav_t* 
         /* PPP-RTK/VRS: force broadcast ephemeris for SPP initial position */
         if (sppopt.mode == PMODE_PPP_RTK || sppopt.mode == PMODE_VRS_RTK) {
             sppopt.sateph = EPHOPT_BRDC;
+            /* Upstream CLAS applies SPP pseudorange large-residual exclusion with
+             * defaults of 20 m and 7 satellites. Keep standalone SPP bit-compatible
+             * by applying the auto-default only to this private CLAS seed copy.
+             * Set pos2-rejethres < 0 to force it off for CLAS diagnostics. */
+            if (sppopt.rejethres == 0.0) {
+                sppopt.rejethres = 20.0;
+            }
+            if (sppopt.rejeminsat <= 0) {
+                sppopt.rejeminsat = 7;
+            }
             /* Enhanced seed (default SEEDENH_BASE = cn0+tdcp; set OFF to disable):
              * apply the proven v0.6.10 SPP error model to this PRIVATE copy only.
              * err[5]/err[6] are the C/N0 snr_max/snr_error coefficients here (varerr

--- a/src/pos/mrtk_spp.c
+++ b/src/pos/mrtk_spp.c
@@ -123,14 +123,18 @@ static double gettgd(int sat, const nav_t* nav, int type) {
     }
 }
 /* index of the 2nd frequency for the iono-free combination -------------------
- * Upstream CLAS SPP uses L1-L5 for GAL/SBS and L1-L2 otherwise. Preserve the
- * #135 IGS-product fallback for receivers whose conventional slot 1 is absent.
+ * Upstream claslib SPP uses L1-L5 for GAL/SBS and L1-L2 otherwise; apply that
+ * choice only while CLAS processing is active (the upstream profiles disagree
+ * here, and GAL/SBS rows without an E5a/L5 observation would otherwise drop
+ * out of non-CLAS SPP). Preserve the #135 IGS-product fallback for receivers
+ * whose conventional slot 1 is absent.
  * nav may be NULL to skip the carrier-frequency validity check (e.g. for SNR
  * masking, which only needs the observation slot). */
 static int iflc_freq2_idx(const obsd_t* obs, const nav_t* nav, const prcopt_t* opt) {
     int sys = satsys(obs->sat, NULL);
     int j;
-    if (opt->ionoopt == IONOOPT_IFLC && opt->correction != CORR_IGS && NFREQ >= 3 && (sys & (SYS_GAL | SYS_SBS))) {
+    if (opt->ionoopt == IONOOPT_IFLC && opt->correction == CORR_QZS_CLAS && NFREQ >= 3 &&
+        (sys & (SYS_GAL | SYS_SBS))) {
         return 2;
     }
     if (opt->ionoopt == IONOOPT_IFLC && opt->correction == CORR_IGS && obs->P[1] == 0.0) {
@@ -444,7 +448,7 @@ static void exclsat(const obsd_t* obs, const double* resp, const prcopt_t* opt, 
             continue;
         }
         outp[sat - 1] = 1;
-        trace(NULL, 2, "pntpos : excluded obs due to large residuals :sat=%2d res=%.2f avg=%f\n", sat, resp[i],
+        trace(NULL, 2, "pntpos : excluded obs due to large residuals :sat=%2d res=%.2f rms=%.2f\n", sat, resp[i],
               sqrt(v2 / j));
     }
 }

--- a/src/pos/mrtk_spp.c
+++ b/src/pos/mrtk_spp.c
@@ -252,7 +252,7 @@ static double prange(const obsd_t* obs, const nav_t* nav, const prcopt_t* opt, d
 /* pseudorange residuals -----------------------------------------------------*/
 static int rescode(int iter, const obsd_t* obs, int n, const double* rs, const double* dts, const double* vare,
                    const int* svh, const nav_t* nav, const double* x, const prcopt_t* opt, double* v, double* H,
-                   double* var, double* azel, int* vsat, double* resp, int* ns) {
+                   double* var, double* azel, int* vsat, double* resp, int* ns, const int* outp) {
     gtime_t time;
     double r, freq, dion = 0.0, dtrp = 0.0, vmeas, vion = 0.0, vtrp = 0.0, rr[3], pos[3], dtr;
     double e[3], P, fact_ion;
@@ -283,6 +283,9 @@ static int rescode(int iter, const obsd_t* obs, int n, const double* rs, const d
             continue;
         }
         /* excluded satellite? */
+        if (sat >= 1 && sat <= MAXSAT && outp && outp[sat - 1]) {
+            continue;
+        }
         if (satexclude(sat, vare[i], svh[i], opt)) {
             continue;
         }
@@ -420,6 +423,31 @@ static int valsol(const double* azel, const int* vsat, int n, const prcopt_t* op
     }
     return 1;
 }
+/* exclude satellites with large SPP pseudorange residuals ---------------------*/
+static void exclsat(const obsd_t* obs, const double* resp, const prcopt_t* opt, int n, const int* vsat, int* outp) {
+    double v2 = 0.0, thres = opt->rejethres * opt->rejethres;
+    int i, j;
+
+    for (i = j = 0; i < n && i < MAXOBS; i++) {
+        if (!vsat[i]) {
+            continue;
+        }
+        v2 += resp[i] * resp[i];
+        j++;
+    }
+    if (j == 0 || v2 / j > thres) {
+        return;
+    }
+    for (i = 0; i < n && i < MAXOBS; i++) {
+        int sat = obs[i].sat;
+        if (!vsat[i] || sat < 1 || sat > MAXSAT || resp[i] * resp[i] <= thres) {
+            continue;
+        }
+        outp[sat - 1] = 1;
+        trace(NULL, 2, "pntpos : excluded obs due to large residuals :sat=%2d res=%.2f avg=%f\n", sat, resp[i],
+              sqrt(v2 / j));
+    }
+}
 /* IGG-III three-segment equivalent-weight factor (#116 P2) ------------------
  * rt = standardized residual; returns a multiplicative weight in [0,1].
  * |rt|<=k0: full weight; k0<|rt|<=k1: smooth down-weight; |rt|>k1: reject. */
@@ -455,7 +483,8 @@ static double median_abs(const double* x, int n, double* work) {
 static int estpos(const obsd_t* obs, int n, const double* rs, const double* dts, const double* vare, const int* svh,
                   const nav_t* nav, const prcopt_t* opt, sol_t* sol, double* azel, int* vsat, double* resp, char* msg) {
     double x[NX] = {0}, dx[NX], Q[NX * NX], *v, *H, *var, *vpre, sig;
-    int i, j, k, info, stat = 1, nv, ns;
+    int i, j, k, info, stat = 1, nv = 0, ns;
+    int outp[MAXSAT] = {0};
 
     trace(NULL, 3, "estpos  : n=%d\n", n);
 
@@ -469,8 +498,11 @@ static int estpos(const obsd_t* obs, int n, const double* rs, const double* dts,
     }
 
     for (i = 0; i < MAXITR; i++) {
+        if (i > 0 && nv > opt->rejeminsat && opt->rejethres > 0.0) {
+            exclsat(obs, resp, opt, n, vsat, outp);
+        }
         /* pseudorange residuals (m) */
-        nv = rescode(i, obs, n, rs, dts, vare, svh, nav, x, opt, v, H, var, azel, vsat, resp, &ns);
+        nv = rescode(i, obs, n, rs, dts, vare, svh, nav, x, opt, v, H, var, azel, vsat, resp, &ns, outp);
 
         if (nv < NX) {
             sprintf(msg, "lack of valid sats ns=%d", nv);

--- a/src/pos/mrtk_spp.c
+++ b/src/pos/mrtk_spp.c
@@ -133,8 +133,7 @@ static double gettgd(int sat, const nav_t* nav, int type) {
 static int iflc_freq2_idx(const obsd_t* obs, const nav_t* nav, const prcopt_t* opt) {
     int sys = satsys(obs->sat, NULL);
     int j;
-    if (opt->ionoopt == IONOOPT_IFLC && opt->correction == CORR_QZS_CLAS && NFREQ >= 3 &&
-        (sys & (SYS_GAL | SYS_SBS))) {
+    if (opt->ionoopt == IONOOPT_IFLC && opt->correction == CORR_QZS_CLAS && NFREQ >= 3 && (sys & (SYS_GAL | SYS_SBS))) {
         return 2;
     }
     if (opt->ionoopt == IONOOPT_IFLC && opt->correction == CORR_IGS && obs->P[1] == 0.0) {

--- a/src/pos/mrtk_spp.c
+++ b/src/pos/mrtk_spp.c
@@ -123,13 +123,16 @@ static double gettgd(int sat, const nav_t* nav, int type) {
     }
 }
 /* index of the 2nd frequency for the iono-free combination -------------------
- * #135: for IGS-product PPP, when the conventional slot 1 carries no observation
- * (F9P-class GAL E5b / BDS B2I, with E5a/B3I absent), fall back to the first
- * populated higher slot. Returns 1 otherwise, so existing dual-frequency data is
- * unaffected. nav may be NULL to skip the carrier-frequency validity check
- * (e.g. for SNR masking, which only needs the observation slot). */
+ * Upstream CLAS SPP uses L1-L5 for GAL/SBS and L1-L2 otherwise. Preserve the
+ * #135 IGS-product fallback for receivers whose conventional slot 1 is absent.
+ * nav may be NULL to skip the carrier-frequency validity check (e.g. for SNR
+ * masking, which only needs the observation slot). */
 static int iflc_freq2_idx(const obsd_t* obs, const nav_t* nav, const prcopt_t* opt) {
+    int sys = satsys(obs->sat, NULL);
     int j;
+    if (opt->ionoopt == IONOOPT_IFLC && opt->correction != CORR_IGS && NFREQ >= 3 && (sys & (SYS_GAL | SYS_SBS))) {
+        return 2;
+    }
     if (opt->ionoopt == IONOOPT_IFLC && opt->correction == CORR_IGS && obs->P[1] == 0.0) {
         for (j = 2; j < NFREQ; j++) {
             if (obs->P[j] != 0.0 && (!nav || sat2freq(obs->sat, obs->code[j], nav) != 0.0)) {


### PR DESCRIPTION
Part 5/5 of the #225 sync series — stacked on the part-4 PR.

- GAL/SBS iono-free second frequency from slot 2 (E5a), restoring Galileo rows to the CLAS SPP velocity seed like upstream
- port of upstream's SPP large-residual exclusion (`pos2-rejethres` / `pos2-rejeminsat`); default 0 keeps standalone SPP bit-compatible, the CLAS PPP-RTK/VRS private seed copy maps 0 to upstream's 20 m / 7 sats

Validation: full suite green at this tip (series-final state; storm-day byte-verified 93.54 % fix vs upstream claslib 92.88 %, see the #225 closure comment for the full matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)