### PR TITLE
test(clas): sensitive 2ch merge regression + l6_merge docs (#303 part 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -697,6 +697,9 @@ set_tests_properties(madocalib_pppar_abs_check PROPERTIES
 #   claslib_ppp_rtk         PPP-RTK with L6 (RINEX obs, 2019/239)
 #   claslib_ppp_rtk_bnx     PPP-RTK with L6 (BINEX obs, 2019/239)
 #   claslib_ppp_rtk_2ch     PPP-RTK with 2-channel L6 (2025/157)
+#   claslib_ppp_rtk_2ch_merge_diff_check
+#                           Sensitivity guard: 2ch merge output must differ from
+#                           ch1-only output (catches a dead/no-op merge, #303 A-4)
 #   claslib_ppp_rtk_l6mrg_1file
 #                           PPP-RTK with l6_merge but only one L6 file (2025/157)
 #   claslib_ppp_rtk_st12    PPP-RTK with SubType 12 (BINEX obs, 2019/349)
@@ -1032,7 +1035,6 @@ set_tests_properties(claslib_ppp_rtk_f9p_abs_check PROPERTIES
 # ── rnx2rtkp CLAS PPP-RTK regression (dual-channel L6) ────────────────────────
 # Data: 2025/06/06 20:00-21:00, 0627157U.bnx + 2025157U_ch1.l6 + ch2.l6
 # Reference: ref_L6_2CH.nmea (upstream claslib output with -l6msg 1)
-# Note: tolerance 0.21m due to wider accuracy gap on 2025 dataset (~20.2cm RMS)
 add_test(NAME claslib_ppp_rtk_2ch
     COMMAND $<TARGET_FILE:mrtk> post
         -k ${CMAKE_SOURCE_DIR}/conf/claslib/rnx2rtkp.toml
@@ -1051,12 +1053,16 @@ set_tests_properties(claslib_ppp_rtk_2ch PROPERTIES
     LABELS            "regression;claslib;ppp-rtk"
 )
 
+# Tolerance 0.10m: post-#305 dual-channel merge measures 4.543cm 3D RMS / fix
+# rate identical to reference (99.86%) -- ~2.2x headroom, matching the
+# ch1-only sibling claslib_ppp_rtk_l6mrg_1file_check's 0.10m/4.11cm precedent.
+# Fix-rate check is no longer skipped: the merge now reproduces the
+# reference's fix rate exactly, so a degradation is a real regression signal.
 add_test(NAME claslib_ppp_rtk_2ch_check
     COMMAND ${Python3_EXECUTABLE} ${_COMPARE_NMEA}
         ${_CLSDATA}/ref_L6_2CH.nmea
         ${CMAKE_BINARY_DIR}/out_claslib_ppp_rtk_2ch.nmea
-        --tolerance 0.21
-        --skip-fixrate
+        --tolerance 0.10
 )
 set_tests_properties(claslib_ppp_rtk_2ch_check PROPERTIES
     DEPENDS           claslib_ppp_rtk_2ch
@@ -1117,6 +1123,29 @@ set_tests_properties(claslib_ppp_rtk_l6mrg_1file_check PROPERTIES
     DEPENDS           claslib_ppp_rtk_l6mrg_1file
     FIXTURES_REQUIRED claslib_data
     LABELS            "regression;claslib;ppp-rtk"
+)
+
+# ── Sensitivity guard: the 2ch merge must actually change the solution ───────
+# claslib_ppp_rtk_2ch_check / claslib_ppp_rtk_l6mrg_1file_check alone cannot
+# tell a working 2-channel merge from a dead one that silently degrades to
+# ch1-only: both would still pass their tolerance-vs-reference checks. This
+# test instead compares the two engine outputs directly and asserts they
+# DIFFER by at least 2mm -- comfortably below the actual 1.77cm 3D RMS
+# merge-vs-ch1-only delta (median dH 0.319cm / max 3.156cm), comfortably above
+# the ~0.2mm single-epoch Accelerate ULP wobble between otherwise-identical
+# runs (#303 A-4). Verified sensitive: the same comparison against a run with
+# the merge disabled (l6_merge=0, both .l6 files still supplied) measures
+# 0.015cm 3D RMS and correctly FAILs this check.
+add_test(NAME claslib_ppp_rtk_2ch_merge_diff_check
+    COMMAND ${Python3_EXECUTABLE} ${_COMPARE_NMEA}
+        ${CMAKE_BINARY_DIR}/out_claslib_ppp_rtk_l6mrg_1file.nmea
+        ${CMAKE_BINARY_DIR}/out_claslib_ppp_rtk_2ch.nmea
+        --expect-min-rms 0.002
+)
+set_tests_properties(claslib_ppp_rtk_2ch_merge_diff_check PROPERTIES
+    DEPENDS           "claslib_ppp_rtk_2ch;claslib_ppp_rtk_l6mrg_1file"
+    FIXTURES_REQUIRED  claslib_data
+    LABELS             "regression;claslib;ppp-rtk"
 )
 
 # ── rnx2rtkp CLAS VRS-RTK regression ──────────────────────────────────────────

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -191,7 +191,7 @@ TOML section: `[positioning.clas.resilience]`
 |:---------|:-----|:------|:------------|
 | `max_obs_loss` | float | PPP-RTK | Maximum observation gap duration before filter reset (s). |
 | `float_count` | integer | PPP-RTK, VRS | Number of float epochs before triggering filter reset. |
-| `l6_merge` | integer | PPP-RTK, VRS | L6 message merge mode for CLAS corrections. |
+| `l6_merge` | integer | PPP-RTK, VRS | L6 message merge mode for CLAS corrections, across the two CLAS transmit pattern channels. `0` = off (channel 0 only). `1` = merge, choosing the per-satellite channel with more valid observations. `2` = merge with load-balanced channel choice. Applies to post-processing PPP-RTK (since the dual-channel correction merge, [#303](https://github.com/h-shiono/MRTKLIB/issues/303)) and VRS-RTK. Real-time `mrtk run` currently uses the second stream for PRN handover redundancy, not merging. |
 | `reset_interval` | integer | PPP-RTK, VRS | Regular filter reset interval (s). 0 = disabled. |
 
 ## Positioning — CLAS Adaptive Filter

--- a/docs/releases/release-notes-v0.4.4.md
+++ b/docs/releases/release-notes-v0.4.4.md
@@ -13,6 +13,11 @@ The unused base-station stream slot (stream index 1) is repurposed as a second L
 correction input, enabling `rtkrcv` to process two independent CLAS L6D streams
 simultaneously — matching the post-processing engine's dual-channel capability.
 
+*Clarification (added later): at this date the post-processing engine's
+"dual-channel capability" was two-stream VRS-RTK only. Dual-channel correction
+merging in the post-processing PPP-RTK engine itself landed later, via
+[#303](https://github.com/h-shiono/MRTKLIB/issues/303)/#305.*
+
 ### Highlights
 
 - **2ch CLAS real-time** — `rtkrcv` now accepts two L6 correction streams: stream 3

--- a/docs/releases/release-notes-v0.6.14.md
+++ b/docs/releases/release-notes-v0.6.14.md
@@ -77,6 +77,11 @@ ID, so two channels suffice no matter how many PRNs the receiver tracks
 for merging). The re-lock clock now takes the fresher of `raw[0].time` /
 `rtcm[0].time`, so it advances for any rover format.
 
+*Clarification (added later): "for merging" here means each channel gets a
+coherent, routable L6 stream. Genuine per-channel correction merging inside
+the PPP-RTK filter (as opposed to demux-level routing / handover redundancy)
+landed later, via [#303](https://github.com/h-shiono/MRTKLIB/issues/303)/#305.*
+
 #### Verification
 
 A live archive that froze on a real QZS handover (J195 set) was replayed through

--- a/scripts/docs/gen_config_ref.py
+++ b/scripts/docs/gen_config_ref.py
@@ -552,7 +552,16 @@ _OPTION_META: dict[str, tuple[str, str]] = {
     "misc-rnxopt2": ("All", "RINEX conversion option string for base stream."),
     "misc-pppopt": ("PPP", "PPP processing option string (passed to PPP engine)."),
     "misc-rtcmopt": ("RT, PP", "RTCM decoder option string."),
-    "misc-l6mrg": ("PPP-RTK, VRS", "L6 message merge mode for CLAS corrections."),
+    "misc-l6mrg": (
+        "PPP-RTK, VRS",
+        "L6 message merge mode for CLAS corrections, across the two CLAS transmit "
+        "pattern channels. `0` = off (channel 0 only). `1` = merge, choosing the "
+        "per-satellite channel with more valid observations. `2` = merge with "
+        "load-balanced channel choice. Applies to post-processing PPP-RTK (since "
+        "the dual-channel correction merge, [#303](https://github.com/h-shiono/MRTKLIB/issues/303)) "
+        "and VRS-RTK. Real-time `mrtk run` currently uses the second stream for "
+        "PRN handover redundancy, not merging.",
+    ),
     "misc-regularly": ("PPP-RTK, VRS", "Regular filter reset interval (s). 0 = disabled."),
     "misc-startcmd": ("RT", "Shell command executed on server start."),
     "misc-stopcmd": ("RT", "Shell command executed on server stop."),

--- a/scripts/tests/compare_nmea.py
+++ b/scripts/tests/compare_nmea.py
@@ -217,6 +217,9 @@ def main():
     )
     args = parser.parse_args()
 
+    if args.expect_min_rms is not None and args.expect_min_rms <= 0.0:
+        parser.error("--expect-min-rms must be > 0 (a non-positive minimum passes trivially)")
+
     # Parse files
     print(f"Reference : {args.ref}")
     print(f"Test      : {args.test}")

--- a/scripts/tests/compare_nmea.py
+++ b/scripts/tests/compare_nmea.py
@@ -207,12 +207,23 @@ def main():
         action="store_true",
         help="Skip fix rate degradation check (for float-only solutions)",
     )
+    parser.add_argument(
+        "--expect-min-rms",
+        type=float,
+        default=None,
+        help="Inverse mode: assert the two solutions DIFFER by at least this 3D RMS "
+        "(metres), instead of asserting similarity. Overrides --tolerance and "
+        "--skip-fixrate for the pass/fail judgment.",
+    )
     args = parser.parse_args()
 
     # Parse files
     print(f"Reference : {args.ref}")
     print(f"Test      : {args.test}")
-    print(f"Tolerance : {args.tolerance:.4f} m")
+    if args.expect_min_rms is not None:
+        print(f"Expect min RMS: {args.expect_min_rms:.4f} m (solutions must DIFFER)")
+    else:
+        print(f"Tolerance : {args.tolerance:.4f} m")
     if args.skip_epochs > 0:
         print(f"Skip      : {args.skip_epochs} initial epochs")
     print()
@@ -264,6 +275,23 @@ def main():
     # Generate plot if requested
     if args.plot:
         plot_results(metrics)
+
+    # Inverse mode: assert the solutions differ instead of matching.
+    if args.expect_min_rms is not None:
+        if metrics["rms_3d"] >= args.expect_min_rms:
+            print(
+                f"PASS: 3D RMS ({metrics['rms_3d']:.6f} m) >= expected minimum "
+                f"({args.expect_min_rms:.6f} m) -- solutions differ as expected"
+            )
+            print("\nRESULT: PASS")
+            return 0
+        else:
+            print(
+                f"FAIL: 3D RMS ({metrics['rms_3d']:.6f} m) < expected minimum "
+                f"({args.expect_min_rms:.6f} m) -- solutions unexpectedly match"
+            )
+            print("\nRESULT: FAIL")
+            return 1
 
     # Pass/Fail judgment
     passed = True


### PR DESCRIPTION
## Summary

Final part of #303. With the merge itself landed (#305), this PR makes the regression suite actually guard it, and documents `l6_merge`. No C code changes.

## Test changes

- **`scripts/tests/compare_nmea.py`**: new `--expect-min-rms <m>` inverse-assertion mode — PASS when two solutions DIFFER by at least the given 3D RMS. Normal mode untouched.
- **`claslib_ppp_rtk_2ch_check`** *(deliberate tolerance change, #303 A-4)*: `--tolerance 0.21` → **`0.10`** — measured 4.543 cm 3D RMS vs `ref_L6_2CH.nmea`, ~2.2× headroom, same value as the sibling `l6mrg_1file_check` (0.10 m / 4.11 cm). `--skip-fixrate` removed: the merged solution reproduces the reference fix rate exactly (99.86%), so a fix-rate drop is now a real regression signal.
- **New `claslib_ppp_rtk_2ch_merge_diff_check`**: compares the merged 2ch output against the ch1-only output (reusing the existing `l6mrg_1file` test's product — no extra engine run) with `--expect-min-rms 0.002`.

**Sensitivity proven in both directions:**

| Scenario | 3D RMS vs ch1-only | Verdict |
|---|---|---|
| Working merge (`-l6msg 1`, 2 files) | **1.770 cm** | PASS (≥ 2 mm) |
| Dead merge (no flag, 2 files still supplied) | **0.015 cm** | **FAIL** — correctly caught |

The 2 mm threshold sits ~9× below the real merge delta and ~13× above the dead-merge residual (which itself is the known sub-mm samefac-path difference, not zero). The pre-#305 test set passed both scenarios identically — that blind spot is closed.

## Docs

- `l6_merge` in the config reference now states the 0/1/2 semantics (off / priority-channel merge / load-balanced merge), that it applies to post-processing PPP-RTK (#303) and VRS-RTK, and that real-time `mrtk run` uses the second stream for PRN handover redundancy, not merging. Edited in `scripts/docs/gen_config_ref.py` (the generator source) and regenerated, keeping the CI regeneration gate green.
- `release-notes-v0.4.4.md` / `release-notes-v0.6.14.md`: history not rewritten — one italic clarification each, noting that genuine PPP-RTK correction merging landed via #303/#305.

## Validation

`ctest -R claslib`: **45/45 passed**, including the tightened check and the new diff check. `ruff format --check` clean on the touched script; config reference regeneration diff is exactly the one `l6_merge` row.

Closes #303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)