### PR TITLE
refactor(toml): nest adaptive_filter under CLAS and regroup config reference

### DIFF
--- a/conf/benchmark/clas.toml
+++ b/conf/benchmark/clas.toml
@@ -100,7 +100,7 @@ troposphere = 0.001
 iono_time_const = 10.0
 clock_stability = 5.00e-12
 
-[adaptive_filter]
+[positioning.clas.adaptive_filter]
 iono_forgetting = 0.3
 iono_gain = 3.0
 enabled = false

--- a/conf/claslib/rnx2rtkp.toml
+++ b/conf/claslib/rnx2rtkp.toml
@@ -99,7 +99,7 @@ troposphere = 0.001        # process-noise std trop(m)
 iono_time_const = 10.0     # time constant of ionosphere variation (s)
 clock_stability = 5.00e-12 # (s/s)
 
-[adaptive_filter]
+[positioning.clas.adaptive_filter]
 iono_forgetting = 0.3 # forgetting factor of iono (0.0~1.0)
 iono_gain = 3.0       # adaptive filter gain in iono estimation
 enabled = false       # adjust adaptively pos/vel/acc process noise (0:off,1:on)

--- a/conf/claslib/rnx2rtkp_L1CL5.toml
+++ b/conf/claslib/rnx2rtkp_L1CL5.toml
@@ -100,7 +100,7 @@ troposphere = 0.001        # process-noise std trop(m)
 iono_time_const = 10.0     # time constant of ionosphere variation (s)
 clock_stability = 5.00e-12 # (s/s)
 
-[adaptive_filter]
+[positioning.clas.adaptive_filter]
 iono_forgetting = 0.3 # forgetting factor of iono (0.0~1.0)
 iono_gain = 3.0       # adaptive filter gain in iono estimation
 enabled = false       # adjust adaptively pos/vel/acc process noise (0:off,1:on)

--- a/conf/claslib/rnx2rtkp_f9p.toml
+++ b/conf/claslib/rnx2rtkp_f9p.toml
@@ -103,7 +103,7 @@ troposphere = 0.001        # process-noise std trop(m)
 iono_time_const = 10.0     # time constant of ionosphere variation (s)
 clock_stability = 5.00e-12 # (s/s)
 
-[adaptive_filter]
+[positioning.clas.adaptive_filter]
 iono_forgetting = 0.3 # forgetting factor of iono (0.0~1.0)
 iono_gain = 3.0       # adaptive filter gain in iono estimation
 enabled = false       # adjust adaptively pos/vel/acc process noise (0:off,1:on)

--- a/conf/claslib/rnx2rtkp_sf.toml
+++ b/conf/claslib/rnx2rtkp_sf.toml
@@ -104,7 +104,7 @@ troposphere = 0.001        # process-noise std trop(m)
 iono_time_const = 10.0     # time constant of ionosphere variation (s)
 clock_stability = 5.00e-12 # (s/s)
 
-[adaptive_filter]
+[positioning.clas.adaptive_filter]
 iono_forgetting = 0.3 # forgetting factor of iono (0.0~1.0)
 iono_gain = 3.0       # adaptive filter gain in iono estimation
 enabled = false       # adjust adaptively pos/vel/acc process noise (0:off,1:on)

--- a/conf/claslib/rnx2rtkp_vrs.toml
+++ b/conf/claslib/rnx2rtkp_vrs.toml
@@ -96,7 +96,7 @@ troposphere = 0.001        # process-noise std trop(m)
 iono_time_const = 10.0     # time constant of ionosphere variation (s)
 clock_stability = 5.00e-12 # (s/s)
 
-[adaptive_filter]
+[positioning.clas.adaptive_filter]
 iono_forgetting = 0.3 # forgetting factor of iono (0.0~1.0)
 iono_gain = 3.0       # adaptive filter gain in iono estimation
 enabled = false       # adjust adaptively pos/vel/acc process noise (0:off,1:on)

--- a/conf/claslib/rnx2rtkp_vrs_g5p3.toml
+++ b/conf/claslib/rnx2rtkp_vrs_g5p3.toml
@@ -96,7 +96,7 @@ troposphere = 0.001        # process-noise std trop(m)
 iono_time_const = 10.0     # time constant of ionosphere variation (s)
 clock_stability = 5.00e-12 # (s/s)
 
-[adaptive_filter]
+[positioning.clas.adaptive_filter]
 iono_forgetting = 0.3 # forgetting factor of iono (0.0~1.0)
 iono_gain = 3.0       # adaptive filter gain in iono estimation
 enabled = false       # adjust adaptively pos/vel/acc process noise (0:off,1:on)

--- a/conf/claslib/rtkrcv.toml
+++ b/conf/claslib/rtkrcv.toml
@@ -100,7 +100,7 @@ troposphere = 0.001        # (m)
 iono_time_const = 10.0     # (s)
 clock_stability = 5.00e-12 # (s/s)
 
-[adaptive_filter]
+[positioning.clas.adaptive_filter]
 iono_forgetting = 0.3 # iono forgetting factor
 iono_gain = 3.0       # iono adaptive filter gain
 enabled = false

--- a/conf/claslib/rtkrcv_2ch.toml
+++ b/conf/claslib/rtkrcv_2ch.toml
@@ -100,7 +100,7 @@ troposphere = 0.001        # (m)
 iono_time_const = 10.0     # (s)
 clock_stability = 5.00e-12 # (s/s)
 
-[adaptive_filter]
+[positioning.clas.adaptive_filter]
 iono_forgetting = 0.3 # iono forgetting factor
 iono_gain = 3.0       # iono adaptive filter gain
 enabled = false

--- a/conf/claslib/rtkrcv_mosaic_g5.toml
+++ b/conf/claslib/rtkrcv_mosaic_g5.toml
@@ -119,7 +119,7 @@ gps = 0     # L1/L2
 qzs = 1     # L1/L2
 galileo = 0 # E1/E5a
 
-[adaptive_filter]
+[positioning.clas.adaptive_filter]
 iono_forgetting = 0.3
 iono_gain = 3.0
 enabled = false

--- a/conf/claslib/rtkrcv_rtcm3_ubx.toml
+++ b/conf/claslib/rtkrcv_rtcm3_ubx.toml
@@ -100,7 +100,7 @@ troposphere = 0.001        # (m)
 iono_time_const = 10.0     # (s)
 clock_stability = 5.00e-12 # (s/s)
 
-[adaptive_filter]
+[positioning.clas.adaptive_filter]
 iono_forgetting = 0.3 # iono forgetting factor
 iono_gain = 3.0       # iono adaptive filter gain
 enabled = false

--- a/conf/claslib/rtkrcv_sbf_l6d.toml
+++ b/conf/claslib/rtkrcv_sbf_l6d.toml
@@ -100,7 +100,7 @@ troposphere = 0.001        # (m)
 iono_time_const = 10.0     # (s)
 clock_stability = 5.00e-12 # (s/s)
 
-[adaptive_filter]
+[positioning.clas.adaptive_filter]
 iono_forgetting = 0.3 # iono forgetting factor
 iono_gain = 3.0       # iono adaptive filter gain
 enabled = false

--- a/conf/claslib/rtkrcv_ubx_clas.toml
+++ b/conf/claslib/rtkrcv_ubx_clas.toml
@@ -108,7 +108,7 @@ troposphere = 0.001
 iono_time_const = 10.0
 clock_stability = 5.00e-12
 
-[adaptive_filter]
+[positioning.clas.adaptive_filter]
 iono_forgetting = 0.3
 iono_gain = 3.0
 enabled = false

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -18,7 +18,7 @@ Options are grouped by their TOML section.
 | **PPP** | `ppp-kine` · `ppp-static` · `ppp-fixed` |
 | **PPP-RTK** | `ppp-rtk` (CLAS PPP-RTK) |
 | **SSR2OSR** | `ssr2osr` · `ssr2osr-fixed` |
-| **VRS** | `vrs-rtk` |
+| **VRS** | `vrs-rtk` — a CLAS-only mode: it builds CLAS-derived OSR and double-differences it like RTK (`correction = qzs-clas`, not a generic RTK base station). |
 | **RT** | Real-time only (`mrtk run` / `rtkrcv`) |
 | **PP** | Post-processing only (`mrtk post` / `rnx2rtkp`) |
 
@@ -67,16 +67,6 @@ Each slot maps to a different signal depending on the constellation:
     adds the E5b slot without valid bias, causing false cycle slips on
     Galileo and degrading fix rate from >99% to ~67%.
 
-## Positioning — CLAS
-
-TOML section: `[positioning.clas]`
-
-| TOML Key | Type | Modes | Description |
-|:---------|:-----|:------|:------------|
-| `grid_selection_radius` | integer | PPP-RTK, VRS | CLAS grid search radius (m). Controls how far from the rover to search for grid-based tropospheric/ionospheric corrections. |
-| `receiver_type` | string | PPP-RTK, VRS | Rover receiver type identifier. Used for ISB (inter-system bias) table lookup. |
-| `enhanced_spp_seed` | enum | PPP-RTK | Enhanced SPP seed for CLAS PPP-RTK reconvergence. Selects the code / Doppler QC stack used to seed the float filter after outages (opt-in; the default base seed uses C/N0 + TDCP). `off` · `cn0+tdcp` · `cn0+tdcp+robust` |
-
 ## Positioning — SNR Mask
 
 TOML section: `[positioning.snr_mask]`
@@ -88,6 +78,15 @@ TOML section: `[positioning.snr_mask]`
 | `L1` | array[int] | All | L1 SNR mask values per elevation bin (dBHz). 9-element array (0–45 dBHz per 5° elevation bin). |
 | `L2` | array[int] | All | L2 SNR mask values per elevation bin (dBHz). 9-element array (0–45 dBHz per 5° elevation bin). |
 | `L5` | array[int] | All | L5 SNR mask values per elevation bin (dBHz). 9-element array (0–45 dBHz per 5° elevation bin). |
+
+## Positioning — Atmosphere
+
+TOML section: `[positioning.atmosphere]`
+
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `ionosphere` | enum | All | Ionospheric correction model. PPP uses `dual-freq` or `est-stec`. PPP-RTK uses `est-stec` or `est-adaptive`. RTK typically uses `dual-freq`. `off` · `brdc` · `sbas` · `dual-freq` · `est-stec` · `ionex-tec` · `qzs-brdc` · `est-adaptive` |
+| `troposphere` | enum | All | Tropospheric correction model. PPP/PPP-RTK use `est-ztd` or `est-ztdgrad`. SPP/RTK typically use `saas`. `off` · `saas` · `sbas` · `est-ztd` · `est-ztdgrad` |
 
 ## Positioning — Corrections
 
@@ -110,14 +109,102 @@ TOML section: `[positioning.corrections]`
 | `qzs_frequency` | enum | PPP-RTK, VRS | QZS frequency pair selection for CLAS processing. `l1` · `l1+l2` · `l1+l5` · `l1+l2+l5` · `l1+l5(l2)` |
 | `tidal_correction` | enum | PPP, PPP-RTK, VRS | Tidal displacement correction. Option `solid+otl-clasgrid+pole` uses CLAS grid-based ocean tide loading. `off` · `on` · `otl` · `solid+otl-clasgrid+pole` |
 
-## Positioning — Atmosphere
+## Positioning — SPP
 
-TOML section: `[positioning.atmosphere]`
+TOML section: `[positioning.spp]`
 
 | TOML Key | Type | Modes | Description |
 |:---------|:-----|:------|:------------|
-| `ionosphere` | enum | All | Ionospheric correction model. PPP uses `dual-freq` or `est-stec`. PPP-RTK uses `est-stec` or `est-adaptive`. RTK typically uses `dual-freq`. `off` · `brdc` · `sbas` · `dual-freq` · `est-stec` · `ionex-tec` · `qzs-brdc` · `est-adaptive` |
-| `troposphere` | enum | All | Tropospheric correction model. PPP/PPP-RTK use `est-ztd` or `est-ztdgrad`. SPP/RTK typically use `saas`. `off` · `saas` · `sbas` · `est-ztd` · `est-ztdgrad` |
+| `ignore_chi_error` | boolean | SPP | Ignore chi-square test errors in SPP solution validation. |
+
+## Positioning — Relative
+
+TOML section: `[positioning.relative]`
+
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `max_age` | float | RTK, VRS | Maximum age of differential correction (s). |
+| `baseline_length` | float | RTK | Baseline length constraint (m). 0 = no constraint. |
+| `baseline_sigma` | float | RTK | Standard deviation of baseline length constraint (m). |
+| `time_interpolation` | boolean | RTK, VRS, PP | Enable time interpolation between observation epochs. |
+
+## Positioning — PPP
+
+TOML section: `[positioning.ppp]`
+
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `satellite_clock_bias` | integer | PPP | PPP satellite code bias source selection. |
+| `satellite_phase_bias` | integer | PPP | PPP satellite phase bias source selection. |
+| `drop_uncorrected_code` | boolean | PPP | In uncombined IGS PPP, discard a pseudorange measurement when its satellite or receiver code bias is unavailable. |
+| `clock_jump` | boolean | PPP | Reset PPP phase-bias states at a GPS day boundary. |
+| `max_bias_dt` | integer | PPP | Maximum age of bias correction data (s) before invalidation. |
+| `options` | string | PPP | PPP processing option string (passed to PPP engine). |
+
+## Positioning — Signal Selection
+
+TOML section: `[signals]`
+
+> **Legacy preset form.** These per-constellation presets are the older, coarser signal-selection surface (no per-code control, no GLONASS entry). Prefer [`[positioning].signals`](#positioning) for new configurations; when `signals` is set it overrides this section. GLONASS L2 code selection (e.g. L2C/A vs L2P) can only be expressed via `[positioning].signals`.
+
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `gps` | enum | PPP, PPP-RTK, VRS | GPS frequency pair selection for the SSR-corrected measurement model. Applied via `apply_pppsig()` for every correction source except `igs`, so it also reshapes the observation set used by CLAS PPP-RTK / VRS. `L1/L2` · `L1/L5` · `L1/L2/L5` |
+| `qzs` | enum | PPP, PPP-RTK, VRS | QZS frequency pair selection. `L1/L5` · `L1/L2` · `L1/L5/L2` |
+| `galileo` | enum | PPP, PPP-RTK, VRS | Galileo frequency pair selection. `E1/E5a` · `E1/E5b` · `E1/E6` · `E1/E5a/E5b/E6` · `E1/E5a/E6/E5b` |
+| `bds2` | enum | PPP, PPP-RTK, VRS | BDS-2 frequency pair selection. `B1I/B3I` · `B1I/B2I` · `B1I/B3I/B2I` |
+| `bds3` | enum | PPP, PPP-RTK, VRS | BDS-3 frequency pair selection. `B1I/B3I` · `B1I/B2a` · `B1I/B3I/B2a` |
+
+## Positioning — MADOCA
+
+TOML section: `[positioning.madoca]`
+
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `iono_correction` | boolean | PPP | Enable ionospheric correction in MADOCA-PPP processing. |
+
+## Positioning — CLAS
+
+TOML section: `[positioning.clas]`
+
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `grid_selection_radius` | integer | PPP-RTK, VRS | CLAS grid search radius (m). Controls how far from the rover to search for grid-based tropospheric/ionospheric corrections. |
+| `receiver_type` | string | PPP-RTK, VRS | Rover receiver type identifier. Used for ISB (inter-system bias) table lookup. |
+| `enhanced_spp_seed` | enum | PPP-RTK | Enhanced SPP seed for CLAS PPP-RTK reconvergence. Selects the code / Doppler QC stack used to seed the float filter after outages (opt-in; the default base seed uses C/N0 + TDCP). `off` · `cn0+tdcp` · `cn0+tdcp+robust` |
+
+## Positioning — CLAS Ambiguities
+
+TOML section: `[positioning.clas.ambiguities]`
+
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `phase_shift` | enum | PPP-RTK, VRS | Phase cycle shift correction. Corrects quarter-cycle shifts between systems. `off` · `table` |
+| `isb` | boolean | PPP-RTK, VRS | Inter-system bias estimation mode. |
+| `reference_type` | string | PPP-RTK, VRS | Reference station receiver type for ISB table lookup. |
+
+## Positioning — CLAS Resilience
+
+TOML section: `[positioning.clas.resilience]`
+
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `max_obs_loss` | float | PPP-RTK | Maximum observation gap duration before filter reset (s). |
+| `float_count` | integer | PPP-RTK, VRS | Number of float epochs before triggering filter reset. |
+| `l6_merge` | integer | PPP-RTK, VRS | L6 message merge mode for CLAS corrections. |
+| `reset_interval` | integer | PPP-RTK, VRS | Regular filter reset interval (s). 0 = disabled. |
+
+## Positioning — CLAS Adaptive Filter
+
+TOML section: `[positioning.clas.adaptive_filter]`
+
+| TOML Key | Type | Modes | Description |
+|:---------|:-----|:------|:------------|
+| `enabled` | boolean | PPP-RTK, VRS | Enable adaptive Kalman filter process noise scaling. |
+| `iono_forgetting` | float | PPP-RTK, VRS | Forgetting factor for ionospheric state (0–1). Lower = faster adaptation. |
+| `iono_gain` | float | PPP-RTK, VRS | Adaptive gain for ionospheric process noise adjustment. |
+| `pva_forgetting` | float | PPP-RTK, VRS | Forgetting factor for position/velocity/acceleration states (0–1). |
+| `pva_gain` | float | PPP-RTK, VRS | Adaptive gain for PVA process noise adjustment. |
 
 ## Ambiguity Resolution
 
@@ -263,93 +350,6 @@ TOML section: `[kalman_filter.process_noise]`
 | `ifb` | float | PPP | Inter-frequency bias process noise (m). For multi-frequency PPP bias estimation. |
 | `iono_time_const` | float | PPP-RTK, VRS | Ionospheric time constant (s). Controls iono state temporal correlation in the adaptive filter. |
 | `clock_stability` | float | RTK, VRS | Receiver clock stability (s/s). Used in clock state prediction. |
-
-## Adaptive Filter
-
-TOML section: `[adaptive_filter]`
-
-| TOML Key | Type | Modes | Description |
-|:---------|:-----|:------|:------------|
-| `enabled` | boolean | PPP-RTK, VRS | Enable adaptive Kalman filter process noise scaling. |
-| `iono_forgetting` | float | PPP-RTK, VRS | Forgetting factor for ionospheric state (0–1). Lower = faster adaptation. |
-| `iono_gain` | float | PPP-RTK, VRS | Adaptive gain for ionospheric process noise adjustment. |
-| `pva_forgetting` | float | PPP-RTK, VRS | Forgetting factor for position/velocity/acceleration states (0–1). |
-| `pva_gain` | float | PPP-RTK, VRS | Adaptive gain for PVA process noise adjustment. |
-
-## Signal Selection
-
-TOML section: `[signals]`
-
-> **Legacy preset form.** These per-constellation presets are the older, coarser signal-selection surface (no per-code control, no GLONASS entry). Prefer [`[positioning].signals`](#positioning) for new configurations; when `signals` is set it overrides this section. GLONASS L2 code selection (e.g. L2C/A vs L2P) can only be expressed via `[positioning].signals`.
-
-| TOML Key | Type | Modes | Description |
-|:---------|:-----|:------|:------------|
-| `gps` | enum | PPP, PPP-RTK | GPS frequency pair selection for PPP/PPP-RTK processing. `L1/L2` · `L1/L5` · `L1/L2/L5` |
-| `qzs` | enum | PPP, PPP-RTK | QZS frequency pair selection. `L1/L5` · `L1/L2` · `L1/L5/L2` |
-| `galileo` | enum | PPP, PPP-RTK | Galileo frequency pair selection. `E1/E5a` · `E1/E5b` · `E1/E6` · `E1/E5a/E5b/E6` · `E1/E5a/E6/E5b` |
-| `bds2` | enum | PPP, PPP-RTK | BDS-2 frequency pair selection. `B1I/B3I` · `B1I/B2I` · `B1I/B3I/B2I` |
-| `bds3` | enum | PPP, PPP-RTK | BDS-3 frequency pair selection. `B1I/B3I` · `B1I/B2a` · `B1I/B3I/B2a` |
-
-## Positioning — SPP
-
-TOML section: `[positioning.spp]`
-
-| TOML Key | Type | Modes | Description |
-|:---------|:-----|:------|:------------|
-| `ignore_chi_error` | boolean | SPP | Ignore chi-square test errors in SPP solution validation. |
-
-## Positioning — MADOCA
-
-TOML section: `[positioning.madoca]`
-
-| TOML Key | Type | Modes | Description |
-|:---------|:-----|:------|:------------|
-| `iono_correction` | boolean | PPP | Enable ionospheric correction in MADOCA-PPP processing. |
-
-## Positioning — PPP
-
-TOML section: `[positioning.ppp]`
-
-| TOML Key | Type | Modes | Description |
-|:---------|:-----|:------|:------------|
-| `satellite_clock_bias` | integer | PPP | PPP satellite code bias source selection. |
-| `satellite_phase_bias` | integer | PPP | PPP satellite phase bias source selection. |
-| `drop_uncorrected_code` | boolean | PPP | In uncombined IGS PPP, discard a pseudorange measurement when its satellite or receiver code bias is unavailable. |
-| `clock_jump` | boolean | PPP | Reset PPP phase-bias states at a GPS day boundary. |
-| `max_bias_dt` | integer | PPP | Maximum age of bias correction data (s) before invalidation. |
-| `options` | string | PPP | PPP processing option string (passed to PPP engine). |
-
-## Positioning — CLAS Ambiguities
-
-TOML section: `[positioning.clas.ambiguities]`
-
-| TOML Key | Type | Modes | Description |
-|:---------|:-----|:------|:------------|
-| `phase_shift` | enum | PPP-RTK, VRS | Phase cycle shift correction. Corrects quarter-cycle shifts between systems. `off` · `table` |
-| `isb` | boolean | PPP-RTK, VRS | Inter-system bias estimation mode. |
-| `reference_type` | string | PPP-RTK, VRS | Reference station receiver type for ISB table lookup. |
-
-## Positioning — CLAS Resilience
-
-TOML section: `[positioning.clas.resilience]`
-
-| TOML Key | Type | Modes | Description |
-|:---------|:-----|:------|:------------|
-| `max_obs_loss` | float | PPP-RTK | Maximum observation gap duration before filter reset (s). |
-| `float_count` | integer | PPP-RTK, VRS | Number of float epochs before triggering filter reset. |
-| `l6_merge` | integer | PPP-RTK, VRS | L6 message merge mode for CLAS corrections. |
-| `reset_interval` | integer | PPP-RTK, VRS | Regular filter reset interval (s). 0 = disabled. |
-
-## Positioning — Relative
-
-TOML section: `[positioning.relative]`
-
-| TOML Key | Type | Modes | Description |
-|:---------|:-----|:------|:------------|
-| `max_age` | float | RTK, VRS | Maximum age of differential correction (s). |
-| `baseline_length` | float | RTK | Baseline length constraint (m). 0 = no constraint. |
-| `baseline_sigma` | float | RTK | Standard deviation of baseline length constraint (m). |
-| `time_interpolation` | boolean | RTK, VRS, PP | Enable time interpolation between observation epochs. |
 
 ## Input — RINEX
 

--- a/scripts/docs/gen_config_ref.py
+++ b/scripts/docs/gen_config_ref.py
@@ -416,11 +416,15 @@ _OPTION_META: dict[str, tuple[str, str]] = {
     ),
     "pos2-afgainpva": ("PPP-RTK, VRS", "Adaptive gain for PVA process noise adjustment."),
     # ── signals ──────────────────────────────────────────────────────────────
-    "pos2-siggps": ("PPP, PPP-RTK", "GPS frequency pair selection for PPP/PPP-RTK processing."),
-    "pos2-sigqzs": ("PPP, PPP-RTK", "QZS frequency pair selection."),
-    "pos2-siggal": ("PPP, PPP-RTK", "Galileo frequency pair selection."),
-    "pos2-sigbds2": ("PPP, PPP-RTK", "BDS-2 frequency pair selection."),
-    "pos2-sigbds3": ("PPP, PPP-RTK", "BDS-3 frequency pair selection."),
+    "pos2-siggps": (
+        "PPP, PPP-RTK, VRS",
+        "GPS frequency pair selection for the SSR-corrected measurement model. Applied via `apply_pppsig()` for "
+        "every correction source except `igs`, so it also reshapes the observation set used by CLAS PPP-RTK / VRS.",
+    ),
+    "pos2-sigqzs": ("PPP, PPP-RTK, VRS", "QZS frequency pair selection."),
+    "pos2-siggal": ("PPP, PPP-RTK, VRS", "Galileo frequency pair selection."),
+    "pos2-sigbds2": ("PPP, PPP-RTK, VRS", "BDS-2 frequency pair selection."),
+    "pos2-sigbds3": ("PPP, PPP-RTK, VRS", "BDS-3 frequency pair selection."),
     # ── receiver ─────────────────────────────────────────────────────────────
     "pos2-ionocorr": ("PPP", "Enable ionospheric correction in MADOCA-PPP processing."),
     "pos2-ign_chierr": ("SPP", "Ignore chi-square test errors in SPP solution validation."),
@@ -629,8 +633,8 @@ def main() -> int:
         "kalman_filter.measurement_error": "Kalman Filter — Measurement Error",
         "kalman_filter.initial_std": "Kalman Filter — Initial Std. Deviation",
         "kalman_filter.process_noise": "Kalman Filter — Process Noise",
-        "adaptive_filter": "Adaptive Filter",
-        "signals": "Signal Selection",
+        "positioning.clas.adaptive_filter": "Positioning — CLAS Adaptive Filter",
+        "signals": "Positioning — Signal Selection",
         "input.rinex": "Input — RINEX",
         "input.rtcm": "Input — RTCM",
         "input.sbas": "Input — SBAS",
@@ -640,6 +644,50 @@ def main() -> int:
         "files": "Files",
         "server": "Server Runtime (rtkrcv)",
     }
+
+    # Explicit section emission order (readability grouping). The `positioning`
+    # cluster is ordered engine-agnostic first (SNR/atmosphere/corrections),
+    # then per-engine (SPP → Relative → PPP → Signal Selection → MADOCA), then
+    # the CLAS family (CLAS → Ambiguities → Resilience → Adaptive Filter). Any
+    # section present in MAPPING but missing here is appended at the end so a
+    # new section can never silently vanish from the reference.
+    section_order = [
+        "positioning",
+        "positioning.snr_mask",
+        "positioning.atmosphere",
+        "positioning.corrections",
+        "positioning.spp",
+        "positioning.relative",
+        "positioning.ppp",
+        "signals",
+        "positioning.madoca",
+        "positioning.clas",
+        "positioning.clas.ambiguities",
+        "positioning.clas.resilience",
+        "positioning.clas.adaptive_filter",
+        "ambiguity_resolution",
+        "ambiguity_resolution.thresholds",
+        "ambiguity_resolution.counters",
+        "ambiguity_resolution.partial_ar",
+        "ambiguity_resolution.hold",
+        "rejection",
+        "slip_detection",
+        "kalman_filter",
+        "kalman_filter.measurement_error",
+        "kalman_filter.initial_std",
+        "kalman_filter.process_noise",
+        "input.rinex",
+        "input.rtcm",
+        "input.sbas",
+        "antenna.rover",
+        "antenna.base",
+        "output",
+        "files",
+        "server",
+    ]
+    ordered_sections = [s for s in section_order if s in sections]
+    ordered_sections += [s for s in sections if s not in section_order]
+    sections = OrderedDict((s, sections[s]) for s in ordered_sections)
 
     lines: list[str] = []
     lines.append("# Configuration Options Reference")
@@ -666,7 +714,10 @@ def main() -> int:
     lines.append("| **PPP** | `ppp-kine` · `ppp-static` · `ppp-fixed` |")
     lines.append("| **PPP-RTK** | `ppp-rtk` (CLAS PPP-RTK) |")
     lines.append("| **SSR2OSR** | `ssr2osr` · `ssr2osr-fixed` |")
-    lines.append("| **VRS** | `vrs-rtk` |")
+    lines.append(
+        "| **VRS** | `vrs-rtk` — a CLAS-only mode: it builds CLAS-derived OSR and "
+        "double-differences it like RTK (`correction = qzs-clas`, not a generic RTK base station). |"
+    )
     lines.append("| **RT** | Real-time only (`mrtk run` / `rtkrcv`) |")
     lines.append("| **PP** | Post-processing only (`mrtk post` / `rnx2rtkp`) |")
     lines.append("")

--- a/scripts/tools/conf2toml.py
+++ b/scripts/tools/conf2toml.py
@@ -161,11 +161,11 @@ MAPPING: list[tuple[str, str, str, str]] = [
     ("stats-tconstiono", "kalman_filter.process_noise", "iono_time_const", "float"),
     ("stats-clkstab", "kalman_filter.process_noise", "clock_stability", "float"),
     # ── adaptive_filter ──────────────────────────────────────────────────────
-    ("pos2-prnadpt", "adaptive_filter", "enabled", "bool"),
-    ("pos2-forgetion", "adaptive_filter", "iono_forgetting", "float"),
-    ("pos2-afgainion", "adaptive_filter", "iono_gain", "float"),
-    ("pos2-forgetpva", "adaptive_filter", "pva_forgetting", "float"),
-    ("pos2-afgainpva", "adaptive_filter", "pva_gain", "float"),
+    ("pos2-prnadpt", "positioning.clas.adaptive_filter", "enabled", "bool"),
+    ("pos2-forgetion", "positioning.clas.adaptive_filter", "iono_forgetting", "float"),
+    ("pos2-afgainion", "positioning.clas.adaptive_filter", "iono_gain", "float"),
+    ("pos2-forgetpva", "positioning.clas.adaptive_filter", "pva_forgetting", "float"),
+    ("pos2-afgainpva", "positioning.clas.adaptive_filter", "pva_gain", "float"),
     # ── signals ──────────────────────────────────────────────────────────────
     ("pos2-siggps", "signals", "gps", "enum"),
     ("pos2-sigqzs", "signals", "qzs", "enum"),

--- a/scripts/tools/conf2toml.py
+++ b/scripts/tools/conf2toml.py
@@ -160,7 +160,7 @@ MAPPING: list[tuple[str, str, str, str]] = [
     ("stats-prndcb", "kalman_filter.process_noise", "ifb", "float"),  # alias
     ("stats-tconstiono", "kalman_filter.process_noise", "iono_time_const", "float"),
     ("stats-clkstab", "kalman_filter.process_noise", "clock_stability", "float"),
-    # ── adaptive_filter ──────────────────────────────────────────────────────
+    # ── positioning.clas.adaptive_filter ─────────────────────────────────────
     ("pos2-prnadpt", "positioning.clas.adaptive_filter", "enabled", "bool"),
     ("pos2-forgetion", "positioning.clas.adaptive_filter", "iono_forgetting", "float"),
     ("pos2-afgainion", "positioning.clas.adaptive_filter", "iono_gain", "float"),

--- a/src/core/mrtk_toml.c
+++ b/src/core/mrtk_toml.c
@@ -166,12 +166,12 @@ static const toml_map_t toml_mapping[] = {
     {"kalman_filter.process_noise", "iono_time_const", "stats-tconstiono"},
     {"kalman_filter.process_noise", "clock_stability", "stats-clkstab"},
 
-    /* ── adaptive_filter ───────────────────────────────────────────────────── */
-    {"adaptive_filter", "enabled", "pos2-prnadpt"},
-    {"adaptive_filter", "iono_forgetting", "pos2-forgetion"},
-    {"adaptive_filter", "iono_gain", "pos2-afgainion"},
-    {"adaptive_filter", "pva_forgetting", "pos2-forgetpva"},
-    {"adaptive_filter", "pva_gain", "pos2-afgainpva"},
+    /* ── positioning.clas.adaptive_filter ──────────────────────────────────── */
+    {"positioning.clas.adaptive_filter", "enabled", "pos2-prnadpt"},
+    {"positioning.clas.adaptive_filter", "iono_forgetting", "pos2-forgetion"},
+    {"positioning.clas.adaptive_filter", "iono_gain", "pos2-afgainion"},
+    {"positioning.clas.adaptive_filter", "pva_forgetting", "pos2-forgetpva"},
+    {"positioning.clas.adaptive_filter", "pva_gain", "pos2-afgainpva"},
 
     /* ── signals ───────────────────────────────────────────────────────────── */
     {"signals", "gps", "pos2-siggps"},


### PR DESCRIPTION
## Summary

Documentation-focused finish to the config taxonomy work. Two things motivated it:

1. **Inconsistency from #266.** The taxonomy nested `[positioning.clas.resilience]` and `[positioning.clas.ambiguities]` but left `[adaptive_filter]` top-level, even though the adaptive filter is read only by `ppp_rtk_pos()` and `relposvrs()` — i.e. it is CLAS-only, exactly like its siblings.
2. **Config reference readability.** The generated `docs/reference/config-options.md` emitted sections in `MAPPING` order, scattering the `positioning` subsections.

## Changes

- **Rename** `[adaptive_filter]` → `[positioning.clas.adaptive_filter]` in the loader (`mrtk_toml.c`), `conf2toml.py` MAPPING, and all 13 bundled CLAS configs.
- **Regroup** the reference via an explicit section order in `gen_config_ref.py`: the `positioning` cluster now runs engine-agnostic (SNR / Atmosphere / Corrections) → per-engine (SPP → Relative → PPP → Signal Selection → MADOCA) → CLAS family (CLAS → Ambiguities → Resilience → Adaptive Filter).
- **`vrs-rtk` clarification** in Mode Abbreviations: it is a CLAS-only mode (CLAS-derived OSR double-differenced, `correction = qzs-clas`), not a generic RTK base station. (The design doc and CLAS guides already frame it this way; this closes the one place — the mode legend — that stated it bare.)
- **Signal Selection Modes fix**: `PPP, PPP-RTK` → `PPP, PPP-RTK, VRS`. `apply_pppsig()` runs for every correction source except `igs`, so the presets also reshape the observation set used by CLAS PPP-RTK / VRS.

## Why `[signals]` was NOT renamed

`[positioning].signals` already exists as a key, so a `[positioning.signals]` table would collide (TOML key/table conflict). Nesting under `[positioning.ppp]` would misrepresent it (it is PPP **and** CLAS). And #234 slates the legacy presets for removal. So `[signals]` stays top-level and is only regrouped in the reference display.

## Verification

- **Bit-identical for bundled configs** (all have adaptive off): `claslib` PP regression **28/28 pass**.
- **Positive load proof**: enabling the adaptive filter through the new nested section with extreme gains changes the solution — **14308 NMEA lines differ** vs the adaptive-off baseline over the 1 h claslib window. This confirms the 3-level `[positioning.clas.adaptive_filter]` path is actually read (the default-off configs alone couldn't prove that).
- **Docs drift gate green** (`config-options.md` matches the generator).

## Known gap (tracked separately)

The loader still has no deprecation alias or unknown-key warning, so this rename — like the #266 renames — silently resets a pre-rename config to defaults with no warning. Filed as #286 to add a comprehensive alias + unknown-key mechanism covering all historical renames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)