### PR TITLE
fix(clas): OR semantics for l6_merge correction fetch in PPP-RTK (#303 part 1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -697,6 +697,8 @@ set_tests_properties(madocalib_pppar_abs_check PROPERTIES
 #   claslib_ppp_rtk         PPP-RTK with L6 (RINEX obs, 2019/239)
 #   claslib_ppp_rtk_bnx     PPP-RTK with L6 (BINEX obs, 2019/239)
 #   claslib_ppp_rtk_2ch     PPP-RTK with 2-channel L6 (2025/157)
+#   claslib_ppp_rtk_l6mrg_1file
+#                           PPP-RTK with l6_merge but only one L6 file (2025/157)
 #   claslib_ppp_rtk_st12    PPP-RTK with SubType 12 (BINEX obs, 2019/349)
 #   claslib_ppp_rtk_l1cl5   PPP-RTK with L1C+L5 frequency (2025/022)
 #   claslib_vrs_rtk         VRS-RTK (2019/239)
@@ -1081,6 +1083,40 @@ set_tests_properties(claslib_ppp_rtk_2ch_abs_check PROPERTIES
     DEPENDS           claslib_ppp_rtk_2ch
     FIXTURES_REQUIRED claslib_data
     LABELS            "absolute;claslib;ppp-rtk"
+)
+
+# ── rnx2rtkp CLAS PPP-RTK with l6_merge but a single L6 source (#303) ─────────
+# Same dataset/window as claslib_ppp_rtk_2ch, but only ch1 is supplied while
+# -l6msg 1 stays on: the correction fetch must skip the empty channel instead of
+# degrading every epoch to Single.  Reference is the upstream 2-channel output,
+# which the single-channel solution tracks to ~4 cm 3D RMS.
+add_test(NAME claslib_ppp_rtk_l6mrg_1file
+    COMMAND $<TARGET_FILE:mrtk> post
+        -k ${CMAKE_SOURCE_DIR}/conf/claslib/rnx2rtkp.toml
+        -ts 2025/06/06 20:00:00 -te 2025/06/06 20:59:59 -ti 1
+        -l6msg 1
+        -o ${CMAKE_BINARY_DIR}/out_claslib_ppp_rtk_l6mrg_1file.nmea
+        ${_CLSDATA}/0627157U.bnx
+        ${_CLSDATA}/0627157U.nav
+        ${_CLSDATA}/2025157U_ch1.l6
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_tests_properties(claslib_ppp_rtk_l6mrg_1file PROPERTIES
+    FIXTURES_REQUIRED claslib_data
+    TIMEOUT           300
+    LABELS            "regression;claslib;ppp-rtk"
+)
+
+add_test(NAME claslib_ppp_rtk_l6mrg_1file_check
+    COMMAND ${Python3_EXECUTABLE} ${_COMPARE_NMEA}
+        ${_CLSDATA}/ref_L6_2CH.nmea
+        ${CMAKE_BINARY_DIR}/out_claslib_ppp_rtk_l6mrg_1file.nmea
+        --tolerance 0.10
+)
+set_tests_properties(claslib_ppp_rtk_l6mrg_1file_check PROPERTIES
+    DEPENDS           claslib_ppp_rtk_l6mrg_1file
+    FIXTURES_REQUIRED claslib_data
+    LABELS            "regression;claslib;ppp-rtk"
 )
 
 # ── rnx2rtkp CLAS VRS-RTK regression ──────────────────────────────────────────

--- a/include/mrtklib/mrtk_clas.h
+++ b/include/mrtklib/mrtk_clas.h
@@ -724,6 +724,18 @@ void clas_backup_current(clas_ctx_t* ctx, const clas_grid_t* grid, int l6mrg);
 void clas_restore_backup(clas_ctx_t* ctx, gtime_t time, clas_grid_t* grid, int l6mrg);
 
 /**
+ * @brief Drop the current correction snapshot of one channel.
+ *
+ * Used when a channel supplies no corrections for the epoch, so that
+ * clas_update_global() clears nav_t.ssr_ch[ch] instead of re-applying the
+ * previous epoch's snapshot.
+ *
+ * @param[in,out] ctx  CLAS context
+ * @param[in]     ch   Channel index
+ */
+void clas_clear_current(clas_ctx_t* ctx, int ch);
+
+/**
  * @brief Apply global corrections (orbit/clock/bias) to nav_t.ssr[].
  * @param[in,out] nav   Navigation data
  * @param[in]     corr  Merged correction snapshot

--- a/src/clas/mrtk_clas.c
+++ b/src/clas/mrtk_clas.c
@@ -1229,6 +1229,14 @@ extern void clas_backup_current(clas_ctx_t* ctx, const clas_grid_t* grid, int l6
     }
 }
 
+extern void clas_clear_current(clas_ctx_t* ctx, int ch) {
+    if (!ctx || ch < 0 || ch >= CLAS_CH_NUM) {
+        return;
+    }
+    memset(&ctx->current[ch], 0, sizeof(clas_corr_t));
+    init_grid_index(&ctx->current[ch]);
+}
+
 extern void clas_restore_backup(clas_ctx_t* ctx, gtime_t time, clas_grid_t* grid, int l6mrg) {
     clas_clock_bank_t* clock;
     int i, ch, nch = l6mrg ? SSR_CH_NUM : 1;

--- a/src/pos/mrtk_postpos.c
+++ b/src/pos/mrtk_postpos.c
@@ -690,6 +690,13 @@ static int inputobs(obsd_t* obs, int solq, const prcopt_t* popt) {
         }
         /* update CLAS L6 corrections */
         if (clas_ctx) {
+            if (popt->l6mrg && !*clas_file[1]) {
+                static int warned_l6mrg_1file = 0;
+                if (!warned_l6mrg_1file) {
+                    warned_l6mrg_1file = 1;
+                    trace(NULL, 2, "l6_merge enabled but only one L6 source supplied - running single-channel\n");
+                }
+            }
             update_clas(obs[0].time);
         }
         /* update stat corrections */

--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -2445,12 +2445,15 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
             clas_update_global(nav, &clas->current[ch], ch);
             clas_update_local(nav, &clas->current[ch], ch);
         }
-        /* local corrections come from ch=0 unless that channel is the one that
-         * failed; all live channels share grid->network, so any of them fits */
+        /* local corrections come from the first channel holding a valid
+         * snapshot: a fetched channel and a backup-restored channel both set
+         * current[ch].use, while a failed channel was cleared above (or left
+         * empty by clas_restore_backup), so this covers the fetch and the
+         * backup paths alike; all live channels share grid->network */
         corr = &clas->current[0];
-        if (!use_backup && !chok[0] && nok > 0) {
+        if (opt->l6mrg && !clas->current[0].use) {
             for (ch = 1; ch < nch; ch++) {
-                if (chok[ch]) {
+                if (clas->current[ch].use) {
                     corr = &clas->current[ch];
                     break;
                 }

--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -2217,6 +2217,11 @@ static void check_clas_facility(nav_t* nav, const clas_ctx_t* clas, const clas_g
 
     for (ch = 0; ch < nch; ch++) {
         int facility = clas->current[ch].facility;
+        /* a channel without corrections carries no facility id: keep the last
+         * known one so that a correction gap does not look like a facility change */
+        if (!clas->current[ch].use) {
+            continue;
+        }
         if (savefacility[ch] != facility) {
             if (savefacility[ch] != -1) {
                 nav->filreset = 1;
@@ -2379,11 +2384,13 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
         use_backup = 1;
     }
 
-    /* fetch corrections for all active channels, or restore a short-gap backup */
+    /* fetch corrections for all active channels, or restore a short-gap backup.
+     * OR semantics as in claslib get_close_cssr(): a channel that cannot supply
+     * corrections is skipped and the epoch fails only if every channel fails. */
     {
         int nch = opt->l6mrg ? SSR_CH_NUM : 1;
-        int ch;
-        int fetch_failed = 0;
+        int ch, nok = 0;
+        int chok[SSR_CH_NUM] = {0};
         for (ch = 0; ch < nch && !use_backup; ch++) {
             /* re-fetch corrections closest to observation time,
              * falling back to L6 buffer time if obs lookup fails */
@@ -2395,13 +2402,23 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
                 }
                 if (bgrc != 0) {
                     trace(NULL, 3, "ppp_rtk_pos: bank lookup failed ch=%d\n", ch);
-                    fetch_failed = 1;
-                    break;
+                    continue;
                 }
                 clas_check_grid_status(clas, &clas->current[ch], ch);
             }
+            chok[ch] = 1;
+            nok++;
         }
-        if (fetch_failed) {
+        if (opt->l6mrg && nok == 1) {
+            static int warned_single_ch = 0;
+            if (!warned_single_ch) {
+                warned_single_ch = 1;
+                trace(NULL, 2,
+                      "ppp_rtk_pos: l6_merge active but only ch=%d supplies corrections, running single-channel\n",
+                      chok[0] ? 0 : 1);
+            }
+        }
+        if (!use_backup && nok == 0) {
             if (!clas_backup_valid(clas, obs[0].time, opt->l6mrg)) {
                 free(azel);
                 free(e);
@@ -2416,12 +2433,29 @@ extern void ppp_rtk_pos(rtk_t* rtk, const obsd_t* obs, int n, nav_t* nav) {
             use_backup = 1;
         } else if (!use_backup) {
             clas_backup_current(clas, grid, opt->l6mrg);
+            /* the snapshot of a channel that failed this epoch is stale: drop it so
+             * that neither ssr_ch[ch] nor the clock merge below picks it up */
+            for (ch = 0; ch < nch; ch++) {
+                if (!chok[ch]) {
+                    clas_clear_current(clas, ch);
+                }
+            }
         }
         for (ch = 0; ch < nch; ch++) {
             clas_update_global(nav, &clas->current[ch], ch);
             clas_update_local(nav, &clas->current[ch], ch);
         }
+        /* local corrections come from ch=0 unless that channel is the one that
+         * failed; all live channels share grid->network, so any of them fits */
         corr = &clas->current[0];
+        if (!use_backup && !chok[0] && nok > 0) {
+            for (ch = 1; ch < nch; ch++) {
+                if (chok[ch]) {
+                    corr = &clas->current[ch];
+                    break;
+                }
+            }
+        }
         check_clas_facility(nav, clas, grid, opt);
 
         /* dual-channel: merge freshest orbit/clock into ch=0 for satposs */


### PR DESCRIPTION
## Summary

Part 1 of #303 (3-part series). With `l6_merge` enabled, `ppp_rtk_pos()` had AND semantics on the per-channel correction fetch: a bank-lookup failure on **any** channel sank the whole epoch, so `mrtk post -l6msg 1` with a single `.l6` file degraded **every** epoch to Single (3600/3600 on the 2025/157 dataset). This PR mirrors upstream claslib `get_close_cssr()` (OR semantics: a failing channel is skipped; the epoch fails only when every channel fails) and makes the one-file case degrade gracefully to single-channel operation with a warning.

The actual channel **merge** (per-channel zdres/ddres, priority-channel selection) is deliberately NOT in this PR — it is part 2. Consequently all existing outputs are unchanged (verified byte-identical, see below).

## Changes

- `src/pos/mrtk_ppp_rtk.c` — fetch block rewritten: per-channel `chok[]`/`nok`, failing channel `continue`s, epoch-level backup/Single fallback only when all channels fail. One-shot warning when only one channel supplies corrections. Local-correction source (`corr`) falls back to the first live channel if ch0 is the failed one.
- `src/clas/mrtk_clas.c` / `include/mrtklib/mrtk_clas.h` — new `clas_clear_current()`: drops a failed channel's stale snapshot (after `clas_backup_current()`, so the last-good backup is preserved). This is what keeps stale corrections out of `nav->ssr_ch[ch]` and out of the ch1→ch0 clock-freshness merge.
- `src/pos/mrtk_ppp_rtk.c` (`check_clas_facility`) — skip channels without corrections so a transient gap is not misread as a facility change (would fire a spurious `filreset`).
- `src/pos/mrtk_postpos.c` — one-shot startup warning when `l6_merge` is set but only one L6 file is supplied.
- `CMakeLists.txt` — new regression pair `claslib_ppp_rtk_l6mrg_1file(_check)`.

## Validation

| Case | Before | After |
|---|---|---|
| ch1 only + `-l6msg 1` | fix 0 / single **3600** | fix **3595** / float 5 — byte-identical to the plain ch1-only run |
| 2ch + `-l6msg 1` | fix 3595 / float 5 | **byte-identical** to before |
| ch1 only (no `-l6msg`) | fix 3595 / float 5 | **byte-identical** to before |

- New regression is genuinely sensitive: the pre-fix binary fails it (3D RMS 0.963 m vs tol 0.10 m); post-fix passes at 4.1 cm RMS, fix rate 99.86% (= reference). The fix-rate check alone cannot catch the bug (all-Single NMEA scores as quality present); the RMS bound is what bites.
- Full suite: **117 tests, 116 passed**. Sole failure is the known environment failure `madocalib_pppar_ion_check` (system-LAPACK vs upstream embedded LU, 1.62 cm vs 0.5 cm tol; reproduces on clean develop).

## Notes for review

- The `corr` fallback path (ch0 failed, ch1 alive) is logically verified but not exercised by the bundled dataset — flagged per review policy.
- `clas_update_global()` already clears per-satellite `t0` when fed an empty snapshot (upstream-equivalent); clearing `current[ch]` is the lever that makes that happen for a failed channel. `clas_update_local()` is an empty placeholder in MRTKLIB — local corrections flow only through `corr`, which is why the snapshot clear is sufficient.

Part 1 of #303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)