### PR TITLE
fix(config): align taxonomy examples with loader

### DIFF
--- a/conf/benchmark/clas.toml
+++ b/conf/benchmark/clas.toml
@@ -174,4 +174,4 @@ time_interpolation = true
 option_1 = ""
 
 [input.sbas]
-satellite = "all"
+satellite = 0

--- a/conf/benchmark/clas.toml
+++ b/conf/benchmark/clas.toml
@@ -171,7 +171,7 @@ max_age = 30.0
 time_interpolation = true
 
 [input.rinex]
-rinex_option_1 = ""
+option_1 = ""
 
 [input.sbas]
-sbas_satellite = "all"
+satellite = "all"

--- a/conf/benchmark/madoca.toml
+++ b/conf/benchmark/madoca.toml
@@ -142,4 +142,4 @@ option_2 = ""
 options = ""
 
 [input.sbas]
-satellite = "0"
+satellite = 0

--- a/conf/benchmark/madoca.toml
+++ b/conf/benchmark/madoca.toml
@@ -129,17 +129,17 @@ trace = ""
 iono_correction = false
 
 [positioning.ppp]
-ppp_option = ""
+options = ""
 
 [positioning.relative]
 time_interpolation = true
 
 [input.rinex]
-rinex_option_1 = ""
-rinex_option_2 = ""
+option_1 = ""
+option_2 = ""
 
 [input.rtcm]
-rtcm_option = ""
+options = ""
 
 [input.sbas]
-sbas_satellite = "0"
+satellite = "0"

--- a/conf/benchmark/rtk.toml
+++ b/conf/benchmark/rtk.toml
@@ -108,4 +108,4 @@ baseline_sigma = 0.0
 time_interpolation = true
 
 [input.sbas]
-satellite = "all"
+satellite = 0

--- a/conf/benchmark/rtk.toml
+++ b/conf/benchmark/rtk.toml
@@ -108,4 +108,4 @@ baseline_sigma = 0.0
 time_interpolation = true
 
 [input.sbas]
-sbas_satellite = "all"
+satellite = "all"

--- a/conf/benchmark/single.toml
+++ b/conf/benchmark/single.toml
@@ -114,17 +114,17 @@ trace = ""
 
 
 [positioning.ppp]
-ppp_option = ""
+options = ""
 
 [positioning.relative]
 time_interpolation = true
 
 [input.rinex]
-rinex_option_1 = ""
-rinex_option_2 = ""
+option_1 = ""
+option_2 = ""
 
 [input.rtcm]
-rtcm_option = ""
+options = ""
 
 [input.sbas]
-sbas_satellite = "0"
+satellite = "0"

--- a/conf/benchmark/single.toml
+++ b/conf/benchmark/single.toml
@@ -127,4 +127,4 @@ option_2 = ""
 options = ""
 
 [input.sbas]
-satellite = "0"
+satellite = 0

--- a/conf/claslib/rnx2rtkp.toml
+++ b/conf/claslib/rnx2rtkp.toml
@@ -173,7 +173,7 @@ max_age = 30.0            # (s)
 time_interpolation = true # (0:off,1:on)
 
 [input.rinex]
-rinex_option_1 = "" # signal priority (Default:L2P(GPS) L1C/A(QZS),-GL2X:L2C(GPS),-JL1X:L1C(QZS))
+option_1 = "" # signal priority (Default:L2P(GPS) L1C/A(QZS),-GL2X:L2C(GPS),-JL1X:L1C(QZS))
 
 [input.sbas]
-sbas_satellite = "all" # (0:all)
+satellite = "all" # (0:all)

--- a/conf/claslib/rnx2rtkp.toml
+++ b/conf/claslib/rnx2rtkp.toml
@@ -176,4 +176,4 @@ time_interpolation = true # (0:off,1:on)
 option_1 = "" # signal priority (Default:L2P(GPS) L1C/A(QZS),-GL2X:L2C(GPS),-JL1X:L1C(QZS))
 
 [input.sbas]
-satellite = "all" # (0:all)
+satellite = 0 # (0:all)

--- a/conf/claslib/rnx2rtkp_L1CL5.toml
+++ b/conf/claslib/rnx2rtkp_L1CL5.toml
@@ -177,4 +177,4 @@ time_interpolation = true # (0:off,1:on)
 option_1 = "-JL1X" # signal priority (Default:L2P(GPS) L1C/A(QZS),-GL2X:L2C(GPS),-JL1X:L1C(QZS))
 
 [input.sbas]
-satellite = "all" # (0:all)
+satellite = 0 # (0:all)

--- a/conf/claslib/rnx2rtkp_L1CL5.toml
+++ b/conf/claslib/rnx2rtkp_L1CL5.toml
@@ -174,7 +174,7 @@ max_age = 30.0            # (s)
 time_interpolation = true # (0:off,1:on)
 
 [input.rinex]
-rinex_option_1 = "-JL1X" # signal priority (Default:L2P(GPS) L1C/A(QZS),-GL2X:L2C(GPS),-JL1X:L1C(QZS))
+option_1 = "-JL1X" # signal priority (Default:L2P(GPS) L1C/A(QZS),-GL2X:L2C(GPS),-JL1X:L1C(QZS))
 
 [input.sbas]
-sbas_satellite = "all" # (0:all)
+satellite = "all" # (0:all)

--- a/conf/claslib/rnx2rtkp_f9p.toml
+++ b/conf/claslib/rnx2rtkp_f9p.toml
@@ -177,7 +177,7 @@ max_age = 30.0            # (s)
 time_interpolation = true # (0:off,1:on)
 
 [input.rinex]
-rinex_option_1 = "" # signal priority (Default:L2P(GPS) L1C/A(QZS),-GL2X:L2C(GPS),-JL1X:L1C(QZS))
+option_1 = "" # signal priority (Default:L2P(GPS) L1C/A(QZS),-GL2X:L2C(GPS),-JL1X:L1C(QZS))
 
 [input.sbas]
-sbas_satellite = "all" # (0:all)
+satellite = "all" # (0:all)

--- a/conf/claslib/rnx2rtkp_f9p.toml
+++ b/conf/claslib/rnx2rtkp_f9p.toml
@@ -180,4 +180,4 @@ time_interpolation = true # (0:off,1:on)
 option_1 = "" # signal priority (Default:L2P(GPS) L1C/A(QZS),-GL2X:L2C(GPS),-JL1X:L1C(QZS))
 
 [input.sbas]
-satellite = "all" # (0:all)
+satellite = 0 # (0:all)

--- a/conf/claslib/rnx2rtkp_sf.toml
+++ b/conf/claslib/rnx2rtkp_sf.toml
@@ -181,4 +181,4 @@ time_interpolation = true # (0:off,1:on)
 option_1 = "" # signal priority (Default:L2P(GPS) L1C/A(QZS),-GL2X:L2C(GPS),-JL1X:L1C(QZS))
 
 [input.sbas]
-satellite = "all" # (0:all)
+satellite = 0 # (0:all)

--- a/conf/claslib/rnx2rtkp_sf.toml
+++ b/conf/claslib/rnx2rtkp_sf.toml
@@ -178,7 +178,7 @@ max_age = 30.0            # (s)
 time_interpolation = true # (0:off,1:on)
 
 [input.rinex]
-rinex_option_1 = "" # signal priority (Default:L2P(GPS) L1C/A(QZS),-GL2X:L2C(GPS),-JL1X:L1C(QZS))
+option_1 = "" # signal priority (Default:L2P(GPS) L1C/A(QZS),-GL2X:L2C(GPS),-JL1X:L1C(QZS))
 
 [input.sbas]
-sbas_satellite = "all" # (0:all)
+satellite = "all" # (0:all)

--- a/conf/claslib/rnx2rtkp_vrs.toml
+++ b/conf/claslib/rnx2rtkp_vrs.toml
@@ -165,7 +165,7 @@ max_age = 30.0            # (s)
 time_interpolation = true # (0:off,1:on)
 
 [input.rinex]
-rinex_option_1 = "" # GPS L2 signal priority (Default:L2P,-GL2X:L2C)
+option_1 = "" # GPS L2 signal priority (Default:L2P,-GL2X:L2C)
 
 [input.sbas]
-sbas_satellite = "all" # (0:all)
+satellite = "all" # (0:all)

--- a/conf/claslib/rnx2rtkp_vrs.toml
+++ b/conf/claslib/rnx2rtkp_vrs.toml
@@ -168,4 +168,4 @@ time_interpolation = true # (0:off,1:on)
 option_1 = "" # GPS L2 signal priority (Default:L2P,-GL2X:L2C)
 
 [input.sbas]
-satellite = "all" # (0:all)
+satellite = 0 # (0:all)

--- a/conf/claslib/rnx2rtkp_vrs_g5p3.toml
+++ b/conf/claslib/rnx2rtkp_vrs_g5p3.toml
@@ -165,7 +165,7 @@ max_age = 30.0            # (s)
 time_interpolation = true # (0:off,1:on)
 
 [input.rinex]
-rinex_option_1 = "" # GPS L2 signal priority (Default:L2P,-GL2X:L2C)
+option_1 = "" # GPS L2 signal priority (Default:L2P,-GL2X:L2C)
 
 [input.sbas]
-sbas_satellite = "all" # (0:all)
+satellite = "all" # (0:all)

--- a/conf/claslib/rnx2rtkp_vrs_g5p3.toml
+++ b/conf/claslib/rnx2rtkp_vrs_g5p3.toml
@@ -168,4 +168,4 @@ time_interpolation = true # (0:off,1:on)
 option_1 = "" # GPS L2 signal priority (Default:L2P,-GL2X:L2C)
 
 [input.sbas]
-satellite = "all" # (0:all)
+satellite = 0 # (0:all)

--- a/conf/has/ppp_gal_has.toml
+++ b/conf/has/ppp_gal_has.toml
@@ -119,17 +119,17 @@ trace = ""
 
 
 [positioning.ppp]
-ppp_option = ""
+options = ""
 
 [positioning.relative]
 time_interpolation = false # (0:off,1:on)
 
 [input.rinex]
-rinex_option_1 = ""
-rinex_option_2 = ""
+option_1 = ""
+option_2 = ""
 
 [input.rtcm]
-rtcm_option = ""
+options = ""
 
 [input.sbas]
-sbas_satellite = "0" # (0:all)
+satellite = "0" # (0:all)

--- a/conf/has/ppp_gal_has.toml
+++ b/conf/has/ppp_gal_has.toml
@@ -132,4 +132,4 @@ option_2 = ""
 options = ""
 
 [input.sbas]
-satellite = "0" # (0:all)
+satellite = 0 # (0:all)

--- a/conf/has/run_gal_has.toml
+++ b/conf/has/run_gal_has.toml
@@ -184,17 +184,17 @@ soltype = "deg"
 solflag = "off"
 
 [positioning.ppp]
-ppp_option = ""
+options = ""
 
 [positioning.relative]
 time_interpolation = false
 
 [input.rinex]
-rinex_option_1 = ""
-rinex_option_2 = ""
+option_1 = ""
+option_2 = ""
 
 [input.rtcm]
-rtcm_option = ""
+options = ""
 
 [input.sbas]
-sbas_satellite = "0"
+satellite = "0"

--- a/conf/has/run_gal_has.toml
+++ b/conf/has/run_gal_has.toml
@@ -197,4 +197,4 @@ option_2 = ""
 options = ""
 
 [input.sbas]
-satellite = "0"
+satellite = 0

--- a/conf/igs/rnx2rtkp_igspppar.toml
+++ b/conf/igs/rnx2rtkp_igspppar.toml
@@ -77,7 +77,7 @@ receiver_atx = "./tests/data/igs/igs20_trim.atx"
 bias_sinex = "./tests/data/igs/COD0MGXFIN_2026021_01D_OSB.BIA"
 
 [positioning.ppp]
-max_bias_dt = 86400.0
+max_bias_dt = 86400
 
 [positioning.relative]
 max_age = 30.0

--- a/conf/igs/rnx2rtkp_igspppar_gps.toml
+++ b/conf/igs/rnx2rtkp_igspppar_gps.toml
@@ -74,7 +74,7 @@ receiver_atx = "./tests/data/igs/igs20_trim.atx"
 bias_sinex = "./tests/data/igs/COD0MGXFIN_2026021_01D_OSB.BIA"
 
 [positioning.ppp]
-max_bias_dt = 86400.0
+max_bias_dt = 86400
 
 [positioning.relative]
 max_age = 30.0

--- a/conf/igs/rtkrcv_igsrts.toml
+++ b/conf/igs/rtkrcv_igsrts.toml
@@ -221,4 +221,4 @@ option_2 = ""
 options = ""
 
 [input.sbas]
-satellite = "0"
+satellite = 0

--- a/conf/igs/rtkrcv_igsrts.toml
+++ b/conf/igs/rtkrcv_igsrts.toml
@@ -207,18 +207,18 @@ path = ""
 ignore_chi_error = false
 
 [positioning.ppp]
-ppp_option = ""
+options = ""
 
 [positioning.relative]
 max_age = 30.0
 time_interpolation = false
 
 [input.rinex]
-rinex_option_1 = ""
-rinex_option_2 = ""
+option_1 = ""
+option_2 = ""
 
 [input.rtcm]
-rtcm_option = ""
+options = ""
 
 [input.sbas]
-sbas_satellite = "0"
+satellite = "0"

--- a/conf/madocalib/rnx2rtkp.toml
+++ b/conf/madocalib/rnx2rtkp.toml
@@ -131,17 +131,17 @@ trace = ""
 iono_correction = false # (0:off,1:on)
 
 [positioning.ppp]
-ppp_option = ""
+options = ""
 
 [positioning.relative]
 time_interpolation = false # (0:off,1:on)
 
 [input.rinex]
-rinex_option_1 = ""
-rinex_option_2 = ""
+option_1 = ""
+option_2 = ""
 
 [input.rtcm]
-rtcm_option = ""
+options = ""
 
 [input.sbas]
-sbas_satellite = "0" # (0:all)
+satellite = "0" # (0:all)

--- a/conf/madocalib/rnx2rtkp.toml
+++ b/conf/madocalib/rnx2rtkp.toml
@@ -144,4 +144,4 @@ option_2 = ""
 options = ""
 
 [input.sbas]
-satellite = "0" # (0:all)
+satellite = 0 # (0:all)

--- a/conf/madocalib/rnx2rtkp_pppar.toml
+++ b/conf/madocalib/rnx2rtkp_pppar.toml
@@ -131,17 +131,17 @@ trace = ""
 iono_correction = false # (0:off,1:on)
 
 [positioning.ppp]
-ppp_option = ""
+options = ""
 
 [positioning.relative]
 time_interpolation = false # (0:off,1:on)
 
 [input.rinex]
-rinex_option_1 = ""
-rinex_option_2 = ""
+option_1 = ""
+option_2 = ""
 
 [input.rtcm]
-rtcm_option = ""
+options = ""
 
 [input.sbas]
-sbas_satellite = "0" # (0:all)
+satellite = "0" # (0:all)

--- a/conf/madocalib/rnx2rtkp_pppar.toml
+++ b/conf/madocalib/rnx2rtkp_pppar.toml
@@ -144,4 +144,4 @@ option_2 = ""
 options = ""
 
 [input.sbas]
-satellite = "0" # (0:all)
+satellite = 0 # (0:all)

--- a/conf/madocalib/rnx2rtkp_pppar_iono.toml
+++ b/conf/madocalib/rnx2rtkp_pppar_iono.toml
@@ -131,17 +131,17 @@ trace = ""
 iono_correction = true # (0:off,1:on)
 
 [positioning.ppp]
-ppp_option = ""
+options = ""
 
 [positioning.relative]
 time_interpolation = false # (0:off,1:on)
 
 [input.rinex]
-rinex_option_1 = ""
-rinex_option_2 = ""
+option_1 = ""
+option_2 = ""
 
 [input.rtcm]
-rtcm_option = ""
+options = ""
 
 [input.sbas]
-sbas_satellite = "0" # (0:all)
+satellite = "0" # (0:all)

--- a/conf/madocalib/rnx2rtkp_pppar_iono.toml
+++ b/conf/madocalib/rnx2rtkp_pppar_iono.toml
@@ -144,4 +144,4 @@ option_2 = ""
 options = ""
 
 [input.sbas]
-satellite = "0" # (0:all)
+satellite = 0 # (0:all)

--- a/conf/madocalib/rtkrcv_madoca_pppar_iono.toml
+++ b/conf/madocalib/rtkrcv_madoca_pppar_iono.toml
@@ -217,4 +217,4 @@ option_2 = ""
 options = ""
 
 [input.sbas]
-satellite = "0"
+satellite = 0

--- a/conf/madocalib/rtkrcv_madoca_pppar_iono.toml
+++ b/conf/madocalib/rtkrcv_madoca_pppar_iono.toml
@@ -203,18 +203,18 @@ path = ""
 iono_correction = true # enable L6D wide-area ionospheric augmentation (PPP-AR/IONO)
 
 [positioning.ppp]
-ppp_option = ""
+options = ""
 
 [positioning.relative]
 max_age = 30.0
 time_interpolation = false
 
 [input.rinex]
-rinex_option_1 = ""
-rinex_option_2 = ""
+option_1 = ""
+option_2 = ""
 
 [input.rtcm]
-rtcm_option = ""
+options = ""
 
 [input.sbas]
-sbas_satellite = "0"
+satellite = "0"

--- a/conf/malib/rnx2rtkp.toml
+++ b/conf/malib/rnx2rtkp.toml
@@ -142,10 +142,10 @@ trace = ""
 ignore_chi_error = false # (0:off,1:on)
 
 [positioning.ppp]
-ppp_sat_clock_bias = 0 # (0:auto,1:ssr,2:bia,3:dcb)
-ppp_sat_phase_bias = 0 # (0:auto,1:ssr,3:fcb)
-max_bias_dt = 0        # (bia and fcb product code/phase bias timeout(s))
-ppp_option = ""
+satellite_clock_bias = 0 # (0:auto,1:ssr,2:bia,3:dcb)
+satellite_phase_bias = 0 # (0:auto,1:ssr,3:fcb)
+max_bias_dt = 0          # (bia and fcb product code/phase bias timeout(s))
+options = ""
 
 [positioning.relative]
 max_age = 30.0             # (s)
@@ -154,11 +154,11 @@ baseline_sigma = 0.0       # (m)
 time_interpolation = false # (0:off,1:on)
 
 [input.rinex]
-rinex_option_1 = ""
-rinex_option_2 = ""
+option_1 = ""
+option_2 = ""
 
 [input.rtcm]
-rtcm_option = ""
+options = ""
 
 [input.sbas]
-sbas_satellite = "0" # (0:all)
+satellite = "0" # (0:all)

--- a/conf/malib/rnx2rtkp.toml
+++ b/conf/malib/rnx2rtkp.toml
@@ -161,4 +161,4 @@ option_2 = ""
 options = ""
 
 [input.sbas]
-satellite = "0" # (0:all)
+satellite = 0 # (0:all)

--- a/conf/malib/rtkrcv.toml
+++ b/conf/malib/rtkrcv.toml
@@ -198,10 +198,10 @@ path = ""
 ignore_chi_error = false # (0:off,1:on)
 
 [positioning.ppp]
-ppp_sat_clock_bias = 0 # (0:auto,1:ssr,2:bia,3:dcb)
-ppp_sat_phase_bias = 0 # (0:auto,1:ssr,3:fcb)
-max_bias_dt = 0        # (bia and fcb product code/phase bias timeout(s))
-ppp_option = ""
+satellite_clock_bias = 0 # (0:auto,1:ssr,2:bia,3:dcb)
+satellite_phase_bias = 0 # (0:auto,1:ssr,3:fcb)
+max_bias_dt = 0          # (bia and fcb product code/phase bias timeout(s))
+options = ""
 
 [positioning.relative]
 max_age = 30.0             # (s)
@@ -210,11 +210,11 @@ baseline_sigma = 0.0       # (m)
 time_interpolation = false # (0:off,1:on)
 
 [input.rinex]
-rinex_option_1 = ""
-rinex_option_2 = ""
+option_1 = ""
+option_2 = ""
 
 [input.rtcm]
-rtcm_option = ""
+options = ""
 
 [input.sbas]
-sbas_satellite = "0" # (0:all)
+satellite = "0" # (0:all)

--- a/conf/malib/rtkrcv.toml
+++ b/conf/malib/rtkrcv.toml
@@ -217,4 +217,4 @@ option_2 = ""
 options = ""
 
 [input.sbas]
-satellite = "0" # (0:all)
+satellite = 0 # (0:all)

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -373,7 +373,7 @@ TOML section: `[input.sbas]`
 
 | TOML Key | Type | Modes | Description |
 |:---------|:-----|:------|:------------|
-| `satellite` | string | RT, PP | SBAS satellite selection. |
+| `satellite` | integer | RT, PP | SBAS satellite selection. |
 
 ## Antenna — Rover
 

--- a/scripts/tools/conf2toml.py
+++ b/scripts/tools/conf2toml.py
@@ -195,7 +195,7 @@ MAPPING: list[tuple[str, str, str, str]] = [
     ("misc-rnxopt1", "input.rinex", "option_1", "str"),
     ("misc-rnxopt2", "input.rinex", "option_2", "str"),
     ("misc-rtcmopt", "input.rtcm", "options", "str"),
-    ("misc-sbasatsel", "input.sbas", "satellite", "str"),
+    ("misc-sbasatsel", "input.sbas", "satellite", "int"),
     # ── antenna.rover ────────────────────────────────────────────────────────
     ("ant1-postype", "antenna.rover", "position_type", "enum"),
     ("ant1-pos1", "antenna.rover", "position_1", "float"),


### PR DESCRIPTION
## Summary

Follow-up for the review of merged PR #272.

The section-taxonomy refactor moved example settings into their new sections but left some keys under their former names. Those keys were consequently ignored by `loadopts_toml()`.

This patch aligns every shipped TOML example with the loader schema:

- `positioning.ppp.satellite_clock_bias`, `satellite_phase_bias`, and `options`
- `input.rinex.option_1` / `option_2`
- `input.rtcm.options`
- `input.sbas.satellite`
- integer literals for `positioning.ppp.max_bias_dt`

## Validation

- `taplo fmt --check`
- parsed all `conf/**/*.toml` with `tomllib`
- verified all shipped MRTK TOML leaf keys map to the loader or the rtkrcv-specific surface