### PR TITLE
fix(clas): isolate position process noise from IFB

### DIFF
--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -260,7 +260,7 @@ TOML section: `[kalman_filter.process_noise]`
 | `accel_v` | float | All | Vertical acceleration process noise (m/s²). Active when `dynamics = true`. |
 | `position_h` | float | PPP-RTK, VRS | Horizontal position process noise (m). |
 | `position_v` | float | PPP-RTK, VRS | Vertical position process noise (m). |
-| `position` | float | All | General position process noise (m). Fallback when h/v not specified. |
+| `position` | float | PPP | General position process noise for static PPP states (m). |
 | `ifb` | float | PPP | Inter-frequency bias process noise (m). For multi-frequency PPP bias estimation. |
 | `iono_time_const` | float | PPP-RTK, VRS | Ionospheric time constant (s). Controls iono state temporal correlation in the adaptive filter. |
 | `clock_stability` | float | RTK, VRS | Receiver clock stability (s/s). Used in clock state prediction. |

--- a/scripts/docs/gen_config_ref.py
+++ b/scripts/docs/gen_config_ref.py
@@ -387,7 +387,7 @@ _OPTION_META: dict[str, tuple[str, str]] = {
     ),
     "stats-prnposith": ("PPP-RTK, VRS", "Horizontal position process noise (m)."),
     "stats-prnpositv": ("PPP-RTK, VRS", "Vertical position process noise (m)."),
-    "stats-prnpos": ("All", "General position process noise (m). Fallback when h/v not specified."),
+    "stats-prnpos": ("PPP", "General position process noise for static PPP states (m)."),
     "stats-prnifb": (
         "PPP",
         "Inter-frequency bias process noise (m). For multi-frequency PPP bias estimation.",

--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -603,8 +603,10 @@ static void udpos_ppp(rtk_t* rtk, const obsd_t* obs, int n, double tt) {
         }
     } else {
         /* process noise added to position */
-        prnpos_h = rtk->opt.stats_prnposith != 0.0 ? rtk->opt.stats_prnposith : rtk->opt.prn[5];
-        prnpos_v = rtk->opt.stats_prnpositv != 0.0 ? rtk->opt.stats_prnpositv : rtk->opt.prn[6];
+        /* Do not fall back to prn[6]: PPP uses that slot for IFB process
+         * noise. CLAS position process noise has dedicated fields. */
+        prnpos_h = rtk->opt.stats_prnposith;
+        prnpos_v = rtk->opt.stats_prnpositv;
         Q[0] = Q[4] = SQR(prnpos_h) * fabs(tt);
         Q[8] = SQR(prnpos_v) * fabs(tt);
         ecef2pos(rtk->x, pos);

--- a/src/pos/mrtk_vrs.c
+++ b/src/pos/mrtk_vrs.c
@@ -312,6 +312,7 @@ static int selfreqpair(const int sat, const prcopt_t* opt, const obsd_t* obs) {
 /* temporal update of position/velocity/acceleration -------------------------*/
 static void udpos(rtk_t* rtk, const obsd_t* obs, double tt) {
     double *F, *FP, *xp, pos[3], Q[9] = {0}, Qv[9], var = 0.0;
+    double prnpos_h, prnpos_v;
     int i, j, na, nb, nx, ni, flag_init = 0;
     double *Fx, *Pxx, *Pxi, *Pxb, *Pxi_, *Pxb_, *xp_, ki;
 
@@ -529,8 +530,11 @@ static void udpos(rtk_t* rtk, const obsd_t* obs, double tt) {
         }
     } else {
         /* process noise added to only position */
-        Q[0] = Q[4] = SQR(rtk->opt.prn[5]) * fabs(tt);
-        Q[8] = SQR(rtk->opt.prn[6]) * fabs(tt);
+        /* Keep CLAS position noise independent of PPP's IFB slot prn[6]. */
+        prnpos_h = rtk->opt.stats_prnposith;
+        prnpos_v = rtk->opt.stats_prnpositv;
+        Q[0] = Q[4] = SQR(prnpos_h) * fabs(tt);
+        Q[8] = SQR(prnpos_v) * fabs(tt);
         ecef2pos(rtk->x, pos);
         covecef(pos, Q, Qv);
         if (rtk->opt.prnadpt == 0 || flag_init) {


### PR DESCRIPTION
## Summary

Addresses #259 by separating the shared process-noise storage used by conventional PPP and CLAS engines.

- PPP-RTK and VRS now use the dedicated `stats_prnposith` / `stats_prnpositv` fields for horizontal and vertical position process noise.
- They no longer fall back to `prn[6]`, which remains exclusively the conventional PPP IFB process-noise slot.
- Correct the generated reference: `kalman_filter.process_noise.position` applies only to static PPP states; it is not a CLAS h/v fallback.

Bundled CLAS configurations explicitly set `position_h = 0.0` and `position_v = 0.0`, so their default behavior remains unchanged.

## Verification

- CLAS PPP-RTK / VRS regressions: 8/8 passed
- PPP regressions: 15/15 passed
- `clang-format --dry-run --Werror`, `ruff format --check`, `taplo fmt --check`, and `git diff --check` passed

The issue will be closed when this work reaches the default `main` branch.