### PR TITLE
feat(toml): add deprecation aliases + unknown-key warning to the loader (#286)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,7 +280,7 @@ set(_UTEST_DIR ${CMAKE_SOURCE_DIR}/tests/utest)
 set(_UTEST_SOURCES
     t_atmos t_clas_route t_coord t_freqidx t_geoid t_gloeph t_ionex
     t_lambda t_matrix t_misc t_obsdef t_ppp t_preceph
-    t_rinex t_rinex4 t_sigcfg_decode t_time
+    t_rinex t_rinex4 t_sigcfg_decode t_time t_toml
     # t_tle excluded: tle_pos() implementation not yet in library
 )
 foreach(test IN LISTS _UTEST_SOURCES)

--- a/src/core/mrtk_toml.c
+++ b/src/core/mrtk_toml.c
@@ -651,12 +651,19 @@ extern int loadopts_toml(const char* file, opt_t* opts) {
     }
 
     /* Accept retired section.key paths for backward compatibility, warning the
-     * user to migrate. The new location (already read above) takes precedence. */
+     * user to migrate. The new location (already read above) takes precedence.
+     * Mirrors the main mapping loop's error handling: stay silent when this
+     * opts table does not own the legacy option (e.g. the same file loaded
+     * into rcvopts), and report an invalid value on a str2opt() failure. */
     for (a = toml_alias; a->old_section; a++) {
         toml_table_t* ntbl;
         tbl = navigate_table(root, a->old_section);
         if (!tbl || !toml_val_to_str(tbl, a->old_key, valbuf, sizeof(valbuf))) {
             continue; /* old key not present */
+        }
+        opt = searchopt(a->legacy_name, opts);
+        if (!opt) {
+            continue; /* legacy option not in this opts table */
         }
         ntbl = navigate_table(root, a->new_section);
         if (ntbl && toml_key_exists(ntbl, a->new_key)) {
@@ -666,10 +673,12 @@ extern int loadopts_toml(const char* file, opt_t* opts) {
         }
         fprintf(stderr, "TOML: [%s].%s is deprecated; move it to [%s].%s\n", a->old_section, a->old_key, a->new_section,
                 a->new_key);
-        opt = searchopt(a->legacy_name, opts);
-        if (opt && str2opt(opt, valbuf)) {
-            count++;
+        if (!str2opt(opt, valbuf)) {
+            fprintf(stderr, "TOML: invalid value for %s.%s = %s (legacy: %s)\n", a->old_section, a->old_key, valbuf,
+                    a->legacy_name);
+            continue;
         }
+        count++;
     }
 
     /* Handle positioning.systems string list (overrides constellations) */

--- a/src/core/mrtk_toml.c
+++ b/src/core/mrtk_toml.c
@@ -318,6 +318,53 @@ static const toml_map_t toml_mapping[] = {
     {NULL, NULL, NULL} /* terminator */
 };
 
+/* ── Deprecated section.key aliases ────────────────────────────────────────── */
+
+/* Old TOML paths retired by the section-taxonomy refactor (#266) and later
+ * renames. Each is still accepted for backward compatibility: loadopts_toml()
+ * applies the value and emits a one-line deprecation warning pointing at the
+ * new path. The new location wins when both are present. saveopts_toml() does
+ * not consult this table, so a re-saved file always uses the new layout.
+ * Add an entry here whenever a section.key is renamed (see #286). */
+typedef struct {
+    const char* old_section;
+    const char* old_key;
+    const char* new_section;
+    const char* new_key;
+    const char* legacy_name;
+} toml_alias_t;
+
+static const toml_alias_t toml_alias[] = {
+    /* [receiver] dismantled (#266) */
+    {"receiver", "phase_shift", "positioning.clas.ambiguities", "phase_shift", "pos2-phasshft"},
+    {"receiver", "isb", "positioning.clas.ambiguities", "isb", "pos2-isb"},
+    {"receiver", "reference_type", "positioning.clas.ambiguities", "reference_type", "pos2-rectype"},
+    {"receiver", "iono_correction", "positioning.madoca", "iono_correction", "pos2-ionocorr"},
+    {"receiver", "ignore_chi_error", "positioning.spp", "ignore_chi_error", "pos2-ign_chierr"},
+    {"receiver", "ppp_sat_clock_bias", "positioning.ppp", "satellite_clock_bias", "pos2-pppsatcb"},
+    {"receiver", "ppp_sat_phase_bias", "positioning.ppp", "satellite_phase_bias", "pos2-pppsatpb"},
+    {"receiver", "max_bias_dt", "positioning.ppp", "max_bias_dt", "pos2-maxbiasdt"},
+    {"receiver", "max_age", "positioning.relative", "max_age", "pos2-maxage"},
+    {"receiver", "baseline_length", "positioning.relative", "baseline_length", "pos2-baselen"},
+    {"receiver", "baseline_sigma", "positioning.relative", "baseline_sigma", "pos2-basesig"},
+    /* keys moved out of [server] (#266) */
+    {"server", "max_obs_loss", "positioning.clas.resilience", "max_obs_loss", "misc-maxobsloss"},
+    {"server", "float_count", "positioning.clas.resilience", "float_count", "misc-floatcnt"},
+    {"server", "l6_margin", "positioning.clas.resilience", "l6_merge", "misc-l6mrg"},
+    {"server", "regularly", "positioning.clas.resilience", "reset_interval", "misc-regularly"},
+    {"server", "ppp_option", "positioning.ppp", "options", "misc-pppopt"},
+    {"server", "time_interpolation", "positioning.relative", "time_interpolation", "misc-timeinterp"},
+    {"server", "rinex_option_1", "input.rinex", "option_1", "misc-rnxopt1"},
+    {"server", "rinex_option_2", "input.rinex", "option_2", "misc-rnxopt2"},
+    {"server", "rtcm_option", "input.rtcm", "options", "misc-rtcmopt"},
+    {"server", "sbas_satellite", "input.sbas", "satellite", "misc-sbasatsel"},
+    {NULL, NULL, NULL, NULL, NULL} /* terminator */
+};
+
+/* Sections owned by a specific app (not the positioning option table); their
+ * keys must not be flagged as unknown. */
+static const char* const toml_app_sections[] = {"cssr2rtcm3", "signal_remap", NULL};
+
 /* ── Helper: navigate nested TOML tables ───────────────────────────────────── */
 
 /**
@@ -350,6 +397,73 @@ static toml_table_t* navigate_table(toml_table_t* root, const char* path) {
         tbl = toml_table_in(tbl, tok);
     }
     return tbl;
+}
+
+/* ── Helper: unknown-key detection ─────────────────────────────────────────── */
+
+/**
+ * @brief Report whether a section.key pair is recognized by the loader.
+ * @param[in] section  Dotted TOML section path.
+ * @param[in] key      Leaf key name.
+ * @return 1 if the key is in the mapping, an alias, or an app-owned section.
+ */
+static int is_known_key(const char* section, const char* key) {
+    const toml_map_t* m;
+    const toml_alias_t* a;
+    const char* const* s;
+
+    for (s = toml_app_sections; *s; s++) {
+        if (!strcmp(section, *s)) {
+            return 1;
+        }
+    }
+    /* positioning.systems is a string-list key handled outside toml_mapping */
+    if (!strcmp(section, "positioning") && !strcmp(key, "systems")) {
+        return 1;
+    }
+    for (m = toml_mapping; m->toml_section; m++) {
+        if (!strcmp(m->toml_section, section) && !strcmp(m->toml_key, key)) {
+            return 1;
+        }
+    }
+    for (a = toml_alias; a->old_section; a++) {
+        if (!strcmp(a->old_section, section) && !strcmp(a->old_key, key)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/**
+ * @brief Recursively walk a parsed TOML table and warn on unrecognized keys.
+ *        Sub-tables extend the dotted section path; scalar/array leaves are
+ *        checked against is_known_key(). Catches values silently dropped
+ *        because their section.key is not in the mapping (typo or stale name).
+ * @param[in] tab   TOML table to walk.
+ * @param[in] path  Dotted section path accumulated so far ("" at the root).
+ */
+static void check_unknown_keys(toml_table_t* tab, const char* path) {
+    int i, n = toml_table_nkval(tab) + toml_table_narr(tab) + toml_table_ntab(tab);
+    char subpath[256];
+
+    for (i = 0; i < n; i++) {
+        const char* key = toml_key_in(tab, i);
+        toml_table_t* sub;
+        if (!key) {
+            continue;
+        }
+        sub = toml_table_in(tab, key);
+        if (sub) {
+            if (*path) {
+                snprintf(subpath, sizeof(subpath), "%s.%s", path, key);
+            } else {
+                snprintf(subpath, sizeof(subpath), "%s", key);
+            }
+            check_unknown_keys(sub, subpath);
+        } else if (!is_known_key(path, key)) {
+            fprintf(stderr, "TOML: unknown key [%s].%s (ignored)\n", *path ? path : "(root)", key);
+        }
+    }
 }
 
 /* ── Helper: read a TOML value as string for str2opt() ─────────────────────── */
@@ -486,6 +600,7 @@ extern int loadopts_toml(const char* file, opt_t* opts) {
     toml_table_t* root;
     char errbuf[256];
     const toml_map_t* m;
+    const toml_alias_t* a;
     toml_table_t* tbl;
     opt_t* opt;
     char valbuf[2048];
@@ -533,6 +648,28 @@ extern int loadopts_toml(const char* file, opt_t* opts) {
             continue;
         }
         count++;
+    }
+
+    /* Accept retired section.key paths for backward compatibility, warning the
+     * user to migrate. The new location (already read above) takes precedence. */
+    for (a = toml_alias; a->old_section; a++) {
+        toml_table_t* ntbl;
+        tbl = navigate_table(root, a->old_section);
+        if (!tbl || !toml_val_to_str(tbl, a->old_key, valbuf, sizeof(valbuf))) {
+            continue; /* old key not present */
+        }
+        ntbl = navigate_table(root, a->new_section);
+        if (ntbl && toml_key_exists(ntbl, a->new_key)) {
+            fprintf(stderr, "TOML: [%s].%s is deprecated and ignored; [%s].%s takes precedence\n", a->old_section,
+                    a->old_key, a->new_section, a->new_key);
+            continue;
+        }
+        fprintf(stderr, "TOML: [%s].%s is deprecated; move it to [%s].%s\n", a->old_section, a->old_key, a->new_section,
+                a->new_key);
+        opt = searchopt(a->legacy_name, opts);
+        if (opt && str2opt(opt, valbuf)) {
+            count++;
+        }
     }
 
     /* Handle positioning.systems string list (overrides constellations) */
@@ -595,6 +732,10 @@ extern int loadopts_toml(const char* file, opt_t* opts) {
             }
         }
     }
+
+    /* Warn on any key the loader does not recognize (typo, or a stale name with
+     * no alias) so it does not silently fall back to a default. */
+    check_unknown_keys(root, "");
 
     toml_free(root);
 

--- a/tests/utest/t_toml.c
+++ b/tests/utest/t_toml.c
@@ -1,0 +1,96 @@
+/*------------------------------------------------------------------------------
+ * t_toml.c : unit test for the TOML loader deprecation aliases and unknown-key
+ *            detection (#286).
+ *
+ * Uses explicit failure returns (not assert) so the checks run even in
+ * NDEBUG builds where assert() is a no-op (see #277).
+ *-----------------------------------------------------------------------------*/
+#include <stdio.h>
+#include <string.h>
+
+#include "mrtklib/mrtk_options.h"
+#include "mrtklib/mrtk_toml.h"
+#include "mrtklib/rtklib.h"
+
+#define FIXTURE "t_toml_fixture.toml"
+#define CAPTURE "t_toml_stderr.txt"
+
+static int fail = 0;
+
+static void expect(int cond, const char* what) {
+    printf("%s: %s\n", cond ? "PASS" : "FAIL", what);
+    if (!cond) {
+        fail = 1;
+    }
+}
+
+static int capture_contains(const char* needle) {
+    char buf[8192];
+    size_t n;
+    FILE* fp = fopen(CAPTURE, "r");
+    int found = 0;
+    if (!fp) {
+        return 0;
+    }
+    n = fread(buf, 1, sizeof(buf) - 1, fp);
+    buf[n] = '\0';
+    fclose(fp);
+    found = strstr(buf, needle) != NULL;
+    return found;
+}
+
+int main(void) {
+    prcopt_t prcopt;
+    solopt_t solopt;
+    filopt_t filopt;
+    FILE* fp;
+
+    /* fixture: two deprecated aliases that must apply, one deprecated key
+     * shadowed by its new location (new must win), and one typo (unknown). */
+    fp = fopen(FIXTURE, "w");
+    if (!fp) {
+        printf("FAIL: cannot write fixture\n");
+        return 1;
+    }
+    fprintf(fp,
+            "[receiver]\n"
+            "phase_shift = \"table\"\n" /* alias -> pos2-phasshft -> phasshft=1 */
+            "max_age = 99.0\n"          /* deprecated, but shadowed below */
+            "[server]\n"
+            "regularly = 600\n" /* alias -> regularly=600 */
+            "[positioning.relative]\n"
+            "max_age = 5.0\n" /* new location wins over [receiver].max_age */
+            "[positioning]\n"
+            "elevaton_mask = 15.0\n"); /* typo -> unknown key */
+    fclose(fp);
+
+    /* Capture loader warnings. stdout stays on the console for PASS/FAIL. */
+    if (!freopen(CAPTURE, "w", stderr)) {
+        printf("FAIL: cannot redirect stderr\n");
+        return 1;
+    }
+
+    resetsysopts();
+    loadopts_toml(FIXTURE, sysopts);
+    getsysopts(&prcopt, &solopt, &filopt);
+    fflush(stderr);
+
+    /* Aliases applied their values. */
+    expect(prcopt.phasshft == 1, "[receiver].phase_shift alias sets phasshft=1");
+    expect(prcopt.regularly == 600, "[server].regularly alias sets regularly=600");
+    /* New location wins over the deprecated one. */
+    expect(prcopt.maxtdiff == 5.0, "[positioning.relative].max_age wins over [receiver].max_age");
+
+    /* Warnings emitted. */
+    expect(capture_contains("[receiver].phase_shift is deprecated; move it to"),
+           "deprecation warning for [receiver].phase_shift");
+    expect(capture_contains("[server].regularly is deprecated; move it to"),
+           "deprecation warning for [server].regularly");
+    expect(capture_contains("[receiver].max_age is deprecated and ignored"),
+           "shadowed-alias warning for [receiver].max_age");
+    expect(capture_contains("unknown key [positioning].elevaton_mask"), "unknown-key warning for typo");
+
+    remove(FIXTURE);
+    remove(CAPTURE);
+    return fail;
+}

--- a/tests/utest/t_toml.c
+++ b/tests/utest/t_toml.c
@@ -54,8 +54,9 @@ int main(void) {
     }
     fprintf(fp,
             "[receiver]\n"
-            "phase_shift = \"table\"\n" /* alias -> pos2-phasshft -> phasshft=1 */
-            "max_age = 99.0\n"          /* deprecated, but shadowed below */
+            "phase_shift = \"table\"\n"     /* alias -> pos2-phasshft -> phasshft=1 */
+            "max_age = 99.0\n"              /* deprecated, but shadowed below */
+            "iono_correction = \"maybe\"\n" /* deprecated + invalid enum value */
             "[server]\n"
             "regularly = 600\n" /* alias -> regularly=600 */
             "[positioning.relative]\n"
@@ -89,6 +90,8 @@ int main(void) {
     expect(capture_contains("[receiver].max_age is deprecated and ignored"),
            "shadowed-alias warning for [receiver].max_age");
     expect(capture_contains("unknown key [positioning].elevaton_mask"), "unknown-key warning for typo");
+    expect(capture_contains("invalid value for receiver.iono_correction"),
+           "invalid-value warning for a deprecated key with a bad value");
 
     remove(FIXTURE);
     remove(CAPTURE);


### PR DESCRIPTION
## Summary

Closes #286. Until now `loadopts_toml()` walked a fixed mapping and **silently ignored** any key not in it. So every section rename — the #266 taxonomy (`[receiver]` removed, `[server]` shrunk, new `[positioning.*]` / `[input.*]` sections) and future ones — silently reset old configs to defaults, with no error and no warning. A user carrying `[receiver] phase_shift = "table"` got the default back with no signal, which for CLAS can quietly degrade positioning quality.

This adds the safety net that step 1 of the taxonomy plan called for but never landed.

## Changes (`src/core/mrtk_toml.c`)

- **Deprecation aliases** (`toml_alias_t[]`): the **21** `section.key` paths retired by #266 are still accepted, applied, and reported with a one-line `move it to [new.path]` warning. The new location wins when both are present (the old one is then reported as *ignored*). `saveopts_toml()` ignores the table, so a re-saved file always uses the new layout.
- **Unknown-key detection**: after loading, recursively walk the parsed tree and warn on any `section.key` that is neither mapped, aliased, nor app-owned (`cssr2rtcm3` / `signal_remap` whitelisted; `positioning.systems` special-cased). Catches typos and stale names that would otherwise vanish silently.

## Verification

- **No false positives**: all **41** bundled configs load with **zero** warnings.
- **Old configs still work end-to-end**: `[server].regularly = 600` via the alias fires the CLAS periodic reset **5×**, identical to the new `[positioning.clas.resilience].reset_interval`. Deprecation + new-wins + unknown-key warnings all verified.
- **Bit-identical for bundled configs**: direct claslib PP output is **byte-identical (md5 match)** with and without this change.
- **Unit test** `tests/utest/t_toml.c` asserts alias application, new-wins precedence, all three warning types, and unknown-key detection. Uses explicit failure returns (not `assert`) so it is not a no-op under NDEBUG (#277). All 23 utests pass.

## Note on a pre-existing failure

While testing I found `claslib_ppp_rtk_check` (and a few VRS / l1cl5 checks) **fail on clean develop**, independent of this PR — the ctest harness run yields 3567 epochs vs the reference's 3580, though a direct `mrtk post` on the same config/data produces the correct 3580 (byte-identical to reference), and the fix-rate delta is +0.00%. This looks like a test-harness/data-state issue on develop, not a positioning regression. Flagging separately; not addressed here.

## Follow-up

#287 renames `[adaptive_filter]` → `[positioning.clas.adaptive_filter]`; its alias entry should be added to `toml_alias[]` when that PR lands (one line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)