### PR TITLE
docs(config): correct phase windup and Shapiro applicability

### DIFF
--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -97,12 +97,12 @@ TOML section: `[positioning.corrections]`
 |:---------|:-----|:------|:------------|
 | `satellite_antenna` | boolean | All | Apply satellite antenna phase center offset correction using ANTEX file. |
 | `receiver_antenna` | boolean | All | Apply receiver antenna phase center offset/variation correction. |
-| `phase_windup` | enum | PPP, PPP-RTK, VRS | Phase wind-up correction. `off` · `on` · `precise` |
+| `phase_windup` | enum | PPP | Phase wind-up correction. `off` · `on` · `precise` |
 | `exclude_eclipse` | boolean | PPP, PPP-RTK | Exclude satellites in eclipse (yaw maneuver period) to avoid degraded orbit/clock. |
 | `raim_fde` | boolean | SPP | RAIM fault detection and exclusion for single-point positioning. |
 | `iono_compensation` | enum | PPP-RTK, VRS, SSR2OSR | Ionospheric compensation method for SSR-based processing. `off` · `ssr` · `meas` |
 | `partial_ar` | boolean | PPP-RTK, VRS | Enable partial ambiguity resolution (fix a satellite subset). |
-| `shapiro_delay` | boolean | PPP, PPP-RTK, VRS | Apply relativistic Shapiro time delay correction. |
+| `shapiro_delay` | boolean | PPP-RTK, VRS | Apply relativistic Shapiro time delay correction. |
 | `exclude_qzs_ref` | boolean | PPP-RTK, VRS | Exclude QZS satellites from reference satellite selection in DD processing. |
 | `no_phase_bias_adj` | boolean | PPP-RTK, VRS | Disable phase bias adjustment. Used when phase bias is already applied by SSR corrections. |
 | `gps_frequency` | enum | PPP-RTK, VRS | GPS frequency pair selection for CLAS processing. `l1` · `l1+l2` · `l1+l5` · `l1+l2+l5` · `l1+l5(l2)` |

--- a/scripts/docs/gen_config_ref.py
+++ b/scripts/docs/gen_config_ref.py
@@ -149,7 +149,7 @@ _OPTION_META: dict[str, tuple[str, str]] = {
         "Apply satellite antenna phase center offset correction using ANTEX file.",
     ),
     "pos1-posopt2": ("All", "Apply receiver antenna phase center offset/variation correction."),
-    "pos1-posopt3": ("PPP, PPP-RTK, VRS", "Phase wind-up correction."),
+    "pos1-posopt3": ("PPP", "Phase wind-up correction."),
     "pos1-posopt4": (
         "PPP, PPP-RTK",
         "Exclude satellites in eclipse (yaw maneuver period) to avoid degraded orbit/clock.",
@@ -163,7 +163,7 @@ _OPTION_META: dict[str, tuple[str, str]] = {
         "PPP-RTK, VRS",
         "Enable partial ambiguity resolution (fix a satellite subset).",
     ),
-    "pos1-posopt8": ("PPP, PPP-RTK, VRS", "Apply relativistic Shapiro time delay correction."),
+    "pos1-posopt8": ("PPP-RTK, VRS", "Apply relativistic Shapiro time delay correction."),
     "pos1-posopt9": (
         "PPP-RTK, VRS",
         "Exclude QZS satellites from reference satellite selection in DD processing.",


### PR DESCRIPTION
## Summary

- document `phase_windup` as applicable to PPP only
- document `shapiro_delay` as applicable to PPP-RTK and VRS only
- regenerate the configuration options reference

Closes #268

## Verification

- `python3 scripts/docs/gen_config_ref.py | cmp -s - docs/reference/config-options.md`
- `python3 -m py_compile scripts/docs/gen_config_ref.py`
- `ruff format --check scripts/docs/gen_config_ref.py`