### PR TITLE
docs(config): sync config reference with loader + add drift-check CI gate

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -69,3 +69,30 @@ jobs:
       - name: ruff format (Python)
         if: ${{ !cancelled() }}
         run: ruff format --check .
+
+  # Guards against the config reference drifting from its generator. The loader's
+  # option table (src/core/mrtk_toml.c) and the generator sources
+  # (scripts/tools/conf2toml.py MAPPING + scripts/docs/gen_config_ref.py) must be
+  # kept in sync so every TOML key the loader accepts is documented. This job
+  # fails when the committed docs/reference/config-options.md no longer matches a
+  # fresh generator run — regenerate and commit the result to fix it.
+  config-ref:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Regenerate config reference
+        run: python scripts/docs/gen_config_ref.py > docs/reference/config-options.md
+
+      - name: Fail if the committed reference is stale
+        run: |
+          if ! git diff --exit-code -- docs/reference/config-options.md; then
+            echo "::error::docs/reference/config-options.md is out of date."
+            echo "Run: python scripts/docs/gen_config_ref.py > docs/reference/config-options.md"
+            exit 1
+          fi

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -35,9 +35,14 @@ TOML section: `[positioning]`
 | `elevation_mask` | float | All | Minimum satellite elevation angle (degrees). Satellites below this are excluded. |
 | `dynamics` | boolean | All | Enable receiver dynamics model (velocity/acceleration state estimation). |
 | `satellite_ephemeris` | enum | All | Satellite ephemeris source. SSR modes (`brdc+ssrapc`, `brdc+ssrcom`) are used for PPP and PPP-RTK. `brdc` · `precise` · `brdc+sbas` · `brdc+ssrapc` · `brdc+ssrcom` |
-| `systems` | string[] | All | GNSS constellations to use. Accepts a human-readable string list like `["GPS", "Galileo"]`. |
+| `systems` | string[] | All | GNSS constellations to use. Accepts a human-readable string list like `["GPS", "Galileo"]`. The low-level `constellations` key (integer/string bitmask, legacy `pos1-navsys` form) is also accepted for backward compatibility; `systems` supersedes it when both are present. |
 | `excluded_sats` | string | All | Satellites to exclude. Space-separated PRN list (e.g., `G01 G02`). Prefix `+` to include only. |
 | `signals` | string[] | All | Explicit RINEX3-style signal code list (`{sys}{freq}{attr}`, e.g. `["G1C", "G2W", "R1C", "R2C", "E1C", "E7Q", "J1C", "J2L"]`). When set it is the **authoritative** signal selection: it overrides `frequency` / the `[signals]` presets, derives the number of frequencies, **and** selects which observation code occupies each band's slot during real-time raw decoding (so e.g. GLONASS L2C/A can be used as the iono-free 2nd frequency without the legacy `-RL2C` receiver option — see [#189](https://github.com/h-shiono/MRTKLIB/issues/189)). List **every** band you want, for every constellation you want to constrain — `signals = ["R2C"]` alone derives nf=1 (single-frequency). A constellation you omit entirely keeps its default signal selection. |
+| `robust` | enum | SPP | Robust estimation strategy for single-point positioning (down-weights outliers via M-estimation). `off` · `igg3` |
+| `robust_k0` | float | SPP | IGG-III robust weighting lower threshold k0 (standardized residual). Residuals below k0 keep full weight. |
+| `robust_k1` | float | SPP | IGG-III robust weighting upper threshold k1 (standardized residual). Residuals above k1 are rejected; between k0 and k1 the weight is tapered. |
+| `tdcp` | enum | SPP | Time-differenced carrier phase (TDCP) velocity estimation and carrier-phase-based cycle-slip / jump QC. `off` · `on` |
+| `tdcp_jump` | float | SPP | TDCP position-jump rejection threshold (m). Epoch-to-epoch jumps exceeding this are rejected as outliers. |
 
 > **Recommended surface.** `[positioning].signals` is the preferred way to select signals. The `[signals]` section (`gps`/`qzs`/`galileo`/`bds2`/`bds3` presets) and `frequency` are the older, coarser mechanism (no per-code control, and **no GLONASS entry**, which is why GLONASS L2 code selection requires `signals`). When `signals` is set it takes precedence.
 
@@ -70,6 +75,7 @@ TOML section: `[positioning.clas]`
 |:---------|:-----|:------|:------------|
 | `grid_selection_radius` | integer | PPP-RTK, VRS | CLAS grid search radius (m). Controls how far from the rover to search for grid-based tropospheric/ionospheric corrections. |
 | `receiver_type` | string | PPP-RTK, VRS | Rover receiver type identifier. Used for ISB (inter-system bias) table lookup. |
+| `enhanced_spp_seed` | enum | PPP-RTK | Enhanced SPP seed for CLAS PPP-RTK reconvergence. Selects the code / Doppler QC stack used to seed the float filter after outages (opt-in; the default base seed uses C/N0 + TDCP). `off` · `cn0+tdcp` · `cn0+tdcp+robust` |
 | `position_uncertainty_x` | float | PPP-RTK, VRS | Rover approximate position X in ECEF (m). Used for initial CLAS grid search before first fix. |
 | `position_uncertainty_y` | float | PPP-RTK, VRS | Rover approximate position Y in ECEF (m). |
 | `position_uncertainty_z` | float | PPP-RTK, VRS | Rover approximate position Z in ECEF (m). |
@@ -145,6 +151,9 @@ TOML section: `[ambiguity_resolution.thresholds]`
 | `alpha` | enum | PPP-RTK, VRS | AR significance level (ILS success rate). `0.1%` · `0.5%` · `1%` · `5%` · `10%` · `20%` |
 | `elevation_mask` | float | RTK, PPP-RTK, VRS | Minimum satellite elevation for AR participation (degrees). |
 | `hold_elevation` | float | RTK, PPP-RTK, VRS | Minimum satellite elevation for fix-and-hold constraint application (degrees). |
+| `max_pdop_ar` | float | RTK, PPP-RTK | Maximum PDOP for attempting ambiguity resolution. 0 = no limit. |
+| `max_pdop_hold` | float | RTK, PPP-RTK | Maximum PDOP for applying the fix-and-hold constraint. 0 = no limit. |
+| `reference_dop` | enum | RTK, PPP-RTK | Reference DOP formulation used for AR validation. `zd` · `sd` |
 
 ## Ambiguity Resolution — Counters
 
@@ -191,6 +200,8 @@ TOML section: `[rejection]`
 | `non_dispersive` | float | PPP-RTK, VRS | Non-dispersive (geometric) residual rejection threshold (σ). |
 | `hold_chi_square` | float | PPP-RTK, VRS | Chi-square threshold for hold-mode outlier detection. |
 | `fix_chi_square` | float | PPP-RTK, VRS | Chi-square threshold for fix-mode outlier detection. |
+| `spp_residual` | float | SPP | SPP pseudorange residual rejection threshold (m) used by RAIM FDE. |
+| `spp_min_sats` | integer | SPP | Minimum number of satellites SPP RAIM FDE retains before it stops excluding outliers. |
 | `gdop` | float | All | Maximum GDOP for valid solution output. |
 | `pseudorange_diff` | float | VRS | Pseudorange consistency check threshold (m). Rejects satellites with large code-phase disagreement. |
 | `position_error_count` | integer | VRS | Number of consecutive position error epochs before filter reset. |
@@ -226,6 +237,8 @@ TOML section: `[kalman_filter.measurement_error]`
 | `phase_elevation` | float | All | Elevation-dependent carrier phase error coefficient (m). |
 | `phase_baseline` | float | RTK | Baseline-length-dependent phase error (m/10km). Proportional to rover–base distance. |
 | `doppler` | float | All | Doppler measurement error (Hz). |
+| `snr_max` | float | All | C/N0 at which the SNR-based measurement weighting model saturates (dBHz). Used when C/N0 weighting is enabled. |
+| `snr_error` | float | All | Carrier phase measurement error at the SNR-weighting reference level (m). |
 | `ura_ratio` | float | PPP | User Range Accuracy scaling ratio. Adjusts satellite-specific weighting based on broadcast URA. |
 
 ## Kalman Filter — Initial Std. Deviation
@@ -449,4 +462,18 @@ path = "rover.log"
 | `nmeareq` | boolean | Send NMEA position request to stream |
 | `nmealat` | float | NMEA request latitude (degrees) |
 | `nmealon` | float | NMEA request longitude (degrees) |
+| `nmeahgt` | float | NMEA request height (m) |
+
+## Console (rtkrcv)
+
+TOML section: `[console]` — **Real-time only** (`mrtk run` / `rtkrcv`)
+
+Interactive rtkrcv console (telnet) settings.
+
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `passwd` | string | RT | Console login password. |
+| `timetype` | enum | RT | Console time display. `gpst` · `utc` · `jst` · `tow` |
+| `soltype` | enum | RT | Console solution display format. `dms` · `deg` · `xyz` · `enu` · `pyl` |
+| `solflag` | flag | RT | Console solution status flags (std / age / ratio / ns). |
 

--- a/scripts/docs/gen_config_ref.py
+++ b/scripts/docs/gen_config_ref.py
@@ -45,6 +45,20 @@ from conf2toml import MAPPING, _KEY_ENUM, _ENUM_STRINGS  # noqa: E402
 _OPTION_META: dict[str, tuple[str, str]] = {
     # ── positioning ──────────────────────────────────────────────────────────
     "pos1-posmode": ("All", "Positioning mode selector."),
+    "pos1-correction": (
+        "PPP, PPP-RTK, VRS",
+        "Correction source (lowercase; parsing is case-sensitive). Decouples the augmentation source from `mode`. "
+        "`none` · `igs` (precise SP3/CLK files) · `igs-rts` (real-time RTCM-SSR / IGS-SSR MT4076; float PPP) · "
+        "`qzs-madoca` · `qzs-clas` · `gal-has`† · `bds-b2b`† (†reserved/not yet implemented). "
+        "Optional: when omitted it is inferred from `mode` + `satellite_ephemeris` for backward compatibility. "
+        '**`igs-rts` is never inferred and must be set explicitly** (it shares `satellite_ephemeris = "brdc+ssrapc"` '
+        'with `qzs-madoca`); it requires `satellite_ephemeris = "brdc+ssrapc"` or `"brdc+ssrcom"`. '
+        "See [Positioning Configuration Model](../design/configuration.md). "
+        "**Note:** `igs` enables conventional IGS-products float PPP for both geodetic receivers "
+        "(e.g. GPS L1+L2, Galileo E1+E5a) and receivers that provide the 2nd frequency only as Galileo **E5b** / "
+        "BeiDou **B2I** (no E5a/B3I, e.g. u-blox F9P) — the iono-free pair is selected from the available "
+        "observations (fixed in v0.6.7, see [#135](https://github.com/h-shiono/MRTKLIB/issues/135)).",
+    ),
     "pos1-frequency": (
         "All",
         "Number of carrier frequencies to use. CLAS PPP-RTK requires `l1+2` (nf=2).",
@@ -64,7 +78,9 @@ _OPTION_META: dict[str, tuple[str, str]] = {
     ),
     "pos1-navsys": (
         "All",
-        'GNSS constellations to use. Accepts a human-readable string list like `["GPS", "Galileo"]`.',
+        'GNSS constellations to use. Accepts a human-readable string list like `["GPS", "Galileo"]`. '
+        "The low-level `constellations` key (integer/string bitmask, legacy `pos1-navsys` form) is also "
+        "accepted for backward compatibility; `systems` supersedes it when both are present.",
     ),
     "pos1-exclsats": (
         "All",
@@ -72,7 +88,35 @@ _OPTION_META: dict[str, tuple[str, str]] = {
     ),
     "pos1-signals": (
         "All",
-        "Explicit signal code list. Overrides default observation definition when set.",
+        "Explicit RINEX3-style signal code list (`{sys}{freq}{attr}`, e.g. "
+        '`["G1C", "G2W", "R1C", "R2C", "E1C", "E7Q", "J1C", "J2L"]`). When set it is the **authoritative** '
+        "signal selection: it overrides `frequency` / the `[signals]` presets, derives the number of "
+        "frequencies, **and** selects which observation code occupies each band's slot during real-time raw "
+        "decoding (so e.g. GLONASS L2C/A can be used as the iono-free 2nd frequency without the legacy `-RL2C` "
+        "receiver option — see [#189](https://github.com/h-shiono/MRTKLIB/issues/189)). List **every** band you "
+        'want, for every constellation you want to constrain — `signals = ["R2C"]` alone derives nf=1 '
+        "(single-frequency). A constellation you omit entirely keeps its default signal selection.",
+    ),
+    "pos1-robust": (
+        "SPP",
+        "Robust estimation strategy for single-point positioning (down-weights outliers via M-estimation).",
+    ),
+    "pos1-robustk0": (
+        "SPP",
+        "IGG-III robust weighting lower threshold k0 (standardized residual). Residuals below k0 keep full weight.",
+    ),
+    "pos1-robustk1": (
+        "SPP",
+        "IGG-III robust weighting upper threshold k1 (standardized residual). Residuals above k1 are rejected; "
+        "between k0 and k1 the weight is tapered.",
+    ),
+    "pos1-tdcp": (
+        "SPP",
+        "Time-differenced carrier phase (TDCP) velocity estimation and carrier-phase-based cycle-slip / jump QC.",
+    ),
+    "pos1-tdcpjump": (
+        "SPP",
+        "TDCP position-jump rejection threshold (m). Epoch-to-epoch jumps exceeding this are rejected as outliers.",
     ),
     # ── positioning.clas ─────────────────────────────────────────────────────
     "pos1-gridsel": (
@@ -82,6 +126,11 @@ _OPTION_META: dict[str, tuple[str, str]] = {
     "pos1-rectype": (
         "PPP-RTK, VRS",
         "Rover receiver type identifier. Used for ISB (inter-system bias) table lookup.",
+    ),
+    "pos1-seedenh": (
+        "PPP-RTK",
+        "Enhanced SPP seed for CLAS PPP-RTK reconvergence. Selects the code / Doppler QC stack used to seed the "
+        "float filter after outages (opt-in; the default base seed uses C/N0 + TDCP).",
     ),
     "pos1-rux": (
         "PPP-RTK, VRS",
@@ -173,6 +222,18 @@ _OPTION_META: dict[str, tuple[str, str]] = {
         "RTK, PPP-RTK, VRS",
         "Minimum satellite elevation for fix-and-hold constraint application (degrees).",
     ),
+    "pos2-maxpdopar": (
+        "RTK, PPP-RTK",
+        "Maximum PDOP for attempting ambiguity resolution. 0 = no limit.",
+    ),
+    "pos2-maxpdophold": (
+        "RTK, PPP-RTK",
+        "Maximum PDOP for applying the fix-and-hold constraint. 0 = no limit.",
+    ),
+    "pos2-refdop": (
+        "RTK, PPP-RTK",
+        "Reference DOP formulation used for AR validation.",
+    ),
     # ── ambiguity_resolution.counters ────────────────────────────────────────
     "pos2-arlockcnt": (
         "RTK, PPP-RTK, VRS",
@@ -234,6 +295,11 @@ _OPTION_META: dict[str, tuple[str, str]] = {
     ),
     "pos2-rejionno4": ("PPP-RTK, VRS", "Chi-square threshold for hold-mode outlier detection."),
     "pos2-rejionno5": ("PPP-RTK, VRS", "Chi-square threshold for fix-mode outlier detection."),
+    "pos2-rejethres": ("SPP", "SPP pseudorange residual rejection threshold (m) used by RAIM FDE."),
+    "pos2-rejeminsat": (
+        "SPP",
+        "Minimum number of satellites SPP RAIM FDE retains before it stops excluding outliers.",
+    ),
     "pos2-rejgdop": ("All", "Maximum GDOP for valid solution output."),
     "pos2-rejdiffpse": (
         "VRS",
@@ -272,6 +338,14 @@ _OPTION_META: dict[str, tuple[str, str]] = {
         "Baseline-length-dependent phase error (m/10km). Proportional to rover\u2013base distance.",
     ),
     "stats-errdoppler": ("All", "Doppler measurement error (Hz)."),
+    "stats-snrmax": (
+        "All",
+        "C/N0 at which the SNR-based measurement weighting model saturates (dBHz). Used when C/N0 weighting is enabled.",
+    ),
+    "stats-errsnr": (
+        "All",
+        "Carrier phase measurement error at the SNR-weighting reference level (m).",
+    ),
     "stats-uraratio": (
         "PPP",
         "User Range Accuracy scaling ratio. Adjusts satellite-specific weighting based on broadcast URA.",
@@ -595,6 +669,15 @@ def main() -> int:
         lines.append("")
         lines.append(f"TOML section: `[{section}]`")
         lines.append("")
+        if section == "signals":
+            lines.append(
+                "> **Legacy preset form.** These per-constellation presets are the older, coarser "
+                "signal-selection surface (no per-code control, no GLONASS entry). Prefer "
+                "[`[positioning].signals`](#positioning) for new configurations; when `signals` is set it "
+                "overrides this section. GLONASS L2 code selection (e.g. L2C/A vs L2P) can only be expressed "
+                "via `[positioning].signals`."
+            )
+            lines.append("")
         lines.append("| TOML Key | Type | Modes | Description |")
         lines.append("|:---------|:-----|:------|:------------|")
 
@@ -634,6 +717,13 @@ def main() -> int:
 
         # Section-specific supplementary notes
         if section == "positioning":
+            lines.append(
+                "> **Recommended surface.** `[positioning].signals` is the preferred way to select signals. "
+                "The `[signals]` section (`gps`/`qzs`/`galileo`/`bds2`/`bds3` presets) and `frequency` are the "
+                "older, coarser mechanism (no per-code control, and **no GLONASS entry**, which is why GLONASS "
+                "L2 code selection requires `signals`). When `signals` is set it takes precedence."
+            )
+            lines.append("")
             lines.append("### Frequency Index Mapping")
             lines.append("")
             lines.append(
@@ -697,6 +787,28 @@ def main() -> int:
     lines.append("| `nmeareq` | boolean | Send NMEA position request to stream |")
     lines.append("| `nmealat` | float | NMEA request latitude (degrees) |")
     lines.append("| `nmealon` | float | NMEA request longitude (degrees) |")
+    lines.append("| `nmeahgt` | float | NMEA request height (m) |")
+    lines.append("")
+
+    # Console configuration (rtkrcv rcvopts, not in MAPPING)
+    lines.append("## Console (rtkrcv)")
+    lines.append("")
+    lines.append("TOML section: `[console]` — **Real-time only** (`mrtk run` / `rtkrcv`)")
+    lines.append("")
+    lines.append("Interactive rtkrcv console (telnet) settings.")
+    lines.append("")
+    lines.append("| TOML Key | Type | Modes | Description |")
+    lines.append("|:---------|:-----|:------|:------------|")
+    lines.append("| `passwd` | string | RT | Console login password. |")
+    lines.append(
+        "| `timetype` | enum | RT | Console time display. `gpst` · `utc` · `jst` · `tow` |"
+    )
+    lines.append(
+        "| `soltype` | enum | RT | Console solution display format. `dms` · `deg` · `xyz` · `enu` · `pyl` |"
+    )
+    lines.append(
+        "| `solflag` | flag | RT | Console solution status flags (std / age / ratio / ns). |"
+    )
     lines.append("")
 
     print("\n".join(lines))

--- a/scripts/docs/gen_config_ref.py
+++ b/scripts/docs/gen_config_ref.py
@@ -41,7 +41,10 @@ from conf2toml import MAPPING, _KEY_ENUM, _ENUM_STRINGS  # noqa: E402
 
 # {legacy_key: (modes, description)}
 # Description for enum types should NOT include the values — they are appended
-# automatically from _ENUM_STRINGS.
+# automatically from _ENUM_STRINGS (via _KEY_ENUM).
+# Exception: a key deliberately omitted from _KEY_ENUM (e.g. `pos1-correction`,
+# whose values carry inline annotations the plain append cannot express) gets no
+# automatic append, so its description embeds the value list itself.
 _OPTION_META: dict[str, tuple[str, str]] = {
     # ── positioning ──────────────────────────────────────────────────────────
     "pos1-posmode": ("All", "Positioning mode selector."),

--- a/scripts/tools/conf2toml.py
+++ b/scripts/tools/conf2toml.py
@@ -34,6 +34,10 @@ MAPPING: list[tuple[str, str, str, str]] = [
     # (legacy_key, toml_section, toml_key, value_type)
     # ── positioning ──────────────────────────────────────────────────────────
     ("pos1-posmode", "positioning", "mode", "enum"),
+    # correction has an annotated enum value list embedded in its description
+    # (see gen_config_ref.py _OPTION_META); intentionally omitted from _KEY_ENUM
+    # so the generator does not append a second, unannotated value list.
+    ("pos1-correction", "positioning", "correction", "enum"),
     ("pos1-frequency", "positioning", "frequency", "enum"),
     ("pos1-soltype", "positioning", "solution_type", "enum"),
     ("pos1-elmask", "positioning", "elevation_mask", "float"),
@@ -42,8 +46,14 @@ MAPPING: list[tuple[str, str, str, str]] = [
     ("pos1-navsys", "positioning", "systems", "navsys"),
     ("pos1-exclsats", "positioning", "excluded_sats", "str"),
     ("pos1-signals", "positioning", "signals", "siglist"),
+    ("pos1-robust", "positioning", "robust", "enum"),
+    ("pos1-robustk0", "positioning", "robust_k0", "float"),
+    ("pos1-robustk1", "positioning", "robust_k1", "float"),
+    ("pos1-tdcp", "positioning", "tdcp", "enum"),
+    ("pos1-tdcpjump", "positioning", "tdcp_jump", "float"),
     ("pos1-gridsel", "positioning.clas", "grid_selection_radius", "int"),
     ("pos1-rectype", "positioning.clas", "receiver_type", "str"),
+    ("pos1-seedenh", "positioning.clas", "enhanced_spp_seed", "enum"),
     ("pos1-rux", "positioning.clas", "position_uncertainty_x", "float"),
     ("pos1-ruy", "positioning.clas", "position_uncertainty_y", "float"),
     ("pos1-ruz", "positioning.clas", "position_uncertainty_z", "float"),
@@ -89,6 +99,9 @@ MAPPING: list[tuple[str, str, str, str]] = [
     ("pos2-aralpha", "ambiguity_resolution.thresholds", "alpha", "enum"),
     ("pos2-arelmask", "ambiguity_resolution.thresholds", "elevation_mask", "float"),
     ("pos2-elmaskhold", "ambiguity_resolution.thresholds", "hold_elevation", "float"),
+    ("pos2-maxpdopar", "ambiguity_resolution.thresholds", "max_pdop_ar", "float"),
+    ("pos2-maxpdophold", "ambiguity_resolution.thresholds", "max_pdop_hold", "float"),
+    ("pos2-refdop", "ambiguity_resolution.thresholds", "reference_dop", "enum"),
     # ── ambiguity_resolution.counters ────────────────────────────────────────
     ("pos2-arlockcnt", "ambiguity_resolution.counters", "lock_count", "int"),
     ("pos2-arminfix", "ambiguity_resolution.counters", "min_fix", "int"),
@@ -111,6 +124,8 @@ MAPPING: list[tuple[str, str, str, str]] = [
     ("pos2-rejionno3", "rejection", "non_dispersive", "float"),
     ("pos2-rejionno4", "rejection", "hold_chi_square", "float"),
     ("pos2-rejionno5", "rejection", "fix_chi_square", "float"),
+    ("pos2-rejethres", "rejection", "spp_residual", "float"),
+    ("pos2-rejeminsat", "rejection", "spp_min_sats", "int"),
     ("pos2-rejgdop", "rejection", "gdop", "float"),
     ("pos2-rejdiffpse", "rejection", "pseudorange_diff", "float"),
     ("pos2-poserrcnt", "rejection", "position_error_count", "int"),
@@ -128,6 +143,8 @@ MAPPING: list[tuple[str, str, str, str]] = [
     ("stats-errphaseel", "kalman_filter.measurement_error", "phase_elevation", "float"),
     ("stats-errphasebl", "kalman_filter.measurement_error", "phase_baseline", "float"),
     ("stats-errdoppler", "kalman_filter.measurement_error", "doppler", "float"),
+    ("stats-snrmax", "kalman_filter.measurement_error", "snr_max", "float"),
+    ("stats-errsnr", "kalman_filter.measurement_error", "snr_error", "float"),
     ("stats-uraratio", "kalman_filter.measurement_error", "ura_ratio", "float"),
     # ── kalman_filter.initial_std ────────────────────────────────────────────
     ("stats-stdbias", "kalman_filter.initial_std", "bias", "float"),
@@ -308,6 +325,9 @@ _ENUM_STRINGS = {
     "SIGOPT4": "0:B1I/B3I,1:B1I/B2I,2:B1I/B3I/B2I",
     "SIGOPT5": "0:B1I/B3I,1:B1I/B2a,2:B1I/B3I/B2a",
     "ARALPHAOPT": "0:0.1%,1:0.5%,2:1%,3:5%,4:10%,5:20%",
+    "ROBOPT": "0:off,1:igg3",
+    "SEEDOPT": "0:off,1:cn0+tdcp,2:cn0+tdcp+robust",
+    "DOPOPT": "0:zd,1:sd",
 }
 
 for _name, _defstr in _ENUM_STRINGS.items():
@@ -353,6 +373,10 @@ _KEY_ENUM: dict[str, str] = {
     "pos2-aralpha": "ARALPHAOPT",
     "pos2-syncsol": "SWTOPT",
     "pos2-arfilter": "SWTOPT",
+    "pos1-robust": "ROBOPT",
+    "pos1-tdcp": "SWTOPT",
+    "pos1-seedenh": "SEEDOPT",
+    "pos2-refdop": "DOPOPT",
     "pos2-ionocorr": "SWTOPT",
     "pos2-ign_chierr": "SWTOPT",
     "pos2-bds2bias": "SWTOPT",


### PR DESCRIPTION
## Summary

The TOML config reference (`docs/reference/config-options.md`) had drifted from the actual loader. Two independent gaps:

**A — 18 loader-accepted keys were undocumented.** `src/core/mrtk_toml.c` accepts keys that appear in neither the doc nor its generator sources:

| Section | Keys |
|:--|:--|
| `[positioning]` | `correction`, `robust`, `robust_k0`, `robust_k1`, `tdcp`, `tdcp_jump` (+ `constellations` alias note) |
| `[positioning.clas]` | `enhanced_spp_seed` |
| `[ambiguity_resolution.thresholds]` | `max_pdop_ar`, `max_pdop_hold`, `reference_dop` |
| `[kalman_filter.measurement_error]` | `snr_max`, `snr_error` |
| `[rejection]` | `spp_residual`, `spp_min_sats` |
| `[streams.input.base]` | `nmeahgt` |
| `[console]` (whole section) | `passwd`, `timetype`, `soltype`, `solflag` |

**B — the "auto-generated" contract was broken.** The `correction`/`signals` rich descriptions and two surface notes (Recommended surface / Legacy preset form) had been hand-added to the committed doc after generation, so `python scripts/docs/gen_config_ref.py` no longer reproduced the file — regenerating would silently drop them. This is *why* gap A accumulated: nobody could safely regenerate.

## Fix (root cause)

Restore the generator as the single source of truth, then guard it:

- **`scripts/tools/conf2toml.py`** — add the 14 keys to `MAPPING` + `ROBOPT`/`SEEDOPT`/`DOPOPT` enum defs and `_KEY_ENUM` wiring
- **`scripts/docs/gen_config_ref.py`** — add descriptions/modes to `_OPTION_META`; fold the hand-added `correction`/`signals` prose and both surface notes back into the generator; add the `[console]` block, `nmeahgt` row, and `constellations` alias note
- **`docs/reference/config-options.md`** — regenerated (452 → 479 lines)
- **`.github/workflows/format.yaml`** — new `config-ref` job regenerates and `git diff --exit-code`s the doc, failing PRs where the committed reference is stale

## Verification

- Loader ↔ doc parity: **0 remaining gaps** (automated set-diff of `mrtk_toml.c` keys vs documented keys)
- Generator idempotent: fresh run == committed doc (no lost hand edits)
- No duplicate rows; `ruff format` passes; converter enums resolve (`ROBOPT`/`SEEDOPT`/`DOPOPT`)

Docs + CI only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)