### PR TITLE
fix(clas): separate PPP-RTK atmosphere and C/N0 variance options

### DIFF
--- a/docs/design/spp-accuracy.md
+++ b/docs/design/spp-accuracy.md
@@ -750,15 +750,17 @@ float vector — including the position states — from `rtk->x`. So a poor seed
 propagate into the ambiguity search. The hypothesis was that the v0.6.10 SPP
 accuracy work could lift the seed quality and reduce mis-fixes.
 
-### 11.2 The err[5]/err[6] aliasing constraint
+### 11.2 Separation of C/N0 and CLAS atmosphere-error terms
 
-The seed runs on a private option copy (`prcopt_t sppopt = rtk->opt`), but until
-now it inherited the CLAS error model verbatim. The two slots `err[5]`/`err[6]`
-are **overloaded**: in `mrtk_spp.c::varerr` they are the C/N0 `snr_max`/`snr_error`
-coefficients, but in `mrtk_ppp_rtk.c::varerr` the same slots are the iono/trop
-estimation-error terms. Setting them on `rtk->opt` to enable seed C/N0 weighting
-would corrupt the CLAS measurement model. The fix is to set the SPP error model
-on `sppopt` **only**, leaving `rtk->opt` (read by the CLAS engine) untouched.
+`err[5]`/`err[6]` are the C/N0 `snr_max`/`snr_error` coefficients used by the
+SPP and RTK measurement models. They were formerly overloaded as ionosphere and
+troposphere estimation-error terms by the CLAS PPP-RTK model. #261 separates the
+CLAS terms into `stats_erriono` / `stats_errtrop`, exposed as
+`[kalman_filter.measurement_error] ionosphere` / `troposphere`. C/N0 weighting
+can therefore be configured without changing the CLAS measurement variance.
+
+The seed still uses a private option copy (`prcopt_t sppopt = rtk->opt`) so its
+profile does not overwrite the operational filter options.
 
 ### 11.3 The `enhanced_spp_seed` profile
 

--- a/docs/reference/benchmark.md
+++ b/docs/reference/benchmark.md
@@ -552,9 +552,9 @@ PPP-RTK computes a single-point fix every epoch that seeds — and, on a filter
 reset (obs-loss gap, persistent-FLOAT, large PPP-RTK↔SPP divergence), re-seeds —
 the CLAS filter position, which then feeds the ambiguity search. The same
 v0.6.10 SPP error model can be applied to that seed **without touching the CLAS
-measurement model** (the seed runs on a private option copy; the C/N0 slots
-`err[5]/err[6]` mean snr_max/snr_error in SPP but iono/trop terms in the CLAS
-engine, so they are set on the copy only). Controlled by
+measurement model** (the seed runs on a private option copy; C/N0 weighting uses
+`err[5]/err[6]`, while the CLAS ionosphere/troposphere terms are dedicated
+options). Controlled by
 `[positioning.clas] enhanced_spp_seed`, **default `cn0+tdcp`**:
 
 | Value | Seed gets |

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -232,8 +232,10 @@ TOML section: `[kalman_filter.measurement_error]`
 | `phase_elevation` | float | All | Elevation-dependent carrier phase error coefficient (m). |
 | `phase_baseline` | float | RTK | Baseline-length-dependent phase error (m/10km). Proportional to rover–base distance. |
 | `doppler` | float | All | Doppler measurement error (Hz). |
-| `snr_max` | float | All | C/N0 at which the SNR-based measurement weighting model saturates (dBHz). Used when C/N0 weighting is enabled. |
-| `snr_error` | float | All | Carrier phase measurement error at the SNR-weighting reference level (m). |
+| `snr_max` | float | SPP, RTK | C/N0 at which the SNR-based measurement weighting model saturates (dBHz). Used when C/N0 weighting is enabled. |
+| `snr_error` | float | SPP, RTK | Carrier phase measurement error at the SNR-weighting reference level (m). |
+| `ionosphere` | float | PPP-RTK | Additional ionosphere estimation-error term in the CLAS measurement variance model (m). Active when ionosphere estimation is enabled. |
+| `troposphere` | float | PPP-RTK | Additional troposphere estimation-error term in the CLAS measurement variance model (m). Active when troposphere estimation is enabled. |
 | `ura_ratio` | float | PPP | User Range Accuracy scaling ratio. Adjusts satellite-specific weighting based on broadcast URA. |
 
 ## Kalman Filter — Initial Std. Deviation

--- a/include/mrtklib/mrtk_opt.h
+++ b/include/mrtklib/mrtk_opt.h
@@ -311,10 +311,9 @@ typedef struct prcopt_t {         /* processing options type */
     /* PPP-RTK/VRS a-priori SPP seed quality (appended for ABI stability).
      * When set, the per-epoch single-point seed (pntpos) used to (re)initialize
      * the CLAS/VRS filter applies a v0.6.10 SPP profile (see SEEDENH_??? below) on
-     * its PRIVATE option copy only, so the CLAS measurement model (which reuses
-     * err[5]/err[6] as iono/trop terms) is left untouched. prcopt_default sets
-     * SEEDENH_BASE (C/N0 + TDCP): a net win on kinematic data and inert on the
-     * static regression suite. Set SEEDENH_OFF to restore prior seed behaviour. */
+     * its PRIVATE option copy only. prcopt_default sets SEEDENH_BASE (C/N0 + TDCP):
+     * a net win on kinematic data and inert on the static regression suite. Set
+     * SEEDENH_OFF to restore prior seed behaviour. */
     int enhanced_spp_seed; /* a-priori SPP seed profile (SEEDENH_???) */
 
     /* SPP large-residual exclusion (upstream CLAS sync, appended for ABI stability) */
@@ -323,6 +322,11 @@ typedef struct prcopt_t {         /* processing options type */
 
     /* PPP day-boundary clock-jump handling (kept separate from CLAS posopt[5]) */
     int clockjump; /* reset PPP phase biases at a GPS day boundary (0:off,1:on) */
+
+    /* CLAS PPP-RTK atmosphere terms in the measurement variance model
+     * (kept separate from err[5]/err[6], which are C/N0 weighting parameters). */
+    double stats_erriono; /* ionosphere estimation-error term (m) */
+    double stats_errtrop; /* troposphere estimation-error term (m) */
 } prcopt_t;
 
 /* enhanced_spp_seed profiles (applied to the PPP-RTK/VRS a-priori SPP seed only).

--- a/scripts/docs/gen_config_ref.py
+++ b/scripts/docs/gen_config_ref.py
@@ -339,12 +339,20 @@ _OPTION_META: dict[str, tuple[str, str]] = {
     ),
     "stats-errdoppler": ("All", "Doppler measurement error (Hz)."),
     "stats-snrmax": (
-        "All",
+        "SPP, RTK",
         "C/N0 at which the SNR-based measurement weighting model saturates (dBHz). Used when C/N0 weighting is enabled.",
     ),
     "stats-errsnr": (
-        "All",
+        "SPP, RTK",
         "Carrier phase measurement error at the SNR-weighting reference level (m).",
+    ),
+    "stats-erriono": (
+        "PPP-RTK",
+        "Additional ionosphere estimation-error term in the CLAS measurement variance model (m). Active when ionosphere estimation is enabled.",
+    ),
+    "stats-errtrop": (
+        "PPP-RTK",
+        "Additional troposphere estimation-error term in the CLAS measurement variance model (m). Active when troposphere estimation is enabled.",
     ),
     "stats-uraratio": (
         "PPP",

--- a/scripts/tools/conf2toml.py
+++ b/scripts/tools/conf2toml.py
@@ -142,6 +142,8 @@ MAPPING: list[tuple[str, str, str, str]] = [
     ("stats-errdoppler", "kalman_filter.measurement_error", "doppler", "float"),
     ("stats-snrmax", "kalman_filter.measurement_error", "snr_max", "float"),
     ("stats-errsnr", "kalman_filter.measurement_error", "snr_error", "float"),
+    ("stats-erriono", "kalman_filter.measurement_error", "ionosphere", "float"),
+    ("stats-errtrop", "kalman_filter.measurement_error", "troposphere", "float"),
     ("stats-uraratio", "kalman_filter.measurement_error", "ura_ratio", "float"),
     # ── kalman_filter.initial_std ────────────────────────────────────────────
     ("stats-stdbias", "kalman_filter.initial_std", "bias", "float"),

--- a/src/core/mrtk_toml.c
+++ b/src/core/mrtk_toml.c
@@ -146,6 +146,8 @@ static const toml_map_t toml_mapping[] = {
     {"kalman_filter.measurement_error", "doppler", "stats-errdoppler"},
     {"kalman_filter.measurement_error", "snr_max", "stats-snrmax"},
     {"kalman_filter.measurement_error", "snr_error", "stats-errsnr"},
+    {"kalman_filter.measurement_error", "ionosphere", "stats-erriono"},
+    {"kalman_filter.measurement_error", "troposphere", "stats-errtrop"},
     {"kalman_filter.measurement_error", "ura_ratio", "stats-uraratio"},
 
     /* ── kalman_filter.initial_std ─────────────────────────────────────────── */

--- a/src/pos/mrtk_options.c
+++ b/src/pos/mrtk_options.c
@@ -227,6 +227,8 @@ opt_t sysopts[] = {
     {"stats-errdoppler", 1, (void*)&prcopt_.err[4], "Hz"},
     {"stats-snrmax", 1, (void*)&prcopt_.err[5], "dBHz"},
     {"stats-errsnr", 1, (void*)&prcopt_.err[6], "m"},
+    {"stats-erriono", 1, (void*)&prcopt_.stats_erriono, "m"},
+    {"stats-errtrop", 1, (void*)&prcopt_.stats_errtrop, "m"},
     {"stats-stdbias", 1, (void*)&prcopt_.std[0], "m"},
     {"stats-stdiono", 1, (void*)&prcopt_.std[1], "m"},
     {"stats-stdtrop", 1, (void*)&prcopt_.std[2], "m"},

--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -349,10 +349,10 @@ static double varerr(int sat, int sys, double el, int type, const prcopt_t* opt)
         a = fact * opt->err[1];
         b = fact * opt->err[2];
         if (opt->ionoopt == IONOOPT_EST) {
-            c = opt->err[5];
+            c = opt->stats_erriono;
         }
         if (opt->tropopt >= TROPOPT_EST) {
-            d = opt->err[6];
+            d = opt->stats_errtrop;
         }
     }
     return a * a + b * b / sinel / sinel + c * c + d * d;

--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -348,7 +348,7 @@ static double varerr(int sat, int sys, double el, int type, const prcopt_t* opt)
         }
         a = fact * opt->err[1];
         b = fact * opt->err[2];
-        if (opt->ionoopt == IONOOPT_EST) {
+        if (opt->ionoopt == IONOOPT_EST || opt->ionoopt == IONOOPT_EST_ADPT) {
             c = opt->stats_erriono;
         }
         if (opt->tropopt >= TROPOPT_EST) {

--- a/src/pos/mrtk_rtkpos.c
+++ b/src/pos/mrtk_rtkpos.c
@@ -2729,10 +2729,9 @@ extern int rtkpos(mrtk_ctx_t* ctx, rtk_t* rtk, const obsd_t* obs, int n, nav_t* 
             }
             /* Enhanced seed (default SEEDENH_BASE = cn0+tdcp; set OFF to disable):
              * apply the proven v0.6.10 SPP error model to this PRIVATE copy only.
-             * err[5]/err[6] are the C/N0 snr_max/snr_error coefficients here (varerr
-             * in mrtk_spp.c); the CLAS engine reads rtk->opt where the same slots
-             * mean the iono/trop estimation-error terms, so it stays untouched. When
-             * the profile is OFF the seed is bit-identical to prior behaviour. */
+             * err[5]/err[6] are the C/N0 snr_max/snr_error coefficients here; the
+             * CLAS measurement model uses its dedicated atmosphere-error fields.
+             * When the profile is OFF the seed is bit-identical to prior behaviour. */
             if (rtk->opt.enhanced_spp_seed >= SEEDENH_BASE) {
                 sppopt.err[5] = 50.0;  /* C/N0 reference snr_max (dB-Hz) */
                 sppopt.err[6] = 0.5;   /* C/N0 weighting coefficient (m) */


### PR DESCRIPTION
## Summary
- separate CLAS PPP-RTK ionosphere/troposphere measurement-error terms from `err[5]` / `err[6]`, which are C/N0 parameters
- add `stats-erriono` / `stats-errtrop` and TOML keys `[kalman_filter.measurement_error] ionosphere` / `troposphere`
- correct `snr_max` / `snr_error` documentation to SPP and RTK only; VRS does not read these terms
- update legacy-to-TOML conversion and current design/reference documentation

Closes #261

## Verification
- `cmake --build /tmp/mrtklib-274-build --parallel 4`
- CLAS PPP-RTK, VRS, and 2ch VRS regression tests
- `clang-format --dry-run --Werror`
- `ruff format --check`
- `taplo fmt --check`
- `git diff --check`