### PR TITLE
chore: back-merge v0.7.2–v0.7.6 release notes (main → develop)

### DIFF
--- a/docs/releases/release-notes-v0.7.2.md
+++ b/docs/releases/release-notes-v0.7.2.md
@@ -1,0 +1,134 @@
+# Release Notes — v0.7.2
+
+## CLAS PPP-RTK accuracy/robustness fixes and `mrtk dump --parse`
+
+**Release date:** 2026-06-29
+**Type:** Fix + feature (CLAS PPP-RTK accuracy/robustness + CSSR tooling)
+**Branch:** `release/v0.7.2`
+
+---
+
+### Overview
+
+v0.7.2 collects two CLAS PPP-RTK correctness fixes and adds a CSSR dump tool for
+inspecting decoded CLAS L6D / Compact SSR:
+
+- The PPP-RTK **adaptive-ionosphere process noise** is restored under storm-day
+  conditions — a lost `Qp` scatter-back meant the adaptive noise was never
+  actually applied. Storm-day CLAS fix rate improves from **77% to 85% (+8 pp)**.
+- CLAS now **falls back to global orbit/clock corrections** when the
+  close-network partition goes stale, instead of dropping corrections.
+- `mrtk dump` gains a **`--parse`** mode that reproduces the upstream claslib
+  `dumpcssr` per-subtype CSV output byte-identically.
+
+The two fixes are CLAS PPP-RTK behavior changes with an accuracy/robustness
+effect; the dump tool is a self-contained parser that leaves the production CLAS
+decoder untouched. F5 (GSI daily-coordinate) absolute-accuracy regression tests
+are added to guard geodetic accuracy going forward.
+
+---
+
+### 1. Bug fixes
+
+#### PPP-RTK adaptive-ionosphere process noise
+
+The compacted→full-`nx` `Qp` scatter-back had been lost, so the adaptive
+ionosphere process noise was never applied to the filter. Restoring the
+scatter-back makes the adaptive iono noise take effect again.
+
+Storm-day CLAS fix rate improves from **77% to 85% (+8 pp)**
+([#225](https://github.com/h-shiono/MRTKLIB/issues/225),
+[PR #226](https://github.com/h-shiono/MRTKLIB/pull/226)).
+
+#### CLAS stale network partition
+
+When the close-network orbit/clock partition goes stale, CLAS now falls back to
+the **global orbit/clock corrections** rather than dropping the corrections
+entirely. This keeps a solution alive through a stale-partition window
+([#218](https://github.com/h-shiono/MRTKLIB/issues/218),
+[PR #228](https://github.com/h-shiono/MRTKLIB/pull/228)).
+
+---
+
+### 2. What's new
+
+#### `mrtk dump --parse`
+
+`mrtk dump` gains a `--parse` mode that dumps decoded CLAS L6D / Compact SSR to
+the upstream-format per-subtype CSV files (`parse_cssr_type1..12*.csv` and
+`parse_cssr_header.csv`).
+
+It is implemented as a **self-contained vendored parser**
+(`apps/dumpcssr/cssr_parse.c`) ported from claslib 082; the production CLAS
+decoder is left untouched. The mode requires `-grid FILE`.
+
+#### `mrtk dump -grid/--grid FILE`
+
+The CLAS grid definition is now passed directly on the command line via `-grid`
+(alias `--grid`), replacing the previous `-k`/`--config` file indirection.
+
+---
+
+### 3. Changed
+
+- **`mrtk dump` grid input** — the grid definition is taken via `-grid` instead
+  of the `-k`/`--config` file (which existed in `dump` only to read the grid
+  path). The redundant config handling is removed.
+
+---
+
+### 4. Tests
+
+CLAS **absolute-accuracy regression tests** are added: F5 (GSI daily-coordinate)
+geodetic-truth checks for all CLAS PPP-RTK/VRS datasets (TSUKUBA3 / station
+0627), guarding geodetic accuracy in addition to the existing
+consistency-vs-claslib checks
+([PR #227](https://github.com/h-shiono/MRTKLIB/pull/227)).
+
+---
+
+### 5. Validation
+
+**`mrtk dump --parse` byte-identity.** The `--parse` output is byte-identical to
+upstream claslib 082 `dumpcssr` / `ssr2osr -dump` on `2026121A.l6` across all
+per-subtype CSVs (data fields); the only difference is an upstream version delta
+in one header column label
+([PR #230](https://github.com/h-shiono/MRTKLIB/pull/230)).
+
+**CLAS PPP-RTK absolute accuracy.** 2D 95% ≈ **4.2–4.3 cm** vs GSI F5 truth
+(TSUKUBA3, 2019/08/27).
+
+**Storm-day fix rate.** CLAS PPP-RTK storm-day fix rate rises from **77% to 85%**
+with the restored adaptive-iono `Qp` scatter-back.
+
+---
+
+### Compatibility & migration
+
+The `mrtk dump` grid input changes from the `-k`/`--config` file to a direct
+`-grid FILE` argument; scripts that relied on the config-file indirection for the
+grid path must pass `-grid` instead. The PPP-RTK adaptive-iono and stale-partition
+fixes are corrections to existing CLAS behavior and require no configuration
+changes.
+
+### Issues / PRs
+
+- Release PR [#231](https://github.com/h-shiono/MRTKLIB/pull/231).
+- [#225](https://github.com/h-shiono/MRTKLIB/issues/225) /
+  [PR #226](https://github.com/h-shiono/MRTKLIB/pull/226) — restore adaptive-iono
+  `Qp` scatter-back (storm 77%→85%).
+- [#218](https://github.com/h-shiono/MRTKLIB/issues/218) /
+  [PR #228](https://github.com/h-shiono/MRTKLIB/pull/228) — global orbit/clock
+  fallback on stale network partition.
+- [PR #227](https://github.com/h-shiono/MRTKLIB/pull/227) — F5 absolute-accuracy
+  regression checks.
+- [PR #230](https://github.com/h-shiono/MRTKLIB/pull/230) — `mrtk dump --parse`
+  byte-identity validation.
+
+### References
+
+- claslib 082 — `dumpcssr` / `ssr2osr -dump` per-subtype CSV format
+  (`parse_cssr_type1..12*.csv`, `parse_cssr_header.csv`).
+- IS-QZSS-L6 — CLAS L6D Compact SSR message format.
+- GSI F5 daily coordinates — geodetic-truth reference for the CLAS
+  absolute-accuracy regression tests.

--- a/docs/releases/release-notes-v0.7.3.md
+++ b/docs/releases/release-notes-v0.7.3.md
@@ -1,0 +1,123 @@
+# Release Notes — v0.7.3
+
+## Real-time MADOCA-PPP PPP-AR/IONO — L6D wide-area ionospheric augmentation
+
+**Release date:** 2026-06-29
+**Type:** Feature (real-time MADOCA-PPP PPP-AR/IONO)
+**Branch:** `release/v0.7.3`
+
+---
+
+### Overview
+
+v0.7.3 wires the MADOCA-PPP **L6D wide-area ionospheric augmentation**
+(QZS PRN 200/201) into the real-time `mrtk run` path. With this change,
+`ionosphere = est-stec` + `iono_correction = on` applies the same slant-TEC
+(STEC) constraint in real time as it already did in post-processing.
+
+Previously this mode was **post-processing only**. In real time the L6E SSR was
+decoded and applied, but the L6D iono augmentation was never routed into the
+server — so an `est-stec` real-time run silently degraded to plain PPP-AR.
+
+The design is **SBF-first** (mosaic-G5): a single SBF stream carries the
+observations, the L6E SSR and the L6D ionosphere in one slot. The Septentrio SBF
+L6D decoder steers PRN 200/201 to the iono decoder via a dedicated return code
+that `rtksvr` feeds into `nav.pppiono`.
+
+---
+
+### 1. What's new
+
+#### Real-time PPP-AR/IONO
+
+`rtksvr` now decodes the L6D ionospheric frames (`QZSRawL6D`, PRN 200/201) into
+`nav.pppiono` and applies the wide-area STEC constraint live, mirroring
+`update_qzssl6d()` in the post-processing path.
+
+The path is gated on:
+
+- `correction = qzs-madoca`
+- `ionosphere = est-stec`
+- `iono_correction = on`
+
+The GPST week is anchored lazily from the first stream time (the CLAS
+`week_ref` pattern), so recorded-stream replay decodes in the correct week
+([#223](https://github.com/h-shiono/MRTKLIB/issues/223),
+[PR #233](https://github.com/h-shiono/MRTKLIB/pull/233)).
+
+#### New sample configuration
+
+- **`conf/madocalib/rtkrcv_madoca_pppar_iono.toml`** — a real-time single-SBF
+  MADOCA-PPP PPP-AR/IONO sample configuration, plus a real-time subsection added
+  to the MADOCA-PPP quickstart.
+
+---
+
+### 2. Changed
+
+#### Septentrio SBF L6D routing
+
+The `Source = 1` (L6D) branch now returns a dedicated decoder code for
+PRN 200/201/197 (MADOCA ionosphere), so the frame is steered to the iono decoder
+instead of the CLAS redirect.
+
+The discriminator is the **PRN**: 200/201 carry the iono augmentation and are
+disjoint from CLAS (193–199) per IS-QZSS-MDC-004 Table 3-1. There is no effect on
+CLAS — in MADOCA mode the CLAS context is absent, and in CLAS mode PRN 200/201
+were already rejected.
+
+---
+
+### 3. Validation
+
+**Offline decode** of a mosaic-G5 SBF capture:
+
+- 3660 L6D iono frames → 366 complete decodes → `nav.pppiono` regions populated.
+- 89 L6E SSR satellites decoded from the same stream.
+
+**Live mosaic-G5 hardware** (over TCP):
+
+- The real-time iono path fires (`pppiono` regions filled).
+- L6E SSR age ≈ 1 s.
+- PPP-AR/IONO reached a fixed solution (Q=1) ≈ 1 minute after start, holding
+  continuous Q=1 at **~1.2 cm horizontal / ~3.4 cm vertical std**.
+
+The fast fix is the L6D ionospheric augmentation working as intended — the
+same STEC constraint that post-processing already applied, now applied live.
+
+---
+
+### 4. Known limitations
+
+- The augmentation is gated on `correction = qzs-madoca` +
+  `ionosphere = est-stec` + `iono_correction = on`; outside that mode the L6D
+  iono frames are not consumed.
+- L6D iono routing keys on PRN 200/201 (disjoint from CLAS 193–199 per
+  IS-QZSS-MDC-004 Table 3-1); PRN 197 is included in the dedicated return code.
+
+---
+
+### Compatibility & migration
+
+No configuration changes are required for existing workflows. The real-time
+iono augmentation is opt-in through the `est-stec` + `iono_correction = on`
+gate; without it, `mrtk run` MADOCA-PPP behaves exactly as before. A new sample
+configuration (`conf/madocalib/rtkrcv_madoca_pppar_iono.toml`) is provided for
+the new mode.
+
+### Issues / PRs
+
+- [#223](https://github.com/h-shiono/MRTKLIB/issues/223) — wire the L6D iono
+  (PRN 200/201) augmentation into the real-time `mrtk run` path.
+- [PR #233](https://github.com/h-shiono/MRTKLIB/pull/233) — implementation
+  (real-time L6D iono decode into `nav.pppiono`, lazy GPST week anchor,
+  SBF L6D routing return code, sample configuration).
+- [PR #235](https://github.com/h-shiono/MRTKLIB/pull/235) — release/v0.7.3.
+
+### References
+
+- IS-QZSS-MDC-004 — MADOCA-PPP L6E SSR and L6D wide-area ionospheric
+  augmentation message formats; Table 3-1 PRN allocation (CLAS 193–199,
+  iono 200/201).
+- Septentrio SBF Reference Guide — `QZSRawL6D` (L6D) block layout and the
+  `Source` field.

--- a/docs/releases/release-notes-v0.7.4.md
+++ b/docs/releases/release-notes-v0.7.4.md
@@ -1,0 +1,193 @@
+# Release Notes — v0.7.4
+
+## CLAS PPP-RTK claslib parity — storm-day fix-rate gap closed
+
+**Release date:** 2026-07-04
+**Type:** Accuracy (CLAS PPP-RTK claslib parity) + independent fixes
+**Branch:** `release/v0.7.4`
+
+---
+
+### Overview
+
+v0.7.4 is a five-part sync series that aligns the CLAS PPP-RTK engine with
+upstream claslib across three layers — the correction-stream timing, the
+measurement model, and the SPP seed — closing the storm-day fix-rate gap tracked
+in [#225](https://github.com/h-shiono/MRTKLIB/issues/225).
+
+On the deterministic-BLAS storm benchmark the kinematic fix rate rises
+**89.44 % → 93.54 %**, now **exceeding upstream claslib's 92.88 %** on the same
+data. The single largest contributor is the **BackupCSSR / BackupGrid** port
+that bridges short correction gaps (**+118 fixed epochs**, confirmed by a 5-cell
+ablation). A new opt-in **`MRTK_DETERMINISTIC_BLAS`** build links single-thread
+OpenBLAS so these ±0.1 pp comparisons are bit-reproducible run-to-run — with
+**no positioning-code change and the default build unaffected**.
+
+The release also carries several independent bug fixes: a ~0.10 m Galileo E5a
+antenna-PCV error, an `mrtk l6extract` stack overflow, all-GNSS solution-status
+output, and `traceopen` path handling.
+
+All CLAS-scoped changes are applied for CLAS only; the MADOCA-PPP references are
+unaffected. All five #225 PRs (#244–#248) passed CI and Copilot review.
+
+---
+
+### 1. Storm-day fix-rate gap — what closed it
+
+The #225 investigation traced the CLAS PPP-RTK deficit to three layers rather
+than a single bug. Each layer was brought to claslib parity independently:
+
+| Layer | Change | PR |
+|-------|--------|----|
+| Correction-stream timing | mask-time-aligned CSSR selection + per-epoch bank refresh | [#246](https://github.com/h-shiono/MRTKLIB/pull/246) |
+| Gap bridging | BackupCSSR / BackupGrid (≤ 180 s) | [#246](https://github.com/h-shiono/MRTKLIB/pull/246) |
+| Measurement model | claslib slot layout + OSR/adaptive-iono + PCV | [#247](https://github.com/h-shiono/MRTKLIB/pull/247) |
+| Ionosphere decay | est-adaptive AR(1) time constant wired into `udion()` | [#245](https://github.com/h-shiono/MRTKLIB/pull/245) |
+| SPP seed | Galileo E5a rows restored + large-residual exclusion | [#248](https://github.com/h-shiono/MRTKLIB/pull/248) |
+
+#### BackupCSSR / BackupGrid gap bridging
+
+Ported from claslib: CLAS now bridges correction gaps (≤ 180 s) with the last
+usable CSSR / grid snapshot instead of dropping the affected epochs to a single
+solution. On the #225 storm benchmark this is the largest single contributor
+(**+118 fixed epochs**, confirmed by a 5-cell ablation).
+
+#### CLAS PPP-RTK correction-stream timing
+
+CSSR is read through the correction set whose mask time equals the observation
+epoch, stopping at the first future mask — this fixes one-epoch-stale correction
+selection and a startup epoch lost to an empty grid. Grid status is bootstrapped
+by a network scan on the first epoch. `mrtk ssr2osr` now refreshes the bank
+snapshot every epoch instead of only on a network change (it previously served
+the first correction set until it aged out at ~60 s and then stopped)
+([PR #246](https://github.com/h-shiono/MRTKLIB/pull/246)).
+
+#### CLAS PPP-RTK measurement model
+
+Brought to the claslib observation slot layout —
+GPS {L1, L2, L5} / GAL {E1, –, E5a, E6, E5b, E5ab} / QZS {L1, L2, L5, L6} — with
+the OSR ambiguity index for est-adaptive ionosphere, a facility-change
+filter-reset guard, residual wavelength-ratio parity, and CPC freq-major
+persistence across `zdres` passes. All of this is applied for CLAS only.
+
+QZSS L1 signal priority (C > S > L > X > Z) is a **CLAS-scoped runtime
+override**: claslib and MADOCALIB genuinely disagree on the order, so it is
+enabled only from `mrtk post` while `correction = CLAS`, leaving the MADOCA-PPP
+references unaffected ([PR #247](https://github.com/h-shiono/MRTKLIB/pull/247)).
+
+#### Ionosphere Gauss-Markov decay
+
+The est-adaptive ionosphere time constant was parsed but never wired into
+`udion()` state propagation; the AR(1) decay now matches claslib
+([PR #245](https://github.com/h-shiono/MRTKLIB/pull/245)).
+
+#### CLAS SPP velocity seed
+
+The GAL / SBS iono-free second frequency is now taken from slot 2 (E5a),
+restoring the Galileo rows to the seed like upstream
+([PR #248](https://github.com/h-shiono/MRTKLIB/pull/248)).
+
+---
+
+### 2. Deterministic-BLAS builds
+
+`MRTK_DETERMINISTIC_BLAS` is a new opt-in CMake option that links a deterministic
+LP64 single-thread OpenBLAS instead of Apple Accelerate. Accelerate's
+non-deterministic floating-point reductions scatter storm-day fix rates
+run-to-run because the AR ratio test amplifies ULP noise into fix/float flips;
+OpenBLAS makes those comparisons bit-reproducible so the ±0.1 pp deltas above are
+meaningful.
+
+It is intended for benchmarking / CI reproducibility only. There is **no
+positioning-code change and the default build is unaffected**. A configure-time
+check verifies OpenBLAS is the resolved LAPACK provider
+([PR #244](https://github.com/h-shiono/MRTKLIB/pull/244)).
+
+---
+
+### 3. New configuration
+
+- **`pos2-rejethres` / `pos2-rejeminsat`** — upstream SPP large-residual
+  exclusion. Default `0` keeps standalone SPP bit-compatible; the CLAS
+  PPP-RTK / VRS private seed maps `0` to upstream's 20 m / 7-sat defaults
+  ([PR #248](https://github.com/h-shiono/MRTKLIB/pull/248)).
+- **`pos1-frequency = l1+l2+l5`** — config alias for the CLAS three-frequency
+  observation slot layout ([PR #247](https://github.com/h-shiono/MRTKLIB/pull/247)).
+
+---
+
+### 4. Bug fixes
+
+- **Galileo E5a antenna PCV error (~0.10 m)** — receiver PCV slot mapping now
+  uses claslib-compatible ANTEX compaction. The stale offset had been cascading
+  into ambiguity resets (the E34 case in the #225 ledger)
+  ([PR #247](https://github.com/h-shiono/MRTKLIB/pull/247)).
+- **`mrtk l6extract` 2-byte stack overflow** in `sbf_extract_l6_payload`
+  ([PR #237](https://github.com/h-shiono/MRTKLIB/pull/237)).
+- **`traceopen` filename handling** — guard path length before `reppath` and
+  expand time keywords in the trace filename
+  ([#83](https://github.com/h-shiono/MRTKLIB/issues/83),
+  [PR #239](https://github.com/h-shiono/MRTKLIB/pull/239)).
+- **Solution-status (`.stat`) output** now emits all GNSS, not just GPS
+  ([PR #240](https://github.com/h-shiono/MRTKLIB/pull/240)).
+- **Test harness** — BSD `mktemp` suffix collision in `run_rtkrcv_test.sh`
+  ([#194](https://github.com/h-shiono/MRTKLIB/issues/194),
+  [PR #241](https://github.com/h-shiono/MRTKLIB/pull/241)).
+
+---
+
+### 5. Documentation
+
+- **ICD & academic-paper reference catalogs** — `docs/reference/icd/` and
+  `docs/reference/papers/` index pages added to the MkDocs Reference nav
+  (link-only rows; collected PDFs held locally)
+  ([PR #238](https://github.com/h-shiono/MRTKLIB/pull/238)).
+
+---
+
+### 6. Validation
+
+- **Storm-day CLAS kinematic PPP-RTK (deterministic OpenBLAS):** fix rate
+  **89.44 % → 93.54 %**, above upstream claslib's **92.88 %** on the same data.
+  The BackupCSSR contribution (**+118 epochs**) is confirmed by a 5-cell
+  ablation.
+- **claslib label 34/34** (including RT replay and F5 absolute-accuracy checks);
+  the MADOCA-PPP references are unaffected (the QZSS L1 priority change is
+  CLAS-scoped).
+- Full `ctest` suite green apart from the two perennial environment failures on
+  the maintainer's machine (`rtkrcv_rt` headless RT replay,
+  `madocalib_pppar_ion_check` LAPACK-vs-reference tolerance), both of which
+  reproduce identically on a clean `develop`.
+- All five #225 PRs (#244–#248) passed CI and Copilot review.
+
+---
+
+### Compatibility & migration
+
+No configuration changes are required. Existing CLAS PPP-RTK and MADOCA-PPP
+workflows are unaffected; the CLAS parity work is scoped to `correction = CLAS`
+and the MADOCA-PPP references are untouched. The new `pos2-rejethres` /
+`pos2-rejeminsat` and `pos1-frequency = l1+l2+l5` options default to
+backward-compatible behavior, and `MRTK_DETERMINISTIC_BLAS` is off by default
+with no effect on the standard build.
+
+### Issues / PRs
+
+- [#225](https://github.com/h-shiono/MRTKLIB/issues/225) — CLAS PPP-RTK storm-day
+  fix-rate gap vs. upstream claslib.
+- [PR #244](https://github.com/h-shiono/MRTKLIB/pull/244) — `MRTK_DETERMINISTIC_BLAS`.
+- [PR #245](https://github.com/h-shiono/MRTKLIB/pull/245) — ionosphere Gauss-Markov decay.
+- [PR #246](https://github.com/h-shiono/MRTKLIB/pull/246) — correction-stream timing + BackupCSSR / BackupGrid.
+- [PR #247](https://github.com/h-shiono/MRTKLIB/pull/247) — measurement model + Galileo E5a PCV fix.
+- [PR #248](https://github.com/h-shiono/MRTKLIB/pull/248) — SPP seed + large-residual exclusion.
+- [PR #250](https://github.com/h-shiono/MRTKLIB/pull/250) — release.
+- Independent fixes: [PR #237](https://github.com/h-shiono/MRTKLIB/pull/237),
+  [PR #238](https://github.com/h-shiono/MRTKLIB/pull/238),
+  [PR #239](https://github.com/h-shiono/MRTKLIB/pull/239),
+  [PR #240](https://github.com/h-shiono/MRTKLIB/pull/240),
+  [PR #241](https://github.com/h-shiono/MRTKLIB/pull/241).
+
+### References
+
+- IS-QZSS-L6 — CLAS (L6D) CSSR message format.
+- claslib — the upstream reference implementation for CLAS PPP-RTK.

--- a/docs/releases/release-notes-v0.7.5.md
+++ b/docs/releases/release-notes-v0.7.5.md
@@ -1,0 +1,91 @@
+# Release Notes — v0.7.5
+
+## Single-band CLAS PPP-RTK — regression coverage and capability record
+
+**Release date:** 2026-07-06
+**Type:** Test coverage + capability record (no positioning change)
+**Branch:** `release/v0.7.5`
+
+---
+
+### Overview
+
+v0.7.5 is **not a feature release** — there are **no positioning-code changes**.
+It locks in two single-band CLAS PPP-RTK configurations that the v0.7.4 engine
+already handles, backing each with a regression test anchored to **independent
+truth**, and records the mechanics in a new design note.
+
+The v0.7.4 engine already positions these configurations correctly without any
+dedicated single-frequency machinery: the ionosphere Gauss-Markov decay bounds
+the unobservable per-satellite iono residual, so a single-band solution stays
+well-behaved. This release captures that behavior as tests so it cannot silently
+regress, and documents *why* it works.
+
+The two configurations are:
+
+1. **Single-frequency (nf=1) CLAS PPP-RTK.**
+2. **Galileo E1/E5b band mismatch** — u-blox ZED-F9P-class receivers tracking
+   E1+E5b under CLAS E5a-only biases.
+
+---
+
+### 1. Regression coverage for single-band CLAS PPP-RTK
+
+Two new claslib test triples lock in the v0.7.4 behavior. Each triple pairs a
+consistency reference with an absolute check against independent truth.
+
+#### Single-frequency (nf=1)
+
+- New config `conf/claslib/rnx2rtkp_sf.toml`.
+- **2019/239** dataset, validated against **GSI F5 truth**.
+- Absolute accuracy: **2D 1σ 2.5 cm / 95 % 3.9 cm**.
+
+#### Galileo E1/E5b band mismatch
+
+- ZED-F9P-class receivers track E1+E5b, but CLAS carries E5a-only biases, so the
+  mismatched satellites run **E1-only**.
+- Self-collected **ECJ02** dataset, validated against an **independent
+  IGS-products coordinate**.
+- Absolute accuracy: **3D 1σ 18.5 cm / 95 % 20.6 cm**.
+- The E1-only satellites bound the solution at **dm-level** — this is **not**
+  DF-equivalent accuracy, and the test enforces that bound rather than a
+  dual-frequency target.
+
+---
+
+### 2. Tooling
+
+`compare_nmea_abs.py` gains a `--llh` fixed-coordinate option, so an absolute
+accuracy check can be anchored to a supplied lat/lon/height (the ECJ02
+IGS-products coordinate) rather than an averaged solution.
+
+---
+
+### 3. Design record
+
+`docs/design/sf-ppp-rtk.md` records:
+
+- The mechanics of single-band CLAS PPP-RTK, and the dependency on the
+  ionosphere Gauss-Markov decay that bounds the unobservable iono residual.
+- A post-mortem of the explicit SF iono constraint that was **prototyped**, then
+  **subsumed by the v0.7.4 engine changes**, and **deliberately not shipped**.
+
+---
+
+### Compatibility & migration
+
+No configuration changes are required for existing workflows; the new
+`conf/claslib/rnx2rtkp_sf.toml` is additive. There are **no positioning-algorithm,
+matrix, physical-constant, or test-tolerance changes** — v0.7.5 only adds tests,
+one tooling option, and documentation.
+
+### Issues / PRs
+
+- [PR #253](https://github.com/h-shiono/MRTKLIB/pull/253) — regression coverage,
+  `compare_nmea_abs.py --llh`, and `docs/design/sf-ppp-rtk.md`.
+- [PR #254](https://github.com/h-shiono/MRTKLIB/pull/254) — release.
+
+### References
+
+- `docs/design/sf-ppp-rtk.md` — single-band CLAS PPP-RTK behavior record and the
+  not-shipped SF iono-constraint post-mortem.

--- a/docs/releases/release-notes-v0.7.6.md
+++ b/docs/releases/release-notes-v0.7.6.md
@@ -1,0 +1,219 @@
+# Release Notes — v0.7.6
+
+## TOML configuration redesign, IGS PPP-AR receiver code bias, and CLAS periodic filter reset
+
+**Release date:** 2026-07-12
+**Type:** Configuration redesign (backward compatible via deprecation aliases) + PPP features
+**Branch:** `release/v0.7.6`
+
+---
+
+### Overview
+
+v0.7.6 re-organizes the TOML configuration vocabulary that MRTKLIB has carried
+since the v0.5.0 TOML migration. The change is broad but deliberately
+non-disruptive:
+
+- **Old configs keep working.** Every renamed section/key is accepted through a
+  **deprecation alias**: the loader applies the value and prints a one-line
+  warning pointing at the new location. When both the old and new paths are
+  present, the new path wins. The full old → new mapping is reproduced in
+  [section 4](#4-deprecated-old-new-migration-table) below and in the
+  [configuration guide's migration section](../guide/configuration.md).
+- **Unknown keys warn instead of vanishing.** A key the loader does not
+  recognize now emits `TOML: unknown key [section].key (ignored)` instead of
+  silently falling back to a default — so a typo is visible rather than silently
+  ineffective.
+- **No results change for shipped/default configurations.** The redesign fixes
+  several *option-slot collisions* (two unrelated settings sharing one storage
+  slot in the positioning code), but none of these fixes alters the output of
+  any shipped `conf/` sample or default configuration.
+- **The generated config reference is now CI-gated.**
+  `docs/reference/config-options.md` is produced by
+  `scripts/docs/gen_config_ref.py`, and a new `config-ref` CI job fails the
+  build if the committed reference drifts from a fresh generator run.
+
+Alongside the configuration work, v0.7.6 also ships two positioning features:
+**receiver code-bias support** plus an opt-in uncorrected-pseudorange gate for
+IGS PPP-AR ([#263](https://github.com/h-shiono/MRTKLIB/issues/263)), and the
+**claslib periodic full-filter reset** ported to post-processing PPP-RTK
+([#264](https://github.com/h-shiono/MRTKLIB/issues/264)).
+
+This is the largest configuration-facing release to date. If you author or
+maintain `conf/` files by hand, read section 4 — every old path still loads, but
+re-saving a config always writes the new layout.
+
+---
+
+### 1. Configuration redesign
+
+#### Sections regrouped by consumer
+
+The historical grab-bag `[receiver]` and `[server]` sections are dismantled and
+re-grouped by the engine that actually consumes each setting:
+
+- `[positioning.ppp]` — PPP-family options (satellite clock / phase bias, clock
+  jump, uncorrected-code gate, `options`, …).
+- `[positioning.relative]` — baseline / max-age / time-interpolation options.
+- `[positioning.spp]` — single-point-positioning options.
+- `[positioning.madoca]` — MADOCA-PPP options.
+- `[positioning.clas.*]` — CLAS PPP-RTK / VRS options, including
+  `[positioning.clas.ambiguities]`, `[positioning.clas.resilience]`, and
+  `[positioning.clas.adaptive_filter]`.
+- `[input.*]` — stream/format inputs (`[input.rinex]`, `[input.rtcm]`,
+  `[input.sbas]`).
+
+The former `[adaptive_filter]` section is nested as
+`[positioning.clas.adaptive_filter]` because it is consumed by the CLAS
+PPP-RTK / VRS engines only. All shipped `conf/` samples and docs use the new
+layout; old paths continue to load via the aliases in section 4.
+
+#### Other key changes
+
+| Change | Detail |
+|---|---|
+| `excluded_sats` is a string list | `excluded_sats = ["G05", "+G26"]`; the old single-string form still loads. `+` cannot force-include a satellite that has no ephemeris. |
+| `[input.sbas].satellite` | Integer PRN selector for the SBAS satellite. |
+| `[positioning.corrections].snr_fixed` | Renamed from `reserved`; an integer dB-Hz value routed to its own option slot. |
+| Config-reference metadata audited | Per-option mode applicability corrected (phase windup and Shapiro delay are PPP-family options, etc.). |
+| RT CLAS test references relocated | Moved out of the source tree into the build directory so parallel `ctest` invocations no longer collide. |
+
+---
+
+### 2. New PPP features
+
+#### Receiver code bias in IGS PPP-AR ([#263](https://github.com/h-shiono/MRTKLIB/issues/263))
+
+Station-level OSB records in a Bias-SINEX product (matched against the RINEX
+marker name) are now applied to pseudoranges in the uncombined PPP-AR engine,
+with satellite-specific and system-wide fallback paths. Products without station
+records are unaffected.
+
+#### `[positioning.ppp].drop_uncorrected_code` (opt-in, default off)
+
+A port of the MADOCALIB unbias gate: pseudoranges without an applicable code bias
+are excluded from the solution instead of entering it uncorrected. Carrier phase
+is retained. Off by default, so existing IGS PPP-AR runs are unchanged unless the
+option is enabled.
+
+#### `[positioning.clas.resilience].reset_interval` (opt-in, default off) ([#264](https://github.com/h-shiono/MRTKLIB/issues/264))
+
+claslib's periodic full-filter reset, ported into post-processing
+`ppp_rtk_pos()` and covered by a trace-checked regression test. Off by default.
+
+---
+
+### 3. Option-slot collision fixes
+
+Several unrelated settings shared a single storage slot in the positioning code;
+each now has its own. **None of these changes the results of shipped/default
+configurations** — the fixes prevent cross-contamination that only manifested
+under non-default combinations.
+
+| Collision | Fix |
+|---|---|
+| CLAS OSR gated the Shapiro delay on the *phase windup* option instead of `shapiro_delay`. | Now keyed to the correct option. `cssr2rtcm3` / `ssr2obs` explicitly enable it, so converter behavior is unchanged ([PR #267](https://github.com/h-shiono/MRTKLIB/pull/267)). |
+| `osr[].relatv` could carry a stale cross-epoch relativity term when the option was off. | Cleared per epoch ([PR #267](https://github.com/h-shiono/MRTKLIB/pull/267)). |
+| CLAS/VRS position process noise fell back to the *IFB* process-noise slots. | `[kalman_filter.process_noise].position_h` / `position_v` / `ifb` are now independent ([PR #275](https://github.com/h-shiono/MRTKLIB/pull/275)). |
+| PPP day-boundary clock-jump compensation shared a slot with CLAS `iono_compensation`. | Now its own `[positioning.ppp].clock_jump` option (default off, as before) ([PR #278](https://github.com/h-shiono/MRTKLIB/pull/278)). |
+| CLAS atmosphere variance terms shared slots with the SPP C/N0 error model (`snr_max` / `snr_error`). | Now dedicated `[kalman_filter.measurement_error].ionosphere` / `troposphere` options; the ionosphere variance is applied in `est-adaptive` mode too ([PR #279](https://github.com/h-shiono/MRTKLIB/pull/279)). |
+
+An additional fix: rtkrcv previously printed every unknown-key warning twice (it
+loads the options file once for server options and once for system options). The
+unknown-key sweep now runs once per file fingerprint
+([PR #290](https://github.com/h-shiono/MRTKLIB/pull/290)).
+
+---
+
+### 4. Deprecated: old → new migration table
+
+The old paths below still load with a one-line warning; they are planned for
+removal in a future minor release. Re-saving a config always writes the new
+layout.
+
+| Old path | New path |
+|---|---|
+| `[receiver].phase_shift` / `isb` / `reference_type` | `[positioning.clas.ambiguities]` (same key) |
+| `[receiver].iono_correction` | `[positioning.madoca].iono_correction` |
+| `[receiver].ignore_chi_error` | `[positioning.spp].ignore_chi_error` |
+| `[receiver].ppp_sat_clock_bias` / `ppp_sat_phase_bias` | `[positioning.ppp].satellite_clock_bias` / `satellite_phase_bias` |
+| `[receiver].max_bias_dt` | `[positioning.ppp].max_bias_dt` |
+| `[receiver].uncorr_bias` | `[positioning.ppp].drop_uncorrected_code` |
+| `[receiver].max_age` / `baseline_length` / `baseline_sigma` | `[positioning.relative]` (same key) |
+| `[server].max_obs_loss` / `float_count` | `[positioning.clas.resilience]` (same key) |
+| `[server].l6_margin` | `[positioning.clas.resilience].l6_merge` |
+| `[server].regularly` | `[positioning.clas.resilience].reset_interval` |
+| `[server].ppp_option` | `[positioning.ppp].options` |
+| `[server].time_interpolation` | `[positioning.relative].time_interpolation` |
+| `[server].rinex_option_1` / `rinex_option_2` | `[input.rinex].option_1` / `option_2` |
+| `[server].rtcm_option` | `[input.rtcm].options` |
+| `[server].sbas_satellite` | `[input.sbas].satellite` |
+| `[adaptive_filter].*` | `[positioning.clas.adaptive_filter].*` (same keys) |
+
+---
+
+### 5. Removed dead keys
+
+The keys below had no effect (or, for `position_uncertainty_*`, a wrong one), so
+there is no replacement; setting them now triggers the unknown-key warning
+([PR #271](https://github.com/h-shiono/MRTKLIB/pull/271),
+[#280](https://github.com/h-shiono/MRTKLIB/pull/280),
+[#283](https://github.com/h-shiono/MRTKLIB/pull/283)):
+
+| Removed key | Note |
+|---|---|
+| `[ambiguity_resolution.thresholds].ratio2` / `ratio3` / `ratio4` | Unread |
+| `[ambiguity_resolution.hold].gain` | No consumer |
+| `[kalman_filter].sync_solution` | Unread |
+| `[receiver].bds2_bias`, `[receiver].satellite_mode` | Unread |
+| `[files].elevation_mask_file` / `geexe` / `solution_stat` | Unread |
+| `[positioning.clas].position_uncertainty_x` / `_y` / `_z` | Miswired: they overwrote the rover ECEF position used by fixed-position modes instead of setting any uncertainty. Fixed-mode rover coordinates remain settable via the antenna-position options. |
+
+---
+
+### 6. Validation
+
+A five-perspective pre-release review (config loader, algorithm safety,
+config-sweep, docs, tests) was run against the series. The deprecation aliases
+and unknown-key warning are locked in by a new `t_toml` unit test
+([#286](https://github.com/h-shiono/MRTKLIB/issues/286),
+[PR #288](https://github.com/h-shiono/MRTKLIB/pull/288)–[#290](https://github.com/h-shiono/MRTKLIB/pull/290)),
+and the new `[positioning.clas.resilience].reset_interval` path is covered by a
+trace-checked regression test.
+
+**Test suite:** 114/115 on the release gate — the only failure is the known
+environment-dependent `madocalib_pppar_ion_check` (LAPACK-vs-reference
+tolerance), which reproduces on a clean `develop` build. The RT CLAS reference
+relocation ([PR #282](https://github.com/h-shiono/MRTKLIB/pull/282)) removes the
+parallel-`ctest` port-collision false failures previously seen in `rtkrcv_rt`
+tests.
+
+---
+
+### Compatibility & migration
+
+No positioning-algorithm, matrix, physical-constant, or test-tolerance changes.
+Existing configurations continue to run: every renamed path loads through a
+deprecation alias (with a one-line warning pointing at the new location), and the
+option-slot collision fixes leave shipped/default configurations bit-for-bit
+unchanged. To migrate, either follow the table in
+[section 4](#4-deprecated-old-new-migration-table) or simply re-save each config
+— saved configs always use the new layout. See the
+[configuration guide's migration section](../guide/configuration.md) for a
+worked walkthrough.
+
+### Issues / PRs
+
+- [PR #291](https://github.com/h-shiono/MRTKLIB/pull/291) — release PR for
+  v0.7.6.
+- Series [PRs #256–#290](https://github.com/h-shiono/MRTKLIB/pull/290) — the TOML
+  configuration redesign, config-reference CI gate, IGS PPP-AR receiver code bias
+  ([#263](https://github.com/h-shiono/MRTKLIB/issues/263)), and the CLAS periodic
+  filter reset ([#264](https://github.com/h-shiono/MRTKLIB/issues/264)).
+
+### References
+
+- [Configuration guide](../guide/configuration.md) — including the migration
+  section for the v0.7.6 layout.
+- `docs/reference/config-options.md` — the CI-gated generated configuration
+  reference.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,11 @@ nav:
     - Positioning Configuration Model: design/configuration.md
   - Releases:
     - Changelog: releases/changelog.md
+    - v0.7.6: releases/release-notes-v0.7.6.md
+    - v0.7.5: releases/release-notes-v0.7.5.md
+    - v0.7.4: releases/release-notes-v0.7.4.md
+    - v0.7.3: releases/release-notes-v0.7.3.md
+    - v0.7.2: releases/release-notes-v0.7.2.md
     - v0.7.1: releases/release-notes-v0.7.1.md
     - v0.7.0: releases/release-notes-v0.7.0.md
     - v0.6.14: releases/release-notes-v0.6.14.md


### PR DESCRIPTION
Back-merge of PR #293 (docs-only, merged directly to main so GitHub Pages could deploy immediately): brings the five release-note pages (`docs/releases/release-notes-v0.7.2.md` … `v0.7.6.md`) and their `mkdocs.yml` nav entries into develop, keeping develop a superset of main ahead of the next release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)