### PR TITLE
feat(toml): add deprecation alias for the [adaptive_filter] rename

### DIFF
--- a/src/core/mrtk_toml.c
+++ b/src/core/mrtk_toml.c
@@ -358,6 +358,12 @@ static const toml_alias_t toml_alias[] = {
     {"server", "rinex_option_2", "input.rinex", "option_2", "misc-rnxopt2"},
     {"server", "rtcm_option", "input.rtcm", "options", "misc-rtcmopt"},
     {"server", "sbas_satellite", "input.sbas", "satellite", "misc-sbasatsel"},
+    /* [adaptive_filter] nested under CLAS (#287) */
+    {"adaptive_filter", "enabled", "positioning.clas.adaptive_filter", "enabled", "pos2-prnadpt"},
+    {"adaptive_filter", "iono_forgetting", "positioning.clas.adaptive_filter", "iono_forgetting", "pos2-forgetion"},
+    {"adaptive_filter", "iono_gain", "positioning.clas.adaptive_filter", "iono_gain", "pos2-afgainion"},
+    {"adaptive_filter", "pva_forgetting", "positioning.clas.adaptive_filter", "pva_forgetting", "pos2-forgetpva"},
+    {"adaptive_filter", "pva_gain", "positioning.clas.adaptive_filter", "pva_gain", "pos2-afgainpva"},
     {NULL, NULL, NULL, NULL, NULL} /* terminator */
 };
 

--- a/tests/utest/t_toml.c
+++ b/tests/utest/t_toml.c
@@ -59,6 +59,8 @@ int main(void) {
             "iono_correction = \"maybe\"\n" /* deprecated + invalid enum value */
             "[server]\n"
             "regularly = 600\n" /* alias -> regularly=600 */
+            "[adaptive_filter]\n"
+            "enabled = true\n" /* alias (#287 nesting) -> pos2-prnadpt -> prnadpt=1 */
             "[positioning.relative]\n"
             "max_age = 5.0\n" /* new location wins over [receiver].max_age */
             "[positioning]\n"
@@ -79,6 +81,7 @@ int main(void) {
     /* Aliases applied their values. */
     expect(prcopt.phasshft == 1, "[receiver].phase_shift alias sets phasshft=1");
     expect(prcopt.regularly == 600, "[server].regularly alias sets regularly=600");
+    expect(prcopt.prnadpt == 1, "[adaptive_filter].enabled alias sets prnadpt=1");
     /* New location wins over the deprecated one. */
     expect(prcopt.maxtdiff == 5.0, "[positioning.relative].max_age wins over [receiver].max_age");
 

--- a/tests/utest/t_toml.c
+++ b/tests/utest/t_toml.c
@@ -90,6 +90,8 @@ int main(void) {
            "deprecation warning for [receiver].phase_shift");
     expect(capture_contains("[server].regularly is deprecated; move it to"),
            "deprecation warning for [server].regularly");
+    expect(capture_contains("[adaptive_filter].enabled is deprecated; move it to"),
+           "deprecation warning for [adaptive_filter].enabled");
     expect(capture_contains("[receiver].max_age is deprecated and ignored"),
            "shadowed-alias warning for [receiver].max_age");
     expect(capture_contains("unknown key [positioning].elevaton_mask"), "unknown-key warning for typo");


### PR DESCRIPTION
## Summary

Closes the gap left by the merge order of #287 and #288.

- **#287** renamed `[adaptive_filter]` → `[positioning.clas.adaptive_filter]`.
- **#288** added the deprecation-alias mechanism (`toml_alias[]`) covering the 21 `#266` renames, but — since it branched from develop before #287 — it did **not** include the adaptive_filter alias.

With both now on develop, an old `[adaptive_filter]` config is renamed away with no alias, so it silently resets to defaults. This adds the five missing alias entries so the old section is accepted with a migration warning, exactly like the other renames.

## Verification

- Old `[adaptive_filter] enabled = true` now warns (`deprecated; move it to [positioning.clas.adaptive_filter]`) and **applies** (`prnadpt = 1`).
- All **41** bundled configs (which use the new nested section) still load with **zero** warnings.
- `t_toml.c` extended with an `[adaptive_filter]` alias case; all 23 utests pass.

This completes the alias table — every historical section rename now has backward-compat coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)