### PR TITLE
fix(ppp): separate clock jump from iono compensation

### DIFF
--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -316,6 +316,7 @@ TOML section: `[positioning.ppp]`
 | `satellite_clock_bias` | integer | PPP | PPP satellite code bias source selection. |
 | `satellite_phase_bias` | integer | PPP | PPP satellite phase bias source selection. |
 | `drop_uncorrected_code` | boolean | PPP | In uncombined IGS PPP, discard a pseudorange measurement when its satellite or receiver code bias is unavailable. |
+| `clock_jump` | boolean | PPP | Reset PPP phase-bias states at a GPS day boundary. |
 | `max_bias_dt` | integer | PPP | Maximum age of bias correction data (s) before invalidation. |
 | `options` | string | PPP | PPP processing option string (passed to PPP engine). |
 

--- a/include/mrtklib/mrtk_opt.h
+++ b/include/mrtklib/mrtk_opt.h
@@ -320,6 +320,9 @@ typedef struct prcopt_t {         /* processing options type */
     /* SPP large-residual exclusion (upstream CLAS sync, appended for ABI stability) */
     double rejethres; /* pseudorange residual rejection threshold (m, <0:off, 0:CLAS seed auto) */
     int rejeminsat;   /* SPP residual rejection runs only when valid sats exceed this (nv > rejeminsat, as upstream) */
+
+    /* PPP day-boundary clock-jump handling (kept separate from CLAS posopt[5]) */
+    int clockjump; /* reset PPP phase biases at a GPS day boundary (0:off,1:on) */
 } prcopt_t;
 
 /* enhanced_spp_seed profiles (applied to the PPP-RTK/VRS a-priori SPP seed only).

--- a/scripts/docs/gen_config_ref.py
+++ b/scripts/docs/gen_config_ref.py
@@ -428,6 +428,7 @@ _OPTION_META: dict[str, tuple[str, str]] = {
         "PPP",
         "In uncombined IGS PPP, discard a pseudorange measurement when its satellite or receiver code bias is unavailable.",
     ),
+    "pos2-clkjump": ("PPP", "Reset PPP phase-bias states at a GPS day boundary."),
     "pos2-maxbiasdt": ("PPP", "Maximum age of bias correction data (s) before invalidation."),
     "pos2-phasshft": (
         "PPP-RTK, VRS",

--- a/scripts/tools/conf2toml.py
+++ b/scripts/tools/conf2toml.py
@@ -179,6 +179,7 @@ MAPPING: list[tuple[str, str, str, str]] = [
     ("pos2-pppsatcb", "positioning.ppp", "satellite_clock_bias", "int"),
     ("pos2-pppsatpb", "positioning.ppp", "satellite_phase_bias", "int"),
     ("pos2-uncorrbias", "positioning.ppp", "drop_uncorrected_code", "bool"),
+    ("pos2-clkjump", "positioning.ppp", "clock_jump", "bool"),
     ("pos2-maxbiasdt", "positioning.ppp", "max_bias_dt", "int"),
     ("misc-pppopt", "positioning.ppp", "options", "str"),
     ("pos2-phasshft", "positioning.clas.ambiguities", "phase_shift", "enum"),

--- a/src/core/mrtk_toml.c
+++ b/src/core/mrtk_toml.c
@@ -187,6 +187,7 @@ static const toml_map_t toml_mapping[] = {
     {"positioning.ppp", "satellite_clock_bias", "pos2-pppsatcb"},
     {"positioning.ppp", "satellite_phase_bias", "pos2-pppsatpb"},
     {"positioning.ppp", "drop_uncorrected_code", "pos2-uncorrbias"},
+    {"positioning.ppp", "clock_jump", "pos2-clkjump"},
     {"positioning.ppp", "max_bias_dt", "pos2-maxbiasdt"},
     {"positioning.ppp", "options", "misc-pppopt"},
     {"positioning.clas.ambiguities", "phase_shift", "pos2-phasshft"},

--- a/src/pos/mrtk_options.c
+++ b/src/pos/mrtk_options.c
@@ -165,6 +165,7 @@ opt_t sysopts[] = {
     {"pos2-pppsatcb", 0, (void*)&prcopt_.pppsatcb, SATCB},
     {"pos2-pppsatpb", 0, (void*)&prcopt_.pppsatpb, SATPB},
     {"pos2-uncorrbias", 3, (void*)&prcopt_.unbias, SWTOPT},
+    {"pos2-clkjump", 3, (void*)&prcopt_.clockjump, SWTOPT},
     {"pos2-maxbiasdt", 0, (void*)&prcopt_.maxbiasdt, "s"},
     {"pos2-sattmode", 0, (void*)&prcopt_.sattmode, ""},
     {"pos2-qzsarmode", 3, (void*)&prcopt_.qzsmodear, SWTOPT},

--- a/src/pos/mrtk_ppp.c
+++ b/src/pos/mrtk_ppp.c
@@ -1216,7 +1216,7 @@ static void udbias_ppp(rtk_t* rtk, const obsd_t* obs, int n, const nav_t* nav) {
     trace(NULL, 3, "udbias  : n=%d\n", n);
 
     /* handle day-boundary clock jump */
-    if (rtk->opt.posopt[5]) {
+    if (rtk->opt.clockjump) {
         clk_jump = ROUND(time2gpst(obs[0].time, NULL) * 10) % 864000 == 0;
     }
     for (i = 0; i < MAXSAT; i++) {


### PR DESCRIPTION
## Summary

Addresses #260 by separating two unrelated meanings that shared `prcopt_t.posopt[5]`.

- Keep `posopt[5]` exclusively for CLAS `iono_compensation` (`off` / `ssr` / `meas`).
- Add PPP-specific `prcopt_t.clockjump`, exposed as `[positioning.ppp].clock_jump`.
- Move the PPP day-boundary phase-bias reset gate to the new field.
- Update legacy-conf conversion and the generated configuration reference.

The new flag defaults to `false`; bundled PPP configurations retain their prior behavior, and CLAS iono-compensation settings no longer enable the PPP clock-jump path as a side effect.

## Verification

- PPP / CLAS / VRS regressions: 19/19 passed
- `clang-format --dry-run --Werror`, `ruff format --check`, `taplo fmt --check`, and `git diff --check` passed

The issue will be closed when this work reaches the default `main` branch.