### PR TITLE
chore(tests): keep RT CLAS references in build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -705,6 +705,7 @@ set_tests_properties(madocalib_pppar_abs_check PROPERTIES
 #   rtkrcv_rt_clas          Real-time CLAS PPP-RTK (BINEX+L6, rtkrcv file replay)
 #   rtkrcv_rt_clas_2ch      Real-time CLAS PPP-RTK dual-channel L6 (rtkrcv file replay)
 set(_CLSDATA  ${CMAKE_SOURCE_DIR}/tests/data/claslib)
+set(_CLSRTREFDATA ${CMAKE_BINARY_DIR}/tests/data/claslib)
 set(_COMPARE_NMEA ${CMAKE_SOURCE_DIR}/scripts/tests/compare_nmea.py)
 # GSI F5 daily-coordinate truth for station 0627 (TSUKUBA3), used by the
 # *_abs_check tests.  2019 = F3/ITRF2005, 2025 = F5/ITRF2014 (set as _F5_0627
@@ -714,7 +715,11 @@ set(_F5_0627_2019 ${_CLSDATA}/960627.19.pos)
 
 # ── Fixture: extract / clean claslib test data archive ────────────────────────
 add_test(NAME claslib_setup
-    COMMAND bash -c "tar xzf ${_CLSDATA}/claslib_testdata.tar.gz -C ${_CLSDATA}"
+    COMMAND bash -c "tar xzf ${_CLSDATA}/claslib_testdata.tar.gz \
+        --exclude=ref_L6_2CH_RT.nmea --exclude=rtkrcv_clas_ref.nmea -C ${_CLSDATA} && \
+        mkdir -p ${_CLSRTREFDATA} && \
+        tar xzf ${_CLSDATA}/claslib_testdata.tar.gz -C ${_CLSRTREFDATA} \
+        ref_L6_2CH_RT.nmea rtkrcv_clas_ref.nmea"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 set_tests_properties(claslib_setup PROPERTIES
@@ -753,8 +758,8 @@ add_test(NAME claslib_cleanup
         ${_CLSDATA}/0627157U.bnx.tag \
         ${_CLSDATA}/2025157U_ch1.l6.tag \
         ${_CLSDATA}/2025157U_ch2.l6.tag \
-        ${_CLSDATA}/rtkrcv_clas_ref.nmea \
-        ${_CLSDATA}/ref_L6_2CH_RT.nmea"
+        ${_CLSRTREFDATA}/rtkrcv_clas_ref.nmea \
+        ${_CLSRTREFDATA}/ref_L6_2CH_RT.nmea"
 )
 set_tests_properties(claslib_cleanup PROPERTIES
     FIXTURES_CLEANUP claslib_data
@@ -1381,7 +1386,7 @@ add_test(NAME rtkrcv_rt_clas
     COMMAND bash ${_TESTCMAKE}/run_rtkrcv_test.sh
         $<TARGET_FILE:mrtk> run
         ${CMAKE_SOURCE_DIR}
-        ${_CLSDATA}/rtkrcv_clas_ref.nmea
+        ${_CLSRTREFDATA}/rtkrcv_clas_ref.nmea
         10
         conf/claslib/rtkrcv.toml
         52005
@@ -1403,7 +1408,7 @@ add_test(NAME rtkrcv_rt_clas_2ch
     COMMAND bash ${_TESTCMAKE}/run_rtkrcv_test.sh
         $<TARGET_FILE:mrtk> run
         ${CMAKE_SOURCE_DIR}
-        ${_CLSDATA}/ref_L6_2CH_RT.nmea
+        ${_CLSRTREFDATA}/ref_L6_2CH_RT.nmea
         10
         conf/claslib/rtkrcv_2ch.toml
         52006

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -715,10 +715,10 @@ set(_F5_0627_2019 ${_CLSDATA}/960627.19.pos)
 
 # ── Fixture: extract / clean claslib test data archive ────────────────────────
 add_test(NAME claslib_setup
-    COMMAND bash -c "tar xzf ${_CLSDATA}/claslib_testdata.tar.gz \
-        --exclude=ref_L6_2CH_RT.nmea --exclude=rtkrcv_clas_ref.nmea -C ${_CLSDATA} && \
-        mkdir -p ${_CLSRTREFDATA} && \
-        tar xzf ${_CLSDATA}/claslib_testdata.tar.gz -C ${_CLSRTREFDATA} \
+    COMMAND bash -c "tar xzf \"${_CLSDATA}/claslib_testdata.tar.gz\" \
+        --exclude=ref_L6_2CH_RT.nmea --exclude=rtkrcv_clas_ref.nmea -C \"${_CLSDATA}\" && \
+        mkdir -p \"${_CLSRTREFDATA}\" && \
+        tar xzf \"${_CLSDATA}/claslib_testdata.tar.gz\" -C \"${_CLSRTREFDATA}\" \
         ref_L6_2CH_RT.nmea rtkrcv_clas_ref.nmea"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
@@ -758,8 +758,8 @@ add_test(NAME claslib_cleanup
         ${_CLSDATA}/0627157U.bnx.tag \
         ${_CLSDATA}/2025157U_ch1.l6.tag \
         ${_CLSDATA}/2025157U_ch2.l6.tag \
-        ${_CLSRTREFDATA}/rtkrcv_clas_ref.nmea \
-        ${_CLSRTREFDATA}/ref_L6_2CH_RT.nmea"
+        \"${_CLSRTREFDATA}/rtkrcv_clas_ref.nmea\" \
+        \"${_CLSRTREFDATA}/ref_L6_2CH_RT.nmea\""
 )
 set_tests_properties(claslib_cleanup PROPERTIES
     FIXTURES_CLEANUP claslib_data


### PR DESCRIPTION
## Summary

- extract the two RT CLAS NMEA reference files into `${CMAKE_BINARY_DIR}/tests/data/claslib`
- keep the remaining CLAS fixture data extraction unchanged
- make the RT CLAS tests and fixture cleanup use the build-directory references

This prevents CTest from leaving these untracked reference files in `tests/data/claslib/`.

Closes #269

## Verification

- `cmake -S . -B build`
- `ctest --test-dir build --output-on-failure -R "^claslib_setup$"`
- verified the NMEA references are created under `build/tests/data/claslib/`, not under `tests/data/claslib/`
- `ctest --test-dir build --output-on-failure -R "^claslib_cleanup$"`
- verified fixture cleanup removes the build-directory references