### PR TITLE
fix(clas): gate Shapiro delay on shapiro_delay (posopt[7]), not phase_windup

### DIFF
--- a/apps/cssr2rtcm3/cssr2rtcm3.c
+++ b/apps/cssr2rtcm3/cssr2rtcm3.c
@@ -1314,6 +1314,7 @@ int mrtk_cssr2rtcm3(int argc, char** argv) {
     prcopt.elmin = OSR_ELMASK * D2R;
     prcopt.tidecorr = 1;
     prcopt.posopt[2] = 1; /* phase windup correction */
+    prcopt.posopt[7] = 1; /* shapiro time delay correction */
 
     if (*conffile) {
         setsysopts(&prcopt, &solopt, &filopt);

--- a/apps/ssr2obs/ssr2obs.c
+++ b/apps/ssr2obs/ssr2obs.c
@@ -538,6 +538,7 @@ static int set_prcopt(const char* file, prcopt_t* prcopt, solopt_t* solopt, filo
     prcopt->elmin = OSR_ELMASK * D2R;
     prcopt->tidecorr = 1;
     prcopt->posopt[2] = 1; /* phase windup correction */
+    prcopt->posopt[7] = 1; /* shapiro time delay correction */
     solopt->timef = 0;
 
     if (*file) {

--- a/conf/cssr2rtcm3.toml
+++ b/conf/cssr2rtcm3.toml
@@ -10,6 +10,7 @@ systems = ["GPS", "Galileo", "QZSS"]
 [positioning.corrections]
 tidal_correction = "solid+otl-clasgrid+pole"
 phase_windup = "on"
+shapiro_delay = true
 exclude_eclipse = true
 receiver_antenna = false
 

--- a/src/clas/mrtk_clas_osr.c
+++ b/src/clas/mrtk_clas_osr.c
@@ -1235,9 +1235,7 @@ int clas_osr_zdres(const obsd_t* obs, int n, const double* rs, const double* dts
         }
 
         /* shapiro time delay correction */
-        if (opt->posopt[2]) {
-            /* upstream uses posopt[7]; map to posopt[2] for MRTKLIB.
-             * If posopt[2] is used for another purpose, set it appropriately. */
+        if (opt->posopt[7]) {
             osr[i].relatv = shapiro(rs + i * 6, rr);
         }
 

--- a/src/clas/mrtk_clas_osr.c
+++ b/src/clas/mrtk_clas_osr.c
@@ -1234,10 +1234,10 @@ int clas_osr_zdres(const obsd_t* obs, int n, const double* rs, const double* dts
             continue;
         }
 
-        /* shapiro time delay correction */
-        if (opt->posopt[7]) {
-            osr[i].relatv = shapiro(rs + i * 6, rr);
-        }
+        /* shapiro time delay correction. Assigned unconditionally: PRC/CPC below read
+         * .relatv every epoch, but the caller's osr[] is reused across epochs (see the
+         * partial-clear note in clas_ssr2osr), which would let a stale term survive here. */
+        osr[i].relatv = opt->posopt[7] ? shapiro(rs + i * 6, rr) : 0.0;
 
         /* tropospheric delay correction */
         osr[i].trop = clas_osr_prectrop(obs_copy[i].time, pos, azel + i * 2, zwd, ztd);


### PR DESCRIPTION
Fixes #257.

## What was wrong

In the CLAS OSR path, the Shapiro relativistic delay was gated by `posopt[2]` — the slot TOML exposes as **`phase_windup`** — instead of `posopt[7]`, the slot exposed as **`shapiro_delay`**. Slot numbering is identical to upstream claslib (`cssr2osr.c:326` reads `posopt[7]`), so the in-code comment claiming a remap was required had no basis.

Consequences:

- `shapiro_delay` was read nowhere in the repo. Setting it did nothing.
- `phase_windup = "off"` silently disabled **Shapiro delay**, not wind-up. Wind-up is applied unconditionally through `windupcorr()`, which matches upstream for this path.

## Why this is four lines, not one

The issue estimated **zero** regression risk. That does not hold. `posopt[]` follows `exsats` in `prcopt_t` and never appears in the `prcopt_default` initializer, so **`posopt[7]` zero-fills to 0**. Both `apps/cssr2rtcm3` and `apps/ssr2obs` hard-set `posopt[2] = 1` and treat the config file as *optional* — so the crossed wire was the only thing enabling Shapiro in those tools, and `conf/cssr2rtcm3.toml` had no `shapiro_delay` key at all.

Correcting the gate alone would have silently switched Shapiro **off** for `cssr2rtcm3`. The effective default is therefore made explicit:

- `src/clas/mrtk_clas_osr.c` — gate on `posopt[7]`; drop the false comment.
- `conf/cssr2rtcm3.toml` — add the missing `shapiro_delay = true`. Upstream's own `ssr2obs/sample.conf` sets `pos1-posopt8 = on`, so this was an omission.
- `apps/cssr2rtcm3.c`, `apps/ssr2obs.c` — hard-set `posopt[7] = 1` beside the existing `posopt[2] = 1`.

`apps/ssr2osr` never set `posopt[2]`, so it is unaffected either way.

## Verification

Green tests alone prove nothing here: every shipped CLAS config sets **both** flags, so old and new gates agree and the suite is bit-identical by construction. To prove the wire is actually connected, the pre-fix binary was rebuilt and compared on a 10-minute CLAS PPP-RTK window (2019/239, 1160 epochs, `conf/claslib/rnx2rtkp.toml`):

| Toggle | Pre-fix | Post-fix |
|---|---|---|
| `shapiro_delay` on → off | identical (**flag was dead**) | 1128 / 1160 epochs differ |
| `phase_windup` on → off | epochs differ (**wrongly gated Shapiro**) | identical |
| Shipped config | — | **bit-identical** to pre-fix |

Cross-check: `pre(phase_windup=off)` is byte-identical to `post(shapiro_delay=false)` — the same physical configuration, now reached through the correct key.

Blast radius audit: `clas_osr_zdres()` is reached only from the CLAS OSR wrapper and `mrtk_ppp_rtk.c`. Every config that reaches it (`conf/claslib/*`, `conf/benchmark/clas.toml`, `conf/cssr2rtcm3.toml`) sets `shapiro_delay = true`. Configs lacking the key are all `ppp-kine` / `ppp-static` / `kinematic` and never touch the gate.

Behaviour changes **only** for users who explicitly set `shapiro_delay = false` (previously ignored) or `phase_windup = "off"` (previously disabled Shapiro as a side effect) in a CLAS config — which is precisely the semantics being restored.

## Tests

Full suite: **105 / 106 passed**. All 43 CLAS / VRS / OSR tests pass, including `claslib_ssr2obs`, `claslib_ssr2osr`, the VRS suite, and both slow real-time tests (`rtkrcv_rt_clas`, `rtkrcv_rt_clas_2ch`).

The single failure is the documented pre-existing environment failure `madocalib_pppar_ion_check` (system LAPACK vs upstream embedded LU solver, ~1.6 cm against a 0.5 cm tolerance; CLAUDE.md §7.2). **No test tolerance was changed.**

## Follow-up (not bundled)

`docs/reference/config-options.md:108` lists `shapiro_delay` as applying to "PPP, PPP-RTK, VRS", but `posopt[7]` is read only in the CLAS OSR path — the `PPP` entry is inaccurate. Worth a separate docs fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
