### PR TITLE
fix(config): remove noop hold ambiguity gain option

### DIFF
--- a/src/pos/mrtk_options.c
+++ b/src/pos/mrtk_options.c
@@ -180,7 +180,6 @@ opt_t sysopts[] = {
     {"pos2-arminholdsats", 0, (void*)&prcopt_.minholdsats, ""},
     {"pos2-arfilter", 3, (void*)&prcopt_.arfilter, SWTOPT},
     {"pos2-gpsarmode", 3, (void*)&prcopt_.gpsmodear, SWTOPT},
-    {"pos2-gainholdamb", 1, (void*)&prcopt_.gainholdamb, ""},
     {"pos2-rejionno1", 1, (void*)&prcopt_.maxinno_ext[0], "sigma"},
     {"pos2-rejionno2", 1, (void*)&prcopt_.maxinno_ext[1], "sigma"},
     {"pos2-rejionno3", 1, (void*)&prcopt_.maxinno_ext[2], "sigma"},


### PR DESCRIPTION
## Summary

- remove the legacy `pos2-gainholdamb` option registration
- retain `prcopt_t.gainholdamb` for a future demo5 `holdamb()` port

The TOML mapping, converter, generated reference, and bundled configurations already omitted this no-op key. Removing the remaining registration prevents legacy configurations from silently accepting it.

Closes #265

## Verification

- `cmake --build build --parallel 2`
- `ctest --test-dir build --output-on-failure -R "^utest_"` (22/22)
- generated config reference is current
- no remaining `pos2-gainholdamb` registration