### PR TITLE
feat(clas): port periodic filter reset to ppp_rtk_pos() (#264)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -815,6 +815,41 @@ set_tests_properties(claslib_ppp_rtk_abs_check PROPERTIES
     LABELS            "absolute;claslib;ppp-rtk"
 )
 
+# ── CLAS PPP-RTK periodic filter reset (#264) ────────────────────────────────
+# reset_interval overlay forces a full reset every 600 s over the 1 h window
+# (5 resets). -x 3 writes the trace next to the output; the checker asserts the
+# resets fired, each showed as a Single epoch, and the filter re-converged.
+add_test(NAME claslib_ppp_rtk_regularly
+    COMMAND $<TARGET_FILE:mrtk> post
+        -x 3
+        -k ${CMAKE_SOURCE_DIR}/conf/claslib/rnx2rtkp.toml
+        -k ${CMAKE_SOURCE_DIR}/conf/claslib/rnx2rtkp_regularly.toml
+        -ts 2019/08/27 16:00:00 -te 2019/08/27 16:59:59 -ti 1
+        -o ${CMAKE_BINARY_DIR}/out_claslib_ppp_rtk_regularly.nmea
+        ${_CLSDATA}/0627239Q.obs
+        ${_CLSDATA}/sept_2019239.nav
+        ${_CLSDATA}/2019239Q.l6
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_tests_properties(claslib_ppp_rtk_regularly PROPERTIES
+    FIXTURES_REQUIRED claslib_data
+    TIMEOUT           300
+    LABELS            "regression;claslib;ppp-rtk"
+)
+
+add_test(NAME claslib_ppp_rtk_regularly_check
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/tests/check_regularly_reset.py
+        ${CMAKE_BINARY_DIR}/out_claslib_ppp_rtk_regularly.nmea
+        ${CMAKE_BINARY_DIR}/out_claslib_ppp_rtk_regularly.nmea.trace
+        --min-resets 4
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_tests_properties(claslib_ppp_rtk_regularly_check PROPERTIES
+    DEPENDS           claslib_ppp_rtk_regularly
+    FIXTURES_REQUIRED claslib_data
+    LABELS            "regression;claslib;ppp-rtk"
+)
+
 # ── rnx2rtkp CLAS PPP-RTK regression (L6, BINEX obs) ─────────────────────────
 # Data: 2019/08/27 16:00-17:00, 0627239Q.bnx + sept_2019239.nav + 2019239Q.l6
 # Reference: ref_L6_bnx.nmea (upstream claslib output)

--- a/conf/claslib/rnx2rtkp_regularly.toml
+++ b/conf/claslib/rnx2rtkp_regularly.toml
@@ -1,0 +1,13 @@
+# Overlay for the CLAS PPP-RTK periodic-reset regression (#264).
+#
+# Layered after rnx2rtkp.toml. It forces a full filter reset every 600 s so
+# the paired test can confirm that ppp_rtk_pos() honours reset_interval: the
+# trace must record each reset, the epoch of each reset must drop to a Single
+# solution, and the filter must re-converge to Float/Fixed afterwards.
+#
+# reset_interval was ported from upstream claslib (the VRS path already had
+# it). It is off by default (0), so this overlay is the only config that
+# exercises the branch.
+
+[positioning.clas.resilience]
+reset_interval = 600

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -338,7 +338,7 @@ TOML section: `[positioning.clas.resilience]`
 | `max_obs_loss` | float | PPP-RTK | Maximum observation gap duration before filter reset (s). |
 | `float_count` | integer | PPP-RTK, VRS | Number of float epochs before triggering filter reset. |
 | `l6_merge` | integer | PPP-RTK, VRS | L6 message merge mode for CLAS corrections. |
-| `reset_interval` | integer | VRS | Regular filter reset interval (s). 0 = disabled. |
+| `reset_interval` | integer | PPP-RTK, VRS | Regular filter reset interval (s). 0 = disabled. |
 
 ## Positioning — Relative
 

--- a/scripts/docs/gen_config_ref.py
+++ b/scripts/docs/gen_config_ref.py
@@ -549,7 +549,7 @@ _OPTION_META: dict[str, tuple[str, str]] = {
     "misc-pppopt": ("PPP", "PPP processing option string (passed to PPP engine)."),
     "misc-rtcmopt": ("RT, PP", "RTCM decoder option string."),
     "misc-l6mrg": ("PPP-RTK, VRS", "L6 message merge mode for CLAS corrections."),
-    "misc-regularly": ("VRS", "Regular filter reset interval (s). 0 = disabled."),
+    "misc-regularly": ("PPP-RTK, VRS", "Regular filter reset interval (s). 0 = disabled."),
     "misc-startcmd": ("RT", "Shell command executed on server start."),
     "misc-stopcmd": ("RT", "Shell command executed on server stop."),
 }

--- a/scripts/tests/check_regularly_reset.py
+++ b/scripts/tests/check_regularly_reset.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Assert that the CLAS PPP-RTK periodic filter reset (#264) fired and recovered.
+
+Given the trace and NMEA output of a CLAS run with reset_interval enabled,
+verify three things:
+
+1. The trace records at least ``--min-resets`` "regularly reset filter" lines.
+2. Each reset epoch appears in the NMEA output as a Single (GGA quality 1)
+   solution -- the filter state was zeroed at that epoch.
+3. The filter re-converges afterwards, i.e. Float/Fixed (quality >= 4) epochs
+   still dominate the run. A reset that never recovered would leave the rest
+   of the window in Single.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def gga_quality_counts(nmea: str) -> dict[int, int]:
+    """Count GGA sentences by their quality indicator (field 6)."""
+    counts: dict[int, int] = {}
+    for line in nmea.splitlines():
+        if "GGA," not in line:
+            continue
+        fields = line.split(",")
+        if len(fields) < 7 or not fields[6].isdigit():
+            continue
+        q = int(fields[6])
+        counts[q] = counts.get(q, 0) + 1
+    return counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("solution", type=Path, help="NMEA .pos output")
+    parser.add_argument("trace", type=Path, help="MRTKLIB trace output")
+    parser.add_argument("--min-resets", type=int, default=4)
+    args = parser.parse_args()
+
+    trace = args.trace.read_text(encoding="utf-8", errors="replace")
+    resets = trace.count("regularly reset filter")
+    if resets < args.min_resets:
+        print(f"FAIL: expected >= {args.min_resets} periodic resets, trace has {resets}")
+        return 1
+
+    counts = gga_quality_counts(args.solution.read_text(encoding="utf-8", errors="replace"))
+    singles = counts.get(1, 0)
+    converged = counts.get(4, 0) + counts.get(5, 0)
+
+    if singles < args.min_resets:
+        print(f"FAIL: expected >= {args.min_resets} Single epochs (one per reset), found {singles}")
+        return 1
+    if converged <= singles:
+        print(
+            f"FAIL: filter did not recover after resets (Float/Fixed={converged}, Single={singles})"
+        )
+        return 1
+
+    print(
+        f"PASS: {resets} resets fired; {singles} Single epochs recovered to {converged} Float/Fixed"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/check_regularly_reset.py
+++ b/scripts/tests/check_regularly_reset.py
@@ -2,15 +2,19 @@
 """Assert that the CLAS PPP-RTK periodic filter reset (#264) fired and recovered.
 
 Given the trace and NMEA output of a CLAS run with reset_interval enabled,
-verify three things:
+verify three aggregate properties (counts over the whole run, not a per-epoch
+correlation):
 
 1. The trace records at least ``--min-resets`` "regularly reset filter" lines.
-2. Each reset epoch appears in the NMEA output as a Single (GGA quality 1)
-   solution -- the filter state was zeroed at that epoch.
-3. The filter re-converges afterwards, i.e. Float/Fixed (quality >= 4) epochs
-   still dominate the run. A reset that never recovered would leave the rest
-   of the window in Single.
+2. At least ``--min-resets`` Single (GGA quality 1) epochs are present -- each
+   reset zeroes the filter state and emits a Single solution that epoch, so a
+   reset that fired must leave a Single behind.
+3. The filter re-converges: Float/Fixed (quality >= 4) epochs outnumber the
+   Single epochs. A reset that never recovered would leave the rest of the
+   window in Single.
 """
+
+from __future__ import annotations
 
 import argparse
 import sys

--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -2245,6 +2245,7 @@ static void check_clas_facility(nav_t* nav, const clas_ctx_t* clas, const clas_g
  * @param[in,out] nav  Navigation data (includes SSR via nav->ssr_ch[][])
  */
 extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
+    static gtime_t regularly = {-1, 0.0};
     prcopt_t* opt = &rtk->opt;
     clas_ctx_t* clas;
     clas_grid_t* grid;
@@ -2295,6 +2296,30 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
         for (i = 0; i < rtk->nx; i++) {
             rtk->x[i] = 0.0;
         }
+    }
+
+    /* periodic filter reset: force a full state reset every opt->regularly
+     * seconds (0 = disabled). Ported from upstream claslib ppp_rtk_pos()
+     * (#264); mirrors the already-ported VRS path in relposvrs(). Returns
+     * early to skip the epoch, so the buffers allocated above must be freed
+     * here (unlike VRS, which allocates them after this check). */
+    regularly = (regularly.time == -1 ? obs[0].time : regularly);
+    if (opt->regularly != 0 && timediff(obs[0].time, regularly) >= (double)opt->regularly) {
+        trace(NULL, 1, "ppp_rtk_pos: regularly reset filter, tow=%.1f\n", time2gpst(obs[0].time, NULL));
+        for (i = 0; i < rtk->nx; i++) {
+            rtk->x[i] = 0.0;
+        }
+        rtk->sol.stat = SOLQ_SINGLE;
+        regularly = obs[0].time;
+        nav->filreset = 0;
+        prtk_ctx.float_count = 0;
+        free(azel);
+        free(e);
+        free(y);
+        free(rs);
+        free(dts);
+        free(var);
+        return;
     }
 
     /* reset filter if consecutive FLOAT epochs exceed floatcnt threshold */


### PR DESCRIPTION
## Summary

Closes #264. Upstream claslib `ppp_rtk_pos()` resets the filter every `opt->regularly` seconds, but only the VRS sibling (`relposvrs()`) was ported to MRTKLIB. `ppp_rtk_pos()` carried the `maxobsloss` and `filreset` resets but not the periodic one, so `reset_interval` (TOML `[positioning.clas.resilience].reset_interval`) silently did nothing in CLAS PPP-RTK.

This ports the missing block, using the already-ported VRS path as the template.

## What changed

- **`src/pos/mrtk_ppp_rtk.c`** — insert the periodic-reset block right after the `maxobsloss` reset (upstream ordering). On a reset: zero all states, set the solution to `SOLQ_SINGLE`, refresh the timer, and return early.
  - MRTKLIB-specific: `ppp_rtk_pos()` allocates its work buffers **before** this check (VRS allocates them after), so the early return frees `azel/e/y/rs/dts/var` exactly like the existing early-return paths.
  - Set `nav->filreset = 0` directly (MRTKLIB convention; the upstream `resetfilterflag()` wraps a no-op `clearsatcorr()`), and reset `prtk_ctx.float_count` so the float-persistence counter restarts after the hard reset. `clear_current_cssr()` is omitted, matching the VRS port.
- **Test** — `claslib_ppp_rtk_regularly` + `scripts/tests/check_regularly_reset.py` assert the reset actually fires and the filter recovers (trace reset count, Single epochs, recovery to Float/Fixed). Overlay `conf/claslib/rnx2rtkp_regularly.toml`.
- **Docs** — `reset_interval` Modes updated `VRS` → `PPP-RTK, VRS` now that `ppp_rtk_pos()` reads it; `config-options.md` regenerated (drift gate green).

## Verification

- **Default off is bit-identical.** `reset_interval` defaults to 0 and no bundled config sets it, so the gate is skipped entirely. CLAS PP regression: **28/28 pass**.
- **Enabled fires and recovers.** With `reset_interval = 600` over the 1 h claslib window, the reset fires **5×** at exact 600 s intervals (tow 231020/231620/232220/232820/233420). Each reset epoch drops to Single (GGA Q=1) and re-converges to Float→Fixed within a few seconds. 3580 epochs complete with no leak/crash.

The one unrelated ctest failure (`rtkrcv_rt_clas_2ch`) is the known perennial RT-port-contention flaky, not touched by this change.

## Note

This adds a new filter-reset path (algorithm change), gated off by default. Discovered during the config Modes audit that also produced #257–#266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)