### PR TITLE
fix(toml): remove miswired CLAS position uncertainty options

### DIFF
--- a/conf/claslib/rnx2rtkp.toml
+++ b/conf/claslib/rnx2rtkp.toml
@@ -14,9 +14,6 @@ systems = ["GPS", "Galileo", "QZSS"]
 [positioning.clas]
 grid_selection_radius = 1000    # [m]
 receiver_type = "Trimble NetR9" # User receiver type
-position_uncertainty_x = 10.0
-position_uncertainty_y = 10.0
-position_uncertainty_z = 10.0
 
 [positioning.snr_mask]
 rover_enabled = true                      # (0:off,1:on)

--- a/conf/claslib/rnx2rtkp_L1CL5.toml
+++ b/conf/claslib/rnx2rtkp_L1CL5.toml
@@ -14,9 +14,6 @@ systems = ["GPS", "Galileo", "QZSS"]
 [positioning.clas]
 grid_selection_radius = 1000    # [m]
 receiver_type = "Trimble NetR9" # User receiver type
-position_uncertainty_x = 10.0
-position_uncertainty_y = 10.0
-position_uncertainty_z = 10.0
 
 [positioning.snr_mask]
 rover_enabled = true                      # (0:off,1:on)

--- a/conf/claslib/rnx2rtkp_f9p.toml
+++ b/conf/claslib/rnx2rtkp_f9p.toml
@@ -18,9 +18,6 @@ systems = ["GPS", "Galileo", "QZSS"]
 [positioning.clas]
 grid_selection_radius = 1000    # [m]
 receiver_type = "Trimble NetR9" # User receiver type
-position_uncertainty_x = 10.0
-position_uncertainty_y = 10.0
-position_uncertainty_z = 10.0
 
 [positioning.snr_mask]
 rover_enabled = true                      # (0:off,1:on)

--- a/conf/claslib/rnx2rtkp_sf.toml
+++ b/conf/claslib/rnx2rtkp_sf.toml
@@ -20,9 +20,6 @@ systems = ["GPS", "Galileo", "QZSS"]
 [positioning.clas]
 grid_selection_radius = 1000    # [m]
 receiver_type = "Trimble NetR9" # User receiver type
-position_uncertainty_x = 10.0
-position_uncertainty_y = 10.0
-position_uncertainty_z = 10.0
 
 [positioning.snr_mask]
 rover_enabled = true                      # (0:off,1:on)

--- a/conf/claslib/rtkrcv.toml
+++ b/conf/claslib/rtkrcv.toml
@@ -14,9 +14,6 @@ systems = ["GPS", "Galileo", "QZSS"]
 [positioning.clas]
 grid_selection_radius = 1000    # CLAS grid selection radius (m)
 receiver_type = "Trimble NetR9"
-position_uncertainty_x = 10.0
-position_uncertainty_y = 10.0
-position_uncertainty_z = 10.0
 
 [positioning.snr_mask]
 rover_enabled = true                      # (0:off,1:on)

--- a/conf/claslib/rtkrcv_2ch.toml
+++ b/conf/claslib/rtkrcv_2ch.toml
@@ -14,9 +14,6 @@ systems = ["GPS", "Galileo", "QZSS"]
 [positioning.clas]
 grid_selection_radius = 1000    # CLAS grid selection radius (m)
 receiver_type = "Trimble NetR9"
-position_uncertainty_x = 10.0
-position_uncertainty_y = 10.0
-position_uncertainty_z = 10.0
 
 [positioning.snr_mask]
 rover_enabled = true                      # (0:off,1:on)

--- a/conf/claslib/rtkrcv_mosaic_g5.toml
+++ b/conf/claslib/rtkrcv_mosaic_g5.toml
@@ -25,9 +25,6 @@ systems = ["GPS", "Galileo", "QZSS"]
 [positioning.clas]
 grid_selection_radius = 1000
 receiver_type = ""
-position_uncertainty_x = 10.0
-position_uncertainty_y = 10.0
-position_uncertainty_z = 10.0
 
 [positioning.snr_mask]
 rover_enabled = true

--- a/conf/claslib/rtkrcv_rtcm3_ubx.toml
+++ b/conf/claslib/rtkrcv_rtcm3_ubx.toml
@@ -14,9 +14,6 @@ systems = ["GPS", "Galileo", "QZSS"]
 [positioning.clas]
 grid_selection_radius = 1000    # CLAS grid selection radius (m)
 receiver_type = "TRIMBLE NETR9"
-position_uncertainty_x = 10.0
-position_uncertainty_y = 10.0
-position_uncertainty_z = 10.0
 
 [positioning.snr_mask]
 rover_enabled = true                      # (0:off,1:on)

--- a/conf/claslib/rtkrcv_sbf_l6d.toml
+++ b/conf/claslib/rtkrcv_sbf_l6d.toml
@@ -14,9 +14,6 @@ systems = ["GPS", "Galileo", "QZSS"]
 [positioning.clas]
 grid_selection_radius = 1000  # CLAS grid selection radius (m)
 receiver_type = ""
-position_uncertainty_x = 10.0
-position_uncertainty_y = 10.0
-position_uncertainty_z = 10.0
 
 [positioning.snr_mask]
 rover_enabled = true                      # (0:off,1:on)

--- a/conf/claslib/rtkrcv_sbf_l6d.toml
+++ b/conf/claslib/rtkrcv_sbf_l6d.toml
@@ -12,7 +12,7 @@ excluded_sats = []
 systems = ["GPS", "Galileo", "QZSS"]
 
 [positioning.clas]
-grid_selection_radius = 1000  # CLAS grid selection radius (m)
+grid_selection_radius = 1000 # CLAS grid selection radius (m)
 receiver_type = ""
 
 [positioning.snr_mask]

--- a/conf/claslib/rtkrcv_ubx_clas.toml
+++ b/conf/claslib/rtkrcv_ubx_clas.toml
@@ -23,9 +23,6 @@ systems = ["GPS", "Galileo", "QZSS"]
 [positioning.clas]
 grid_selection_radius = 1000    # CLAS grid selection radius (m)
 receiver_type = "TRIMBLE NETR9" # reference receiver type for ISB
-position_uncertainty_x = 10.0
-position_uncertainty_y = 10.0
-position_uncertainty_z = 10.0
 
 [positioning.snr_mask]
 rover_enabled = true

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -76,9 +76,6 @@ TOML section: `[positioning.clas]`
 | `grid_selection_radius` | integer | PPP-RTK, VRS | CLAS grid search radius (m). Controls how far from the rover to search for grid-based tropospheric/ionospheric corrections. |
 | `receiver_type` | string | PPP-RTK, VRS | Rover receiver type identifier. Used for ISB (inter-system bias) table lookup. |
 | `enhanced_spp_seed` | enum | PPP-RTK | Enhanced SPP seed for CLAS PPP-RTK reconvergence. Selects the code / Doppler QC stack used to seed the float filter after outages (opt-in; the default base seed uses C/N0 + TDCP). `off` · `cn0+tdcp` · `cn0+tdcp+robust` |
-| `position_uncertainty_x` | float | PPP-RTK, VRS | Rover approximate position X in ECEF (m). Used for initial CLAS grid search before first fix. |
-| `position_uncertainty_y` | float | PPP-RTK, VRS | Rover approximate position Y in ECEF (m). |
-| `position_uncertainty_z` | float | PPP-RTK, VRS | Rover approximate position Z in ECEF (m). |
 
 ## Positioning — SNR Mask
 

--- a/scripts/docs/gen_config_ref.py
+++ b/scripts/docs/gen_config_ref.py
@@ -137,12 +137,6 @@ _OPTION_META: dict[str, tuple[str, str]] = {
         "Enhanced SPP seed for CLAS PPP-RTK reconvergence. Selects the code / Doppler QC stack used to seed the "
         "float filter after outages (opt-in; the default base seed uses C/N0 + TDCP).",
     ),
-    "pos1-rux": (
-        "PPP-RTK, VRS",
-        "Rover approximate position X in ECEF (m). Used for initial CLAS grid search before first fix.",
-    ),
-    "pos1-ruy": ("PPP-RTK, VRS", "Rover approximate position Y in ECEF (m)."),
-    "pos1-ruz": ("PPP-RTK, VRS", "Rover approximate position Z in ECEF (m)."),
     # ── positioning.snr_mask ─────────────────────────────────────────────────
     "pos1-snrmask_r": ("All", "Enable elevation-dependent SNR mask for the rover receiver."),
     "pos1-snrmask_b": ("RTK", "Enable elevation-dependent SNR mask for the base station."),

--- a/scripts/tools/conf2toml.py
+++ b/scripts/tools/conf2toml.py
@@ -56,9 +56,6 @@ MAPPING: list[tuple[str, str, str, str]] = [
     ("pos1-gridsel", "positioning.clas", "grid_selection_radius", "int"),
     ("pos1-rectype", "positioning.clas", "receiver_type", "str"),
     ("pos1-seedenh", "positioning.clas", "enhanced_spp_seed", "enum"),
-    ("pos1-rux", "positioning.clas", "position_uncertainty_x", "float"),
-    ("pos1-ruy", "positioning.clas", "position_uncertainty_y", "float"),
-    ("pos1-ruz", "positioning.clas", "position_uncertainty_z", "float"),
     # ── positioning.snr_mask ─────────────────────────────────────────────────
     ("pos1-snrmask_r", "positioning.snr_mask", "rover_enabled", "bool"),
     ("pos1-snrmask_b", "positioning.snr_mask", "base_enabled", "bool"),

--- a/src/core/mrtk_toml.c
+++ b/src/core/mrtk_toml.c
@@ -48,9 +48,6 @@ static const toml_map_t toml_mapping[] = {
     {"positioning.clas", "grid_selection_radius", "pos1-gridsel"},
     {"positioning.clas", "receiver_type", "pos1-rectype"},
     {"positioning.clas", "enhanced_spp_seed", "pos1-seedenh"},
-    {"positioning.clas", "position_uncertainty_x", "pos1-rux"},
-    {"positioning.clas", "position_uncertainty_y", "pos1-ruy"},
-    {"positioning.clas", "position_uncertainty_z", "pos1-ruz"},
 
     /* ── positioning.snr_mask ──────────────────────────────────────────────── */
     {"positioning.snr_mask", "rover_enabled", "pos1-snrmask_r"},

--- a/src/pos/mrtk_options.c
+++ b/src/pos/mrtk_options.c
@@ -123,9 +123,6 @@ opt_t sysopts[] = {
     {"pos1-posopt13", 3, (void*)&prcopt_.posopt[12], FRQOPT2}, /* qzs freq (l1+l2/l1+l5) */
     {"pos1-gridsel", 0, (void*)&prcopt_.gridsel, "m"},
     {"pos1-rectype", 2, (void*)prcopt_.rectype[0], ""},
-    {"pos1-rux", 1, (void*)&prcopt_.ru[0], ""},
-    {"pos1-ruy", 1, (void*)&prcopt_.ru[1], ""},
-    {"pos1-ruz", 1, (void*)&prcopt_.ru[2], ""},
     {"pos1-signals", 2, (void*)signals_, ""},
 
     {"pos2-armode", 3, (void*)&prcopt_.modear, ARMOPT},


### PR DESCRIPTION
## Summary

- remove the CLAS TOML position uncertainty keys that incorrectly wrote fixed-mode rover ECEF coordinates (`prcopt_t.ru[]`)
- remove the corresponding legacy option registrations and conf-to-TOML conversion mappings
- remove the keys from bundled CLAS configurations and generated configuration reference

`[antenna.rover]` remains the supported path for fixed rover positions.

Closes #262

## Verification

- `cmake --build build --parallel 2`
- `ctest --test-dir build --output-on-failure -R "^utest_"` (22/22)
- regenerated config reference is clean
- TOML syntax validation for 14 CLAS configs