### PR TITLE
fix(rtk): size ddres nb[] for all six system groups (#307)

### DIFF
--- a/src/pos/mrtk_ppp_rtk.c
+++ b/src/pos/mrtk_ppp_rtk.c
@@ -1600,7 +1600,9 @@ static int ddres(rtk_t* rtk, const nav_t* nav, double* x, double** pbslip, const
     prcopt_t* opt = &rtk->opt;
     double pos[3], lami, lamj, *Ri, *Rj, *Hi = NULL;
     double *tropu, *im, *dtdxu, didxi = 0.0, didxj = 0.0, fi, fj;
-    int i, j, k, l, m, f, nv = 0, nb[NFREQ * 4 * 2 + 1] = {0}, b = 0;
+    /* nb is indexed once per (system group, freq, phase/code) DD block: the
+     * system loop runs 6 groups, so size by 6 as upstream does (#307) */
+    int i, j, k, l, m, f, nv = 0, nb[NFREQ * 6 * 2 + 1] = {0}, b = 0;
     int sati, satj, sysi, sysj, nf = NF_RTK(opt), flg = 0;
     int h, ch = -1, sch, refsatch, refchgflg, ch_sig_cnt[SSR_CH_NUM] = {0};
     int samefac = 0, nch = opt->l6mrg ? SSR_CH_NUM : 1;


### PR DESCRIPTION
## Summary

One-line latent-bound fix from the #305 algorithm-safety review, filed as #307: `ddres()`'s `nb[]` gets one entry per (system group, freq, phase/code) DD block and the system loop runs **six** groups, but the array was sized `NFREQ*4*2+1` (=41 with the library's `-DNFREQ=5`) versus upstream claslib's `NFREQ*6*2+1` (=61).

Unreachable today — the counter could hit 60 only with `nf >= 4` across all six system groups, and CLAS configurations mandate `nf=2` (worst case 24) — so this is correctness by construction, not a behaviour change.

## Validation

- 2ch-merged and single-channel solutions **byte-identical** to the pre-change binary (2025/157 dataset).
- `ctest -R claslib`: 45/45 passed.
- clang-format clean.

Closes #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)