### PR TITLE
fix(benchmark): join hourly L6 sessions, expose misfix, record v0.7.7 results

### DIFF
--- a/docs/reference/benchmark.md
+++ b/docs/reference/benchmark.md
@@ -186,11 +186,9 @@ python compare_ppc.py \
 
 ---
 
-## v0.3.3 Benchmark Results
+## Solution Quality Tiers
 
-Results recorded on MRTKLIB v0.3.3, GNSS-only (no IMU), `--skip-epochs 60`.
-
-### Solution Quality Tiers
+Shared by every results section below.
 
 CLAS and RTK produce integer-fix solutions and are broken down into three tiers.
 MADOCA-PPP never produces an integer fix and is reported as a single **PPP** tier.
@@ -211,12 +209,22 @@ MADOCA-PPP never produces an integer fix and is reported as a single **PPP** tie
 error below 30 cm.  On the FIX row it answers "of the epochs that claimed an
 integer fix, how many were actually right", so its complement is the **misfix
 rate** — a Q=4 epoch beyond 30 cm is a wrong fix, not a degraded one.  The
-per-case progress line prints that complement directly as `misfix=`.  (Added
-after the v0.3.3 tables below, which therefore do not carry the column.)
+per-case progress line prints that complement directly as `misfix=`.  The column
+was added in v0.7.7, so the earlier tables below do not carry it.
 
 **TTFF column:**
 - CLAS / RTK: first epoch of a ≥30-consecutive Q=4 run (shown on FIX row)
 - MADOCA: first epoch of a ≥30-consecutive sub-30 cm run (shown on PPP row)
+
+---
+
+## v0.3.3 Benchmark Results
+
+Results recorded on MRTKLIB v0.3.3, GNSS-only (no IMU), `--skip-epochs 60`.
+
+> The current numbers are in [v0.7.7 Benchmark Results](#v077-benchmark-results).
+> Everything from here to that section is kept as the historical record the
+> later comparisons are measured against.
 
 ### Nagoya
 
@@ -631,6 +639,129 @@ horizontal error over fixed epochs.
   arguably where it matters most (stream gaps and slips make real-time the
   reset-prone regime the seed targets). The numbers above are post-processing;
   the real-time effect has not yet been separately benchmarked.
+
+---
+
+## v0.7.7 Benchmark Results
+
+Full re-run of all six cases × three modes on the current code, in a single
+pass.  This is the first table to carry the `<30cm` column, and the first since
+the benchmark harness bug described below was fixed.
+
+### Environment
+
+| | |
+|---|---|
+| Binary | `mrtk (MRTKLIB ver.0.7.7 git v0.7.7-8-g31511dd)` |
+| Platform | macOS 26.5.2, Apple M3 (arm64) |
+| BLAS / LAPACK | Accelerate (default; **not** a `MRTK_DETERMINISTIC_BLAS` build) |
+| Command | `run_benchmark.py --mode all --skip-download --skip-epochs 60 --force` |
+| Configs | `conf/benchmark/{clas,madoca,rtk}.toml` + `{nagoya,tokyo}.toml`, untuned |
+
+On this data two runs with identical arguments agree to within the last digit
+of latitude/longitude (≈0.2 mm on ~10% of epochs — the known macOS/Accelerate
+floating-point nondeterminism) and every statistic below is unchanged between
+runs.  That is *not* a general guarantee: ambiguity resolution is a threshold
+decision, so a build where fixes sit near the ratio test can flip epochs.  Use
+a `MRTK_DETERMINISTIC_BLAS` build (OpenBLAS LP64, single-threaded) when exact
+reproducibility matters.
+
+### Nagoya
+
+| Case | Mode | Tier | N | nSV | Rate% | `<30cm` | RMS 2D | 1σ (68%) | 95% | TTFF (s) |
+|------|------|------|--:|----:|------:|--------:|-------:|---------:|----:|---------:|
+| nagoya_run1 | CLAS   | FIX |  4 059 | 10.1 | 53.9% | 13.3% |   0.995 m | 0.648 m |  1.162 m |    0 |
+|             |        | FF  |  6 727 |  9.2 | 89.4% | 12.3% |  14.061 m | 1.111 m | 13.114 m |    — |
+|             |        | ALL |  7 525 |  8.6 |     — | 11.0% |  40.073 m | 1.161 m | 49.030 m |    — |
+| nagoya_run1 | MADOCA | PPP |  6 347 | 12.8 |  2.0% |  2.0% |  11.178 m | 3.220 m | 14.813 m | 1089 |
+| nagoya_run1 | RTK    | FIX |  2 103 | 19.0 | 28.9% | 98.7% |   1.002 m | 0.112 m |  0.145 m |  799 |
+|             |        | FF  |  7 213 | 16.8 | 99.0% | 65.5% |   6.129 m | 0.397 m |  5.732 m |    — |
+|             |        | ALL |  7 283 | 16.7 |     — | 64.9% |  21.171 m | 0.408 m |  6.389 m |    — |
+| nagoya_run2 | CLAS   | FIX |  3 194 | 11.3 | 34.0% |  2.5% |   2.372 m | 0.486 m |  1.241 m |    0 |
+|             |        | FF  |  8 338 |  8.8 | 88.8% |  3.3% | 375.042 m | 3.653 m | 35.311 m |    — |
+|             |        | ALL |  9 390 |  8.4 |     — |  2.9% | 426.142 m | 7.316 m | 60.785 m |    — |
+| nagoya_run2 | MADOCA | PPP |  7 493 | 11.9 |  0.2% |  0.2% |  39.302 m | 2.967 m | 19.450 m |    — |
+| nagoya_run2 | RTK    | FIX |    695 | 23.0 |  7.4% | 91.9% |   1.849 m | 0.083 m |  3.315 m |    0 |
+|             |        | FF  |  9 274 | 15.3 | 99.4% | 24.1% |   6.888 m | 3.690 m | 11.765 m |    — |
+|             |        | ALL |  9 332 | 15.3 |     — | 23.9% |  16.616 m | 3.693 m | 11.793 m |    — |
+| nagoya_run3 | CLAS   | FIX |    761 | 10.0 | 14.8% | 71.9% |   2.145 m | 0.286 m |  7.602 m |    8 |
+|             |        | FF  |  4 619 |  7.6 | 89.8% | 18.9% |   9.832 m | 8.329 m | 20.464 m |    — |
+|             |        | ALL |  5 141 |  7.4 |     — | 17.1% |  20.877 m | 8.647 m | 20.780 m |    — |
+| nagoya_run3 | MADOCA | PPP |  4 487 | 10.7 |  2.1% |  2.1% |   3.141 m | 2.817 m |  5.731 m |  852 |
+| nagoya_run3 | RTK    | FIX |     27 |  8.0 |  0.5% | 18.5% |   2.049 m | 2.656 m |  2.755 m |    — |
+|             |        | FF  |  5 095 | 13.2 | 99.1% |  3.6% |   4.721 m | 4.133 m |  8.807 m |    — |
+|             |        | ALL |  5 139 | 13.1 |     — |  3.6% |   4.722 m | 4.155 m |  8.798 m |    — |
+
+### Tokyo
+
+| Case | Mode | Tier | N | nSV | Rate% | `<30cm` | RMS 2D | 1σ (68%) | 95% | TTFF (s) |
+|------|------|------|--:|----:|------:|--------:|-------:|---------:|----:|---------:|
+| tokyo_run1 | CLAS   | FIX |  3 844 | 12.0 | 32.4% | 88.0% |   3.346 m | 0.118 m |  1.660 m |    0 |
+|            |        | FF  | 10 614 |  9.9 | 89.4% | 36.2% | 496.925 m | 4.980 m | 44.407 m |    — |
+|            |        | ALL | 11 867 |  9.5 |     — | 32.4% | 614.175 m | 8.515 m | 56.104 m |    — |
+| tokyo_run1 | MADOCA | PPP |  3 084 | 12.9 | 16.6% | 16.6% |   1.825 m | 0.979 m |  1.957 m |    0 |
+| tokyo_run1 | RTK    | FIX |    396 | 15.3 |  3.4% | 85.6% |   2.068 m | 0.038 m |  6.242 m | 1840 |
+|            |        | FF  | 11 268 | 16.0 | 96.7% |  5.5% |   6.639 m | 6.796 m | 13.897 m |    — |
+|            |        | ALL | 11 657 | 15.5 |     — |  5.3% |  17.026 m | 6.719 m | 13.847 m |    — |
+| tokyo_run2 | CLAS   | FIX |  4 392 | 11.3 | 48.3% | 80.5% |   2.546 m | 0.099 m |  7.782 m |    0 |
+|            |        | FF  |  8 164 |  9.8 | 89.8% | 49.5% |  10.046 m | 1.723 m | 12.535 m |    — |
+|            |        | ALL |  9 091 |  9.2 |     — | 44.5% | 495.580 m | 3.022 m | 19.223 m |    — |
+| tokyo_run2 | MADOCA | PPP |  8 159 | 13.7 |  6.0% |  6.0% |   2.893 m | 1.181 m |  4.579 m |  464 |
+| tokyo_run2 | RTK    | FIX |  1 640 | 22.5 | 18.3% | 88.9% |  77.658 m | 0.013 m |240.842 m |  213 |
+|            |        | FF  |  8 475 | 18.5 | 94.4% | 36.9% |  47.381 m | 7.396 m | 56.789 m |    — |
+|            |        | ALL |  8 982 | 17.5 |     — | 37.7% |  47.646 m | 6.818 m | 57.057 m |    — |
+| tokyo_run3 | CLAS   | FIX |  8 899 | 12.6 | 58.4% | 93.6% |   0.972 m | 0.055 m |  0.479 m |    0 |
+|            |        | FF  | 13 996 | 11.3 | 91.8% | 63.7% |  11.484 m | 0.522 m | 20.050 m |    — |
+|            |        | ALL | 15 241 | 10.7 |     — | 58.6% |  48.709 m | 1.018 m | 25.905 m |    — |
+| tokyo_run3 | MADOCA | PPP | 14 370 | 14.4 | 11.2% | 11.2% |   3.348 m | 1.289 m |  8.840 m |   26 |
+| tokyo_run3 | RTK    | FIX |  2 602 | 24.4 | 17.3% | 98.3% |   1.867 m | 0.011 m |  0.064 m |  335 |
+|            |        | FF  | 14 626 | 21.3 | 97.4% | 31.7% |  56.934 m | 5.991 m | 20.338 m |    — |
+|            |        | ALL | 15 022 | 20.8 |     — | 31.0% | 106.597 m | 6.388 m | 22.078 m |    — |
+
+### How to read these numbers
+
+**Part of the CLAS and MADOCA gain is a harness fix, not an algorithm gain.**
+Three runs — `tokyo_run3`, `nagoya_run1`, `nagoya_run3` — cross a UTC hour
+boundary and therefore need two hourly L6 archive sessions.  Until
+[#316](https://github.com/h-shiono/MRTKLIB/issues/316) /
+[#317](https://github.com/h-shiono/MRTKLIB/pull/317), `mrtk post` silently used
+only the first session, so those runs lost every correction at the boundary and
+their published numbers covered a fraction of the drive.  Concatenating the
+sessions restores them (e.g. tokyo_run3 MADOCA 2 855 → 14 430 epochs, tokyo_run3
+CLAS fix 14.0% → 58.5%).  Attribute that part to the harness, not to the
+engines.  The other three runs are single-session and were never affected.
+
+**MADOCA is the control.** On those three unaffected runs the numbers reproduce
+the v0.3.3 / v0.4.2 record almost exactly — tokyo_run1 `<30cm` 16.6% → 16.6% and
+RMS 1.825 → 1.825 m, nagoya_run2 39.299 → 39.302 m, tokyo_run2 2.894 → 2.893 m.
+Across four minor releases that stability shows the dataset, truth file, epoch
+matching and metric code are unchanged, which is what makes the comparisons on
+the other two modes meaningful.
+
+**CLAS improved across the board.** Fix rate is up on every case against the
+v0.4.2 record (tokyo_run3 7.4% → 58.4%, tokyo_run2 21.7% → 48.3%, nagoya_run1
+17.0% → 53.9%), consistent with the v0.7.x PPP-RTK parity work — with the
+harness caveat above applying to three of them.
+
+**CLAS fixed-epoch accuracy in Nagoya is a long-standing limitation, not a
+regression.** The `<30cm` column makes it visible for the first time (nagoya_run1
+13.3%, nagoya_run2 2.5%), but v0.3.3 already recorded fixed-tier 1σ of 0.402 m
+and 0.717 m on those runs against 0.648 m and 0.486 m today — the same regime.
+RTK on the same data holds 0.112 m and 0.083 m, so this is specific to the CLAS
+path in that area.
+
+!!! warning "RTK is under investigation — do not read these numbers as achievable performance"
+
+    Kinematic RTK has regressed against the v0.4.1 record on all six cases, and
+    the fixed-tier *tail* rather than its median: tokyo_run2 keeps a 1.3 cm 1σ
+    while its 95th percentile is 240 m, i.e. ~11% of the epochs reporting Q=4
+    are wrong fixes.  This is the same false-fix mode that v0.4.0 eliminated
+    (17.993 m → 0.095 m) and v0.4.1 held at 0.079 m.  Integer-fix availability
+    has also dropped sharply on nagoya_run3 (10.1% → 0.5%) and nagoya_run2
+    (28.3% → 7.4%).  Tracked in
+    [#318](https://github.com/h-shiono/MRTKLIB/issues/318); the three RTK
+    parameters v0.4.0 introduced were verified to survive the TOML migration, so
+    the cause is not that config drift.
 
 ---
 

--- a/docs/reference/benchmark.md
+++ b/docs/reference/benchmark.md
@@ -207,6 +207,13 @@ MADOCA-PPP never produces an integer fix and is reported as a single **PPP** tie
 - FIX / FF rows: fraction of that tier among all matched epochs
 - PPP row: fraction of epochs with 2D horizontal error < 30 cm
 
+**`<30cm` column:** fraction of *that row's own* N epochs with 2D horizontal
+error below 30 cm.  On the FIX row it answers "of the epochs that claimed an
+integer fix, how many were actually right", so its complement is the **misfix
+rate** — a Q=4 epoch beyond 30 cm is a wrong fix, not a degraded one.  The
+per-case progress line prints that complement directly as `misfix=`.  (Added
+after the v0.3.3 tables below, which therefore do not carry the column.)
+
 **TTFF column:**
 - CLAS / RTK: first epoch of a ≥30-consecutive Q=4 run (shown on FIX row)
 - MADOCA: first epoch of a ≥30-consecutive sub-30 cm run (shown on PPP row)

--- a/docs/reference/benchmark.md
+++ b/docs/reference/benchmark.md
@@ -111,8 +111,18 @@ cd scripts/benchmark
 python download_l6.py --mode both
 ```
 
-This downloads the CLAS L6D and MADOCA L6E files for all six runs into
-`data/benchmark/l6/`.  Use `--dry-run` to preview the URLs without downloading.
+This downloads, for all six runs into `data/benchmark/l6/`, the CLAS L6D file
+plus — for MADOCA-PPP — the L6E SSR file (first available PRN of 204/205/206/
+207/209/210/211) and every available L6D ionospheric-augmentation file
+(PRN 200/201).  Use `--dry-run` to preview the URLs without downloading.
+
+To fetch a date outside the benchmark cases, use `--datetime` with a UTC date
+and an optional session letter (A–X, one per UTC hour):
+
+```bash
+python download_l6.py --datetime 2026-07-25A   # one hourly session
+python download_l6.py --datetime 2026-07-25    # all 24 sessions of the day
+```
 
 > **`single` mode needs no correction data** — it uses only `rover.obs` +
 > `base.nav` (broadcast ephemeris). Skip this step and run
@@ -125,6 +135,7 @@ Options:
 | `--l6-dir DIR` | `data/benchmark/l6` | Where to store L6 files |
 | `--mode clas\|madoca\|both` | `both` | Which correction type |
 | `--case ID[,ID...]` | all | Restrict to specific run IDs |
+| `--datetime YYYY-MM-DD[S]` | — | UTC date (+ optional session letter) instead of the cases; mutually exclusive with `--case` |
 | `--dry-run` | off | Print URLs without downloading |
 
 ### Step 2 — Run the benchmark

--- a/docs/reference/benchmark.md
+++ b/docs/reference/benchmark.md
@@ -128,6 +128,15 @@ python download_l6.py --datetime 2026-07-25    # all 24 sessions of the day
 > `base.nav` (broadcast ephemeris). Skip this step and run
 > `run_benchmark.py --mode single --skip-download`.
 
+Three of the six runs (`tokyo_run3`, `nagoya_run1`, `nagoya_run3`) cross a UTC
+hour boundary and therefore need two hourly sessions per stream.  `mrtk post`
+cannot read those as a sequence — it keeps only the first L6E file, and it
+treats each CLAS `.l6` file as a separate transmit-pattern channel
+([#316](https://github.com/h-shiono/MRTKLIB/issues/316)) — so `run_benchmark.py`
+concatenates the sessions of each stream into `data/benchmark/l6/merged/`
+before invoking it.  The merged files are regenerated whenever a source
+session is newer, and can be deleted at any time.
+
 Options:
 
 | Option | Default | Description |

--- a/docs/reference/test-accuracy-methodology.md
+++ b/docs/reference/test-accuracy-methodology.md
@@ -156,10 +156,19 @@ Both also report, alongside the error distribution:
   state — Fix, Float or PPP. Single and DGPS epochs are excluded so the figure
   describes the epochs the accuracy statistics come from.
 - **TTFF** — the first epoch that is integer-fixed *and* within 30 cm
-  horizontally and 50 cm vertically (`--ttff-h` / `--ttff-v`), reported in
-  seconds from the first epoch of the file. `--skip-epochs` is deliberately
-  **not** applied to TTFF: it discards the convergence transient, which is
+  horizontally and 50 cm vertically (`--ttff-h` / `--ttff-v`), with the criteria
+  then holding for 5 minutes (`--hold`). The reported time is the **start** of
+  the sustained run: the hold is the confirmation that the solution had
+  converged there, not a delay added to the answer. `--skip-epochs` is
+  deliberately **not** applied — it discards the convergence transient, which is
   exactly what TTFF measures.
+- **PPP convergence time** — the same bounds and hold applied to the PPP
+  solution state **or better**: upgrading to an integer fix counts as
+  maintaining PPP and does not break the run. The line is printed only for
+  solutions that actually contain PPP epochs.
+
+A data gap longer than 3× the median epoch interval ends a sustained run in
+both cases, since nothing is known about the missing time.
 
 ---
 

--- a/docs/reference/test-accuracy-methodology.md
+++ b/docs/reference/test-accuracy-methodology.md
@@ -135,11 +135,31 @@ difference is the input parser.
 
 | Script | Input format | Used for |
 |--------|-------------|---------|
-| `scripts/tests/compare_pos_abs.py` | RTKLIB `.pos` vs SINEX or GSI F5 | PPP-AR absolute check |
+| `scripts/tests/compare_pos_abs.py` | RTKLIB `.pos` **or** NMEA GGA vs SINEX or GSI F5 | PPP-AR absolute check |
 | `scripts/tests/compare_nmea_abs.py` | NMEA GGA vs SINEX or GSI F5 | PPP-RTK absolute check |
 
-Both scripts share the same reference-parsing helpers and pass/fail logic
-(imported from `compare_pos_abs`).
+Both scripts share the same GGA parser, reference-parsing helpers and pass/fail
+logic (imported from `compare_pos_abs`).
+
+`compare_pos_abs.py` detects the input format from the file content
+(`--format pos|nmea` overrides it) and normalises NMEA onto the `.pos`
+convention: ellipsoidal height is rebuilt as GGA field[9] + field[11], and the
+GGA quality indicator is mapped to the RTKLIB solution status (the inverse of
+`nmea_solq[]` in `src/pos/mrtk_sol.c`), so `Q=1` means integer-fixed and `Q=6`
+PPP for either format — `--min-fix-rate` therefore applies to NMEA input too.
+`compare_nmea_abs.py` keeps the GGA-native quality flags and its 2D-first
+defaults.
+
+Both also report, alongside the error distribution:
+
+- **Satellite count** (mean / min / max) over the epochs in a precise solution
+  state — Fix, Float or PPP. Single and DGPS epochs are excluded so the figure
+  describes the epochs the accuracy statistics come from.
+- **TTFF** — the first epoch that is integer-fixed *and* within 30 cm
+  horizontally and 50 cm vertically (`--ttff-h` / `--ttff-v`), reported in
+  seconds from the first epoch of the file. `--skip-epochs` is deliberately
+  **not** applied to TTFF: it discards the convergence transient, which is
+  exactly what TTFF measures.
 
 ---
 

--- a/scripts/benchmark/cases.py
+++ b/scripts/benchmark/cases.py
@@ -10,6 +10,10 @@ from datetime import datetime, timedelta, timezone
 # GPS epoch and leap seconds
 _GPS_EPOCH = datetime(1980, 1, 6, tzinfo=timezone.utc)
 GPS_LEAP = 18  # GPS - UTC leap seconds (correct as of 2024)
+SEC_WEEK = 86400 * 7
+# L6 archive session letters, one per UTC hour.  Upper case is mandatory: the
+# MADOCA archive returns 403 for a lower-case letter.
+SESSIONS = "ABCDEFGHIJKLMNOPQRSTUVWX"
 
 # ---------------------------------------------------------------------------
 # Run metadata
@@ -80,6 +84,62 @@ def tow_to_utc(week: int, tow: float) -> datetime:
     return gps_t - timedelta(seconds=GPS_LEAP)
 
 
+def utc_to_tow(dt: datetime) -> tuple[int, float]:
+    """Convert UTC datetime to GPS week + time-of-week.
+
+    Inverse of :func:`tow_to_utc`: the leap-second offset is added back.
+
+    Args:
+        dt: UTC datetime (timezone-aware).
+
+    Returns:
+        Corresponding GPS week number and time of week in seconds.
+    """
+    gps_t = (dt + timedelta(seconds=GPS_LEAP) - _GPS_EPOCH).total_seconds()
+    return int(gps_t // SEC_WEEK), gps_t % SEC_WEEK
+
+
+def ses_to_hour(ses: str) -> int:
+    """Convert an L6 archive session letter to its UTC hour.
+
+    Args:
+        ses: Session letter A–X (case-insensitive).
+
+    Returns:
+        UTC hour, 0–23.
+
+    Raises:
+        ValueError: If ``ses`` is not a single letter in A–X.
+    """
+    hour = SESSIONS.find(ses.upper()) if len(ses) == 1 else -1
+    if hour < 0:
+        raise ValueError(f"invalid session letter: {ses!r} (expected A–X)")
+    return hour
+
+
+def date_sessions(date: datetime, session: str | None = None) -> list[tuple[int, int, str]]:
+    """Return the L6 archive sessions of a UTC calendar date.
+
+    The archive buckets data by UTC hour, so the date is used directly — no
+    GPS-time round trip, hence no leap-second or hour-boundary ambiguity.
+
+    Args:
+        date: UTC date (time-of-day is ignored).
+        session: Session letter A–X (case-insensitive), or ``None`` for the
+            whole day.
+
+    Returns:
+        List of (year, doy, session_letter) tuples: one entry for a given
+        session letter, 24 entries for a whole day.
+
+    Raises:
+        ValueError: If ``session`` is not a valid session letter.
+    """
+    doy = date.timetuple().tm_yday
+    letters = SESSIONS if session is None else SESSIONS[ses_to_hour(session)]
+    return [(date.year, doy, s) for s in letters]
+
+
 def l6_sessions(week: int, tow_start: float, tow_end: float) -> list[tuple[int, int, str]]:
     """Return the L6 archive sessions (year, doy, letter) covering a run.
 
@@ -101,8 +161,7 @@ def l6_sessions(week: int, tow_start: float, tow_end: float) -> list[tuple[int, 
     t = t_start.replace(minute=0, second=0, microsecond=0)
     while t <= t_end:
         doy = t.timetuple().tm_yday
-        letter = chr(ord("A") + t.hour)
-        entry = (t.year, doy, letter)
+        entry = (t.year, doy, SESSIONS[t.hour])
         if entry not in sessions:
             sessions.append(entry)
         t += timedelta(hours=1)
@@ -134,6 +193,7 @@ if __name__ == "__main__":
     for c in CASES:
         t0 = tow_to_utc(c["gps_week"], c["tow_start"])
         t1 = tow_to_utc(c["gps_week"], c["tow_end"])
+        assert utc_to_tow(t0) == (c["gps_week"], c["tow_start"]), "tow/utc round trip"
         dur = (c["tow_end"] - c["tow_start"]) / 60
         sess = l6_sessions(c["gps_week"], c["tow_start"], c["tow_end"])
         print(

--- a/scripts/benchmark/cases.py
+++ b/scripts/benchmark/cases.py
@@ -84,6 +84,23 @@ def tow_to_utc(week: int, tow: float) -> datetime:
     return gps_t - timedelta(seconds=GPS_LEAP)
 
 
+def tow_to_gpst(week: int, tow: float) -> datetime:
+    """Convert GPS week + time-of-week to a GPST datetime.
+
+    Unlike :func:`tow_to_utc` no leap-second offset is removed: the result is
+    GPS time expressed as a datetime, which is what rnx2rtkp's ``-ts``/``-te``
+    epochs are compared against.
+
+    Args:
+        week: GPS week number.
+        tow: Time of week in seconds.
+
+    Returns:
+        GPST as a timezone-aware datetime.
+    """
+    return _GPS_EPOCH + timedelta(weeks=week, seconds=tow)
+
+
 def utc_to_tow(dt: datetime) -> tuple[int, float]:
     """Convert UTC datetime to GPS week + time-of-week.
 

--- a/scripts/benchmark/compare_ppc.py
+++ b/scripts/benchmark/compare_ppc.py
@@ -178,6 +178,7 @@ def compute_metrics(
     pairs: list[tuple[tuple, tuple]],
     skip_epochs: int = 0,
     threshold_2d: float = float("nan"),
+    acc_threshold_2d: float = 0.30,
 ) -> dict | None:
     """Compute positioning error statistics from matched epoch pairs.
 
@@ -187,6 +188,11 @@ def compute_metrics(
         threshold_2d: Horizontal error threshold in metres for threshold-based
             fix rate and convergence time (e.g. 0.30 for PPP modes where Q=4
             is never set).  When ``nan``, only Q=4-based metrics are computed.
+        acc_threshold_2d: Accuracy threshold in metres, applied *within* each
+            tier (``acc_rate_fix`` / ``acc_rate_ff`` / ``acc_rate_all``).  On
+            the fix tier its complement is the misfix rate: a Q=4 epoch beyond
+            this bound is a wrong integer fix, not a degraded one.  Always
+            computed, including for the AR modes where ``threshold_2d`` is nan.
 
     Returns:
         Dict of statistics, or ``None`` if no usable pairs remain.
@@ -257,6 +263,13 @@ def compute_metrics(
     else:
         rms_2d_ff = rms_3d_ff = p68_2d_ff = p95_2d_ff = math.nan
 
+    # Per-tier accuracy rate: fraction of that tier's epochs inside the bound.
+    # On the fix tier, 100% minus this is the misfix rate.
+    below = horiz < acc_threshold_2d
+    acc_rate_fix = float(np.mean(below[fix_mask]) * 100.0) if n_fix > 0 else math.nan
+    acc_rate_ff = float(np.mean(below[ff_mask]) * 100.0) if n_ff > 0 else math.nan
+    acc_rate_all = float(np.mean(below) * 100.0)
+
     # Q=4-based convergence: first run of ≥30 consecutive Q=4 epochs
     conv_time_s = math.nan
     run = 0
@@ -298,6 +311,7 @@ def compute_metrics(
         # Q=4 fix
         "n_fix": n_fix,
         "fix_rate": n_fix / n * 100.0,
+        "acc_rate_fix": acc_rate_fix,
         "mean_sv_fix": mean_sv_fix,
         "rms_2d_fix": rms_2d_fix,
         "rms_3d_fix": rms_3d_fix,
@@ -307,12 +321,15 @@ def compute_metrics(
         # Q=4 or Q=5 (fix + float)
         "n_ff": n_ff,
         "ff_rate": n_ff / n * 100.0,
+        "acc_rate_ff": acc_rate_ff,
         "mean_sv_ff": mean_sv_ff,
         "rms_2d_ff": rms_2d_ff,
         "rms_3d_ff": rms_3d_ff,
         "p68_2d_ff": p68_2d_ff,
         "p95_2d_ff": p95_2d_ff,
         # All epochs
+        "acc_threshold_2d": acc_threshold_2d,
+        "acc_rate_all": acc_rate_all,
         "mean_sv_all": mean_sv_all,
         "rms_2d_all": float(np.sqrt(np.mean(horiz**2))),
         "rms_3d_all": float(np.sqrt(np.mean(e3d**2))),
@@ -456,6 +473,12 @@ def main() -> int:
     print(f"    RMS    : {_fmt(m['rms_2d_fix'], 'm')}")
     print(f"    1σ     : {_fmt(m['p68_2d_fix'], 'm')}")
     print(f"    95%    : {_fmt(m['p95_2d_fix'], 'm')}")
+    thr_cm = m["acc_threshold_2d"] * 100
+    acc_fix = m["acc_rate_fix"]
+    if math.isnan(acc_fix):
+        print(f"    <{thr_cm:.0f}cm  : nan")
+    else:
+        print(f"    <{thr_cm:.0f}cm  : {acc_fix:.1f}%   (misfix {100.0 - acc_fix:.1f}%)")
     print()
     conv = m["conv_time_s"]
     conv_str = _fmt(conv, "s", 0) if not math.isnan(conv) else "never (no 30-epoch fix run)"

--- a/scripts/benchmark/download_l6.py
+++ b/scripts/benchmark/download_l6.py
@@ -1,37 +1,46 @@
-"""download_l6.py - Download QZSS L6D (CLAS) and L6E (MADOCA) archive files.
+"""download_l6.py - Download QZSS CLAS and MADOCA-PPP L6 archive files.
 
-Downloads only the L6 sessions needed for the configured PPC-Dataset runs.
-Files that already exist are skipped.  Requires only the Python standard library.
+Downloads the L6 sessions needed for the configured PPC-Dataset runs, or the
+sessions of an explicit UTC date.  Files that already exist are skipped.
+Requires only the Python standard library.
 
 Archive URLs
 ------------
-L6D (CLAS):
+CLAS (L6D):
     https://sys.qzss.go.jp/archives/l6/{year}/{year}{doy}{session}.l6
 
-L6E (MADOCA):
+MADOCA-PPP SSR (L6E) and wide-area ionospheric augmentation (L6D):
     https://l6msg.go.gnss.go.jp/archives/{year}/{doy}/{year}{doy}{session}.{prn}.l6
-    PRN candidates tried in order: 209, 193, 194, 195, 196, 199
+    L6E PRN candidates — first available is used: 204, 205, 206, 207, 209, 210, 211
+    L6D PRN candidates — all available are used:  200, 201
+
+``mrtk post`` consumes a single L6E file but up to ``MIONO_MAX_PRN`` L6D files,
+which it discriminates by the ``.200.l6`` / ``.201.l6`` name suffix.  Session
+letters must be upper case: the MADOCA archive answers 403 for lower case.
 
 Usage
 -----
     python download_l6.py [--l6-dir DIR] [--mode clas|madoca|both]
-                          [--case ID[,ID...]] [--dry-run]
+                          [--case ID[,ID...]] [--datetime YYYY-MM-DD[S]]
+                          [--dry-run]
 """
 
 import argparse
 import sys
 import urllib.error
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 
-from cases import CASES, l6_sessions
+from cases import CASES, date_sessions, l6_sessions
 
 # ---------------------------------------------------------------------------
 # URL templates
 # ---------------------------------------------------------------------------
 _L6D_URL = "https://sys.qzss.go.jp/archives/l6/{year}/{year}{doy:03d}{session}.l6"
 _L6E_URL = "https://l6msg.go.gnss.go.jp/archives/{year}/{doy:03d}/{year}{doy:03d}{session}.{prn}.l6"
-MADOCA_PRNS = [209, 193, 194, 195, 196, 199]
+MADOCA_PRNS = [204, 205, 206, 207, 209, 210, 211]
+MADOCA_L6D_PRNS = [200, 201]
 
 
 # ---------------------------------------------------------------------------
@@ -47,26 +56,33 @@ def _l6e_url(year: int, doy: int, session: str, prn: int) -> str:
     return _L6E_URL.format(year=year, doy=doy, session=session, prn=prn)
 
 
-def _probe_l6e_prn(year: int, doy: int, session: str) -> int | None:
-    """Find the first available MADOCA PRN for a given session.
+def _probe_madoca_prns(
+    year: int, doy: int, session: str, prns: list[int], first_only: bool = True
+) -> list[int]:
+    """Find the MADOCA PRNs that have an archive file for a given session.
 
     Args:
         year: Calendar year.
         doy: Day-of-year.
         session: Session letter (A–X).
+        prns: PRN candidates, tried in order.
+        first_only: Stop at the first hit instead of probing every candidate.
 
     Returns:
-        First PRN that returns HTTP 200, or ``None`` if none found.
+        PRNs that returned HTTP 200, in candidate order (empty if none).
     """
-    for prn in MADOCA_PRNS:
+    found = []
+    for prn in prns:
         url = _l6e_url(year, doy, session, prn)
         try:
             req = urllib.request.Request(url, method="HEAD")
             with urllib.request.urlopen(req, timeout=10):
-                return prn
+                found.append(prn)
+                if first_only:
+                    break
         except (urllib.error.HTTPError, urllib.error.URLError, OSError):
             continue
-    return None
+    return found
 
 
 def _download(url: str, dest: Path, dry_run: bool = False) -> bool:
@@ -128,37 +144,133 @@ def download_l6d_session(
     return dest if _download(url, dest, dry_run) else None
 
 
+def _download_madoca(
+    year: int,
+    doy: int,
+    session: str,
+    l6_dir: Path,
+    prns: list[int],
+    first_only: bool,
+    label: str,
+    dry_run: bool = False,
+) -> list[Path]:
+    """Download the MADOCA session files matching a PRN candidate set.
+
+    Args:
+        year: Calendar year.
+        doy: Day-of-year (1-based).
+        session: Session letter (A–X).
+        l6_dir: Local directory to store the files.
+        prns: PRN candidates, tried in order.
+        first_only: Take only the first available PRN.
+        label: Signal label used in messages (``"L6E"`` / ``"L6D"``).
+        dry_run: Print URLs without downloading.
+
+    Returns:
+        Paths to the local files (empty if no PRN is available).  In dry-run
+        the first candidate PRN is assumed.
+    """
+    if dry_run:
+        print(f"  [dry-run]  probing MADOCA {label} PRNs for {year}/{doy:03d}/{session}:")
+        for prn in prns:
+            print(f"             {_l6e_url(year, doy, session, prn)}")
+        return [l6_dir / f"{year}{doy:03d}{session}.{prns[0]}.l6"]
+
+    found = _probe_madoca_prns(year, doy, session, prns, first_only)
+    if not found:
+        print(f"  [FAIL]     no MADOCA {label} PRN found for {year}/{doy:03d}/{session}")
+        return []
+
+    paths = []
+    for prn in found:
+        dest = l6_dir / f"{year}{doy:03d}{session}.{prn}.l6"
+        if _download(_l6e_url(year, doy, session, prn), dest):
+            paths.append(dest)
+    return paths
+
+
 def download_l6e_session(
     year: int, doy: int, session: str, l6_dir: Path, dry_run: bool = False
-) -> Path | None:
-    """Download one L6E (MADOCA) session file.
+) -> list[Path]:
+    """Download the MADOCA-PPP SSR (L6E) file of one session.
 
-    Probes PRN candidates in order and downloads the first available file.
+    Probes PRN candidates in order and downloads the first available file —
+    ``mrtk post`` consumes a single L6E file.
 
     Args:
         year: Calendar year.
         doy: Day-of-year (1-based).
         session: Session letter (A–X).
         l6_dir: Local directory to store the file.
-        dry_run: Print URL without downloading.
+        dry_run: Print URLs without downloading.
 
     Returns:
-        Path to the local file, or ``None`` if no PRN found.
+        Single-element list with the local path, or empty if no PRN is available.
     """
-    if dry_run:
-        print(f"  [dry-run]  probing MADOCA PRNs for {year}/{doy:03d}/{session}:")
-        for prn in MADOCA_PRNS:
-            print(f"             {_l6e_url(year, doy, session, prn)}")
-        return l6_dir / f"{year}{doy:03d}{session}.{MADOCA_PRNS[0]}.l6"
+    return _download_madoca(
+        year, doy, session, l6_dir, MADOCA_PRNS, first_only=True, label="L6E", dry_run=dry_run
+    )
 
-    prn = _probe_l6e_prn(year, doy, session)
-    if prn is None:
-        print(f"  [FAIL]     no MADOCA PRN found for {year}/{doy:03d}/{session}")
-        return None
-    fname = f"{year}{doy:03d}{session}.{prn}.l6"
-    dest = l6_dir / fname
-    url = _l6e_url(year, doy, session, prn)
-    return dest if _download(url, dest, dry_run) else None
+
+def download_l6d_madoca_session(
+    year: int, doy: int, session: str, l6_dir: Path, dry_run: bool = False
+) -> list[Path]:
+    """Download the MADOCA-PPP ionospheric augmentation (L6D) files of one session.
+
+    Every available PRN is downloaded: the engine feeds each ``.200.l6`` /
+    ``.201.l6`` file into its own ``pppiono`` region slot.
+
+    Args:
+        year: Calendar year.
+        doy: Day-of-year (1-based).
+        session: Session letter (A–X).
+        l6_dir: Local directory to store the files.
+        dry_run: Print URLs without downloading.
+
+    Returns:
+        Local paths, or empty if no PRN is available.
+    """
+    return _download_madoca(
+        year,
+        doy,
+        session,
+        l6_dir,
+        MADOCA_L6D_PRNS,
+        first_only=False,
+        label="L6D",
+        dry_run=dry_run,
+    )
+
+
+def ensure_sessions(
+    sessions: list[tuple[int, int, str]],
+    l6_dir: Path,
+    mode: str = "both",
+    dry_run: bool = False,
+) -> dict[str, list[Path]]:
+    """Ensure the L6 files of the given archive sessions are present.
+
+    Args:
+        sessions: (year, doy, session_letter) tuples.
+        l6_dir: Directory to store L6 files.
+        mode: ``"clas"``, ``"madoca"``, or ``"both"``.
+        dry_run: Print URLs without downloading.
+
+    Returns:
+        Dict ``{"clas": [...], "madoca": [...]}`` with local file paths.
+        Missing files are omitted.
+    """
+    result: dict[str, list[Path]] = {"clas": [], "madoca": []}
+
+    for year, doy, session in sessions:
+        if mode in ("clas", "both"):
+            p = download_l6d_session(year, doy, session, l6_dir, dry_run)
+            if p:
+                result["clas"].append(p)
+        if mode in ("madoca", "both"):
+            result["madoca"] += download_l6e_session(year, doy, session, l6_dir, dry_run)
+            result["madoca"] += download_l6d_madoca_session(year, doy, session, l6_dir, dry_run)
+    return result
 
 
 def ensure_case_l6(
@@ -177,18 +289,7 @@ def ensure_case_l6(
         Missing files are omitted.
     """
     sessions = l6_sessions(case["gps_week"], case["tow_start"], case["tow_end"])
-    result: dict[str, list[Path]] = {"clas": [], "madoca": []}
-
-    for year, doy, session in sessions:
-        if mode in ("clas", "both"):
-            p = download_l6d_session(year, doy, session, l6_dir, dry_run)
-            if p:
-                result["clas"].append(p)
-        if mode in ("madoca", "both"):
-            p = download_l6e_session(year, doy, session, l6_dir, dry_run)
-            if p:
-                result["madoca"].append(p)
-    return result
+    return ensure_sessions(sessions, l6_dir, mode, dry_run)
 
 
 def ensure_all(
@@ -215,6 +316,26 @@ def ensure_all(
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
+def _parse_datetime_arg(spec: str) -> list[tuple[int, int, str]]:
+    """Expand a ``YYYY-MM-DD[S]`` CLI argument into archive sessions.
+
+    Args:
+        spec: UTC date, optionally suffixed with a session letter A–X
+            (case-insensitive).  Without a letter the whole day is expanded.
+
+    Returns:
+        List of (year, doy, session_letter) tuples.
+
+    Raises:
+        ValueError: If the date or the session letter is malformed.
+    """
+    try:
+        date = datetime.strptime(spec[:10], "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    except ValueError:
+        raise ValueError(f"invalid --datetime {spec!r} (expected YYYY-MM-DD[S])") from None
+    return date_sessions(date, spec[10:] or None)
+
+
 def main() -> int:
     """Download L6 files for the configured PPC-Dataset runs."""
     p = argparse.ArgumentParser(
@@ -232,23 +353,44 @@ def main() -> int:
         help="Which L6 type to download (default: both)",
     )
     p.add_argument("--case", default="", help="Comma-separated case IDs (default: all)")
+    p.add_argument(
+        "--datetime",
+        default=None,
+        help=(
+            "UTC date, optionally with a session letter A–X: '2026-07-30A' for a "
+            "single hour, '2026-07-30' for the whole day (mutually exclusive with --case)"
+        ),
+    )
     p.add_argument("--dry-run", action="store_true", help="Print URLs without downloading")
     args = p.parse_args()
+
+    if args.datetime and args.case:
+        print("FAIL: --datetime and --case are mutually exclusive", file=sys.stderr)
+        return 1
 
     l6_dir = Path(args.l6_dir)
     if not args.dry_run:
         l6_dir.mkdir(parents=True, exist_ok=True)
 
-    # Filter cases
-    cases = CASES
-    if args.case:
-        ids = {c.strip() for c in args.case.split(",")}
-        cases = [c for c in CASES if c["id"] in ids]
-        if not cases:
-            print(f"FAIL: no matching cases for: {args.case}", file=sys.stderr)
+    if args.datetime:
+        try:
+            sessions = _parse_datetime_arg(args.datetime)
+        except ValueError as exc:
+            print(f"FAIL: {exc}", file=sys.stderr)
             return 1
+        print(f"\n--- {args.datetime} ---")
+        ensure_sessions(sessions, l6_dir, args.mode, args.dry_run)
+    else:
+        # Filter cases
+        cases = CASES
+        if args.case:
+            ids = {c.strip() for c in args.case.split(",")}
+            cases = [c for c in CASES if c["id"] in ids]
+            if not cases:
+                print(f"FAIL: no matching cases for: {args.case}", file=sys.stderr)
+                return 1
+        ensure_all(cases, l6_dir, args.mode, args.dry_run)
 
-    ensure_all(cases, l6_dir, args.mode, args.dry_run)
     print("\nDone.")
     return 0
 

--- a/scripts/benchmark/download_l6.py
+++ b/scripts/benchmark/download_l6.py
@@ -168,13 +168,15 @@ def _download_madoca(
 
     Returns:
         Paths to the local files (empty if no PRN is available).  In dry-run
-        the first candidate PRN is assumed.
+        every candidate is assumed available, so the paths follow ``first_only``
+        exactly as a real run would: the first PRN alone, or all of them.
     """
     if dry_run:
         print(f"  [dry-run]  probing MADOCA {label} PRNs for {year}/{doy:03d}/{session}:")
         for prn in prns:
             print(f"             {_l6e_url(year, doy, session, prn)}")
-        return [l6_dir / f"{year}{doy:03d}{session}.{prns[0]}.l6"]
+        assumed = prns[:1] if first_only else prns
+        return [l6_dir / f"{year}{doy:03d}{session}.{prn}.l6" for prn in assumed]
 
     found = _probe_madoca_prns(year, doy, session, prns, first_only)
     if not found:

--- a/scripts/benchmark/plot_track_2d.py
+++ b/scripts/benchmark/plot_track_2d.py
@@ -35,6 +35,10 @@ from pathlib import Path
 import matplotlib
 
 matplotlib.use("Agg")
+# The solution readers and the geodesy helpers live with the test comparison
+# scripts; reach them regardless of the working directory.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tests"))
+
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
 from _geo import blh2xyz, xyz2enu  # noqa: E402

--- a/scripts/benchmark/run_benchmark.py
+++ b/scripts/benchmark/run_benchmark.py
@@ -40,7 +40,7 @@ import sys
 import time
 from pathlib import Path
 
-from cases import CASES, case_by_id
+from cases import CASES, case_by_id, tow_to_gpst
 from compare_ppc import _match_epochs, compute_metrics, parse_nmea, parse_reference, plot_results
 from download_l6 import ensure_case_l6
 
@@ -66,6 +66,56 @@ def _post_argv(binary: str) -> list[str]:
     standalone `rnx2rtkp` is invoked directly.
     """
     return [binary, "post"] if os.path.basename(binary).startswith("mrtk") else [binary]
+
+
+def _merge_l6_sessions(paths: list[Path], merge_dir: Path) -> list[Path]:
+    """Concatenate the hourly archive sessions of each L6 stream into one file.
+
+    A run that spans a UTC hour boundary needs two hourly archive files per
+    stream, but `mrtk post` cannot consume them as a sequence: it keeps only
+    the *first* L6E file it sees, and it assigns each CLAS `.l6` file to a
+    separate transmit-pattern channel — so the second hour is either dropped
+    or misread as a second channel, and corrections die at the boundary.
+    Concatenating the sessions of one stream into a single file sidesteps both
+    limits; the decoders resynchronise on the L6 preamble of every 250-byte
+    record, so a joined stream decodes exactly like a continuous one.
+
+    Interim workaround for the plumbing; see issue #316 for the fix in postpos.
+
+    Args:
+        paths: L6 file paths for one mode, in session order.
+        merge_dir: Directory for the merged files (created on demand).
+
+    Returns:
+        Path list with each multi-session stream replaced by its merged file.
+        Single-session streams are passed through untouched.
+    """
+    # Group the way postpos itself classifies the files: ".200.l6" / ".201.l6"
+    # are MADOCA-PPP L6D iono streams keyed per PRN, everything else is the one
+    # stream postpos keeps (MADOCA L6E, or the single CLAS channel of this
+    # dataset — the PPC rover records one L6 PRN, never two channels).
+    streams: dict[str, list[Path]] = {}
+    for p in paths:
+        suffix = p.name.split(".", 1)[1]  # "2024205B.204.l6" -> "204.l6"
+        streams.setdefault(suffix if suffix[:3] in ("200", "201") else "l6e", []).append(p)
+
+    merged = []
+    for group in streams.values():
+        if len(group) == 1:
+            merged.append(group[0])
+            continue
+        # "2024205B.204.l6" + "2024205C.204.l6" -> "2024205B-C.204.l6"
+        session, suffix = group[0].name.split(".", 1)
+        out = merge_dir / f"{session}-{group[-1].name.split('.', 1)[0][-1]}.{suffix}"
+        newest_in = max(p.stat().st_mtime for p in group)
+        if not out.exists() or out.stat().st_mtime <= newest_in:
+            merge_dir.mkdir(parents=True, exist_ok=True)
+            with open(out, "wb") as fo:
+                for p in group:
+                    fo.write(p.read_bytes())
+            print(f"  merged {len(group)} L6 sessions -> {out.name}")
+        merged.append(out)
+    return merged
 
 
 def _find_rnx2rtkp(hint: str = "") -> str:
@@ -127,7 +177,7 @@ def _run_rnx2rtkp(
         rnx2rtkp: Path to rnx2rtkp binary.
         conf: Path to mode configuration file.
         city_conf: Path to city override configuration file (applied after conf).
-        week: GPS week (for -ts/-te flags).
+        week: GPS week of tow_start / tow_end.
         tow_start: Run start TOW with margin already subtracted.
         tow_end: Run end TOW with margin already added.
         output: Destination NMEA file path.
@@ -140,6 +190,11 @@ def _run_rnx2rtkp(
     Returns:
         True if rnx2rtkp exited with code 0.
     """
+    # rnx2rtkp parses -ts/-te as "y/m/d" "h:m:s" in GPST; a week/TOW pair is
+    # silently discarded (epoch2time() rejects month 0 and returns t0).
+    ts = tow_to_gpst(week, tow_start)
+    te = tow_to_gpst(week, tow_end)
+
     # Resolve all file paths to absolute so they work regardless of cwd.
     output = output.resolve()
     obs = obs.resolve()
@@ -154,11 +209,11 @@ def _run_rnx2rtkp(
             "-k",
             city_conf,
             "-ts",
-            str(week),
-            f"{tow_start:.3f}",
+            ts.strftime("%Y/%m/%d"),
+            ts.strftime("%H:%M:%S"),
             "-te",
-            str(week),
-            f"{tow_end:.3f}",
+            te.strftime("%Y/%m/%d"),
+            te.strftime("%H:%M:%S"),
             "-o",
             str(output),
             str(obs),
@@ -451,6 +506,10 @@ def run_benchmark(args: argparse.Namespace) -> int:
                         mdc_l6d = l6_dir / f"{year}{doy:03d}{session}.{prn}.l6"
                         if mdc_l6d.exists():
                             l6_paths["madoca"].append(mdc_l6d)
+
+            # Join multi-session streams so corrections survive the hour boundary
+            for key in list(l6_paths):
+                l6_paths[key] = _merge_l6_sessions(l6_paths[key], l6_dir / "merged")
 
         for mode in modes:
             conf = str(conf_dir / f"{mode}.toml")

--- a/scripts/benchmark/run_benchmark.py
+++ b/scripts/benchmark/run_benchmark.py
@@ -237,9 +237,9 @@ def _run_rnx2rtkp(
 # Summary table
 # ---------------------------------------------------------------------------
 #  Three rows per case/mode: FIX (Q=4), FF (Q=4|Q=5), ALL (every epoch)
-#  Columns: Case  Mode  Tier  N  Rate%  RMS_2D  1σ  95%  TTFF_s
+#  Columns: Case  Mode  Tier  N  Rate%  <30cm  RMS_2D  1σ  95%  TTFF_s
 _HDR = (
-    f"{'Case':<20} {'Mode':<7} {'Tier':<5} {'N':>6} {'nSV':>5} {'Rate%':>7} "
+    f"{'Case':<20} {'Mode':<7} {'Tier':<5} {'N':>6} {'nSV':>5} {'Rate%':>7} {'<30cm':>7} "
     f"{'RMS_2D':>10} {'1σ':>10} {'95%':>10} {'TTFF_s':>8}"
 )
 _SEP = "-" * len(_HDR)
@@ -261,6 +261,11 @@ def _fmt_sv(v: float) -> str:
     return "—" if math.isnan(v) else f"{v:.1f}"
 
 
+def _fmt_pct(v: float) -> str:
+    """Format a percentage, or '—' when the tier has no epochs."""
+    return "—" if math.isnan(v) else f"{v:.1f}%"
+
+
 def _row(
     case_id: str,
     mode: str,
@@ -268,6 +273,7 @@ def _row(
     n: int,
     n_sv: str,
     rate: str,
+    acc: str,
     rms2: str,
     p68: str,
     p95: str,
@@ -279,7 +285,10 @@ def _row(
         prefix = f"{case_id:<20} {mode:<7}"
     else:
         prefix = _BLANK_CASE_MODE
-    return f"{prefix} {tier:<5} {n:>6} {n_sv:>5} {rate:>7} {rms2:>10} {p68:>10} {p95:>10} {ttff:>8}"
+    return (
+        f"{prefix} {tier:<5} {n:>6} {n_sv:>5} {rate:>7} {acc:>7} "
+        f"{rms2:>10} {p68:>10} {p95:>10} {ttff:>8}"
+    )
 
 
 def print_summary(rows: list[dict]) -> None:
@@ -299,6 +308,11 @@ def print_summary(rows: list[dict]) -> None:
       FIX row : Q=4 fix rate (clas/rtk)
       FF  row : Q=4|Q=5 rate (clas/rtk)
       PPP row : <30cm threshold rate (madoca)
+
+    <30cm column:
+      Fraction of that row's own N epochs within 30 cm 2D — so on the FIX row
+      it answers "of the epochs that claimed an integer fix, how many were
+      actually right", and its complement is the misfix rate.
 
     TTFF column:
       FIX row : first ≥30-consecutive-Q=4 run (clas/rtk)
@@ -337,6 +351,7 @@ def print_summary(rows: list[dict]) -> None:
                     m["n_matched"],
                     _fmt_sv(m["mean_sv_all"]),
                     ppp_rate,
+                    _fmt_pct(m["acc_rate_all"]),
                     _fmt_m(m["rms_2d_all"]),
                     _fmt_m(m["p68_2d_all"]),
                     _fmt_m(m["p95_2d_all"]),
@@ -355,6 +370,7 @@ def print_summary(rows: list[dict]) -> None:
                     m["n_fix"],
                     _fmt_sv(m["mean_sv_fix"]),
                     f"{m['fix_rate']:.1f}%",
+                    _fmt_pct(m["acc_rate_fix"]),
                     _fmt_m(m["rms_2d_fix"]),
                     _fmt_m(m["p68_2d_fix"]),
                     _fmt_m(m["p95_2d_fix"]),
@@ -371,6 +387,7 @@ def print_summary(rows: list[dict]) -> None:
                     m["n_ff"],
                     _fmt_sv(m["mean_sv_ff"]),
                     f"{m['ff_rate']:.1f}%",
+                    _fmt_pct(m["acc_rate_ff"]),
                     _fmt_m(m["rms_2d_ff"]),
                     _fmt_m(m["p68_2d_ff"]),
                     _fmt_m(m["p95_2d_ff"]),
@@ -387,6 +404,7 @@ def print_summary(rows: list[dict]) -> None:
                     m["n_matched"],
                     _fmt_sv(m["mean_sv_all"]),
                     "—",
+                    _fmt_pct(m["acc_rate_all"]),
                     _fmt_m(m["rms_2d_all"]),
                     _fmt_m(m["p68_2d_all"]),
                     _fmt_m(m["p95_2d_all"]),
@@ -399,6 +417,8 @@ def print_summary(rows: list[dict]) -> None:
     print("  CLAS/RTK tiers: FIX=Q=4 | FF=Q=4+5 (excl SPP) | ALL=every epoch")
     print("  MADOCA tier:    PPP=all valid PPP-float epochs (Q=3); Rate%=<30cm fraction")
     print("  SINGLE tier:    SPP=all valid SPP epochs (Q=1); Rate%=<2m fraction")
+    print("  <30cm column:   fraction of THAT row's N epochs within 30 cm 2D.")
+    print("                  On the FIX row, 100% minus it is the misfix rate.")
 
 
 # ---------------------------------------------------------------------------
@@ -605,7 +625,10 @@ def run_benchmark(args: argparse.Namespace) -> int:
                 rate_str = f"{thr_label}={m['thr_rate']:.1f}%"
                 conv_str = _fmt_s(m["conv_thr_s"])
             else:
-                rate_str = f"Fix={m['fix_rate']:.1f}%  FF={m['ff_rate']:.1f}%"
+                rate_str = (
+                    f"Fix={m['fix_rate']:.1f}%  FF={m['ff_rate']:.1f}%  "
+                    f"misfix={_fmt_pct(100.0 - m['acc_rate_fix'])}"
+                )
                 conv_str = _fmt_s(m["conv_time_s"])
             print(
                 f"  N={m['n_matched']}  {rate_str}  "

--- a/scripts/benchmark/run_benchmark.py
+++ b/scripts/benchmark/run_benchmark.py
@@ -82,6 +82,12 @@ def _merge_l6_sessions(paths: list[Path], merge_dir: Path) -> list[Path]:
 
     Interim workaround for the plumbing; see issue #316 for the fix in postpos.
 
+    `download_l6.py` probes for the first available L6E PRN per session, so two
+    hours of one run can carry different PRNs.  They are still merged into one
+    stream — postpos would keep a single file either way, so merging loses
+    nothing and recovers the second hour — but the merged name can only carry
+    one suffix, so every merge reports its source files by name.
+
     Args:
         paths: L6 file paths for one mode, in session order.
         merge_dir: Directory for the merged files (created on demand).
@@ -107,13 +113,15 @@ def _merge_l6_sessions(paths: list[Path], merge_dir: Path) -> list[Path]:
         # "2024205B.204.l6" + "2024205C.204.l6" -> "2024205B-C.204.l6"
         session, suffix = group[0].name.split(".", 1)
         out = merge_dir / f"{session}-{group[-1].name.split('.', 1)[0][-1]}.{suffix}"
+        if len({p.name.split(".", 1)[1] for p in group}) > 1:
+            print(f"  NOTE: sessions carry different PRNs; {out.name} names only the first")
         newest_in = max(p.stat().st_mtime for p in group)
         if not out.exists() or out.stat().st_mtime <= newest_in:
             merge_dir.mkdir(parents=True, exist_ok=True)
             with open(out, "wb") as fo:
                 for p in group:
                     fo.write(p.read_bytes())
-            print(f"  merged {len(group)} L6 sessions -> {out.name}")
+            print(f"  merged {' + '.join(p.name for p in group)} -> {out.name}")
         merged.append(out)
     return merged
 

--- a/scripts/benchmark/run_benchmark.py
+++ b/scripts/benchmark/run_benchmark.py
@@ -434,7 +434,7 @@ def run_benchmark(args: argparse.Namespace) -> int:
             else:
                 # Build expected paths without downloading
                 from cases import l6_sessions
-                from download_l6 import MADOCA_PRNS
+                from download_l6 import MADOCA_L6D_PRNS, MADOCA_PRNS
 
                 sessions = l6_sessions(case["gps_week"], case["tow_start"], case["tow_end"])
                 for year, doy, session in sessions:
@@ -446,6 +446,11 @@ def run_benchmark(args: argparse.Namespace) -> int:
                         if l6e.exists():
                             l6_paths["madoca"].append(l6e)
                             break
+                    # MADOCA-PPP L6D iono: every available PRN, as ensure_case_l6 does
+                    for prn in MADOCA_L6D_PRNS:
+                        mdc_l6d = l6_dir / f"{year}{doy:03d}{session}.{prn}.l6"
+                        if mdc_l6d.exists():
+                            l6_paths["madoca"].append(mdc_l6d)
 
         for mode in modes:
             conf = str(conf_dir / f"{mode}.toml")

--- a/scripts/tests/compare_nmea_abs.py
+++ b/scripts/tests/compare_nmea_abs.py
@@ -41,17 +41,20 @@ Float or PPP (GGA quality 4, 5, 3).  Quality 1 (stand-alone SPS) and 2 (DGPS)
 are excluded.
 
 TTFF is the first epoch that is RTK-fixed (GGA quality 4) *and* within 30 cm
-horizontally and 50 cm vertically (--ttff-h / --ttff-v).  It is measured from
-the first epoch of the file — --skip-epochs discards the convergence transient,
-which is exactly what TTFF measures, so it is not applied.  When the solution
-contains PPP epochs (GGA quality 3) the same bounds are applied to the PPP
-state and reported as a reference convergence time.
+horizontally and 50 cm vertically (--ttff-h / --ttff-v), which then has to hold
+for 5 minutes (--hold); the time reported is the START of the sustained run.
+It is measured from the first epoch of the file — --skip-epochs discards the
+convergence transient, which is exactly what TTFF measures, so it is not
+applied.  When the solution contains PPP epochs (GGA quality 3) the same bounds
+and hold are applied to the PPP state *or better* (an RTK fix counts as
+maintaining PPP) and reported as a reference convergence time.
 
 Options
 -------
     --tolerance FLOAT   Tolerance for criterion A in metres (default 0.100)
     --ttff-h FLOAT      TTFF horizontal bound in metres (default 0.30)
     --ttff-v FLOAT      TTFF vertical bound in metres (default 0.50)
+    --hold FLOAT        Seconds the TTFF / convergence criteria must hold (300)
     --skip-epochs INT   Skip N initial epochs
     --use-3d            Evaluate pass/fail on 3D error instead of 2D horizontal
     --plot              Generate ENU error time-series plot
@@ -235,6 +238,12 @@ def main():  # noqa: D103
         default=0.50,
         help="TTFF vertical error bound in metres (default 0.50)",
     )
+    p.add_argument(
+        "--hold",
+        type=float,
+        default=300.0,
+        help="Seconds the TTFF / convergence criteria must hold (default 300)",
+    )
     p.add_argument("--skip-epochs", type=int, default=0, help="Initial epochs to discard")
     p.add_argument(
         "--use-3d",
@@ -368,7 +377,16 @@ def main():  # noqa: D103
     else:
         print("    (none)")
     print()
-    print_ttff(true_xyz, test_data, args.ttff_h, args.ttff_v, geoid_ok, fix_q=4, ppp_q=3)
+    print_ttff(
+        true_xyz,
+        test_data,
+        args.ttff_h,
+        args.ttff_v,
+        geoid_ok,
+        fix_q=4,
+        ppp_q=3,
+        hold=args.hold,
+    )
     print()
 
     if args.plot:

--- a/scripts/tests/compare_nmea_abs.py
+++ b/scripts/tests/compare_nmea_abs.py
@@ -43,7 +43,9 @@ are excluded.
 TTFF is the first epoch that is RTK-fixed (GGA quality 4) *and* within 30 cm
 horizontally and 50 cm vertically (--ttff-h / --ttff-v).  It is measured from
 the first epoch of the file — --skip-epochs discards the convergence transient,
-which is exactly what TTFF measures, so it is not applied.
+which is exactly what TTFF measures, so it is not applied.  When the solution
+contains PPP epochs (GGA quality 3) the same bounds are applied to the PPP
+state and reported as a reference convergence time.
 
 Options
 -------
@@ -366,7 +368,7 @@ def main():  # noqa: D103
     else:
         print("    (none)")
     print()
-    print_ttff(true_xyz, test_data, args.ttff_h, args.ttff_v, geoid_ok, fix_q=4)
+    print_ttff(true_xyz, test_data, args.ttff_h, args.ttff_v, geoid_ok, fix_q=4, ppp_q=3)
     print()
 
     if args.plot:

--- a/scripts/tests/compare_nmea_abs.py
+++ b/scripts/tests/compare_nmea_abs.py
@@ -2,8 +2,10 @@
 """compare_nmea_abs.py - Absolute accuracy check of NMEA GGA output vs geodetic truth.
 
 Compares a NMEA GGA file against a true reference coordinate derived from
-either an IGS SINEX file or a GSI F5 daily coordinate file.  Shares all
-reference-parsing and pass/fail logic with compare_pos_abs.py.
+either an IGS SINEX file or a GSI F5 daily coordinate file.  Shares the GGA
+parser, reference parsing and pass/fail logic with compare_pos_abs.py, which
+also accepts NMEA input directly (``--format nmea``) and reports Q on the .pos
+scale; this script keeps the GGA-native quality flags and 2D-first defaults.
 
 Reference derivation and pass/fail criteria are identical to compare_pos_abs.py.
 See that script's docstring for details.
@@ -26,13 +28,28 @@ emits a warning.  In that case 2D horizontal comparison is more reliable.
 
 Usage
 -----
-    compare_nmea_abs.py --sinex FILE.SNX[.gz] --station CODE [--epoch YYYY/MM/DD] [options] test.nmea
+    compare_nmea_abs.py --sinex FILE.SNX[.gz] --station CODE [--epoch YYYY/MM/DD]
+                        [options] test.nmea
     compare_nmea_abs.py --f5 FILE --date YYYY/MM/DD [options] test.nmea
     compare_nmea_abs.py --llh LAT,LON,H [--ref-precision FLOAT] [options] test.nmea
+
+Reported statistics
+-------------------
+In addition to the error distribution, the satellite count (mean / min / max)
+of GGA field[7] is reported over the epochs in a precise solution state — Fix,
+Float or PPP (GGA quality 4, 5, 3).  Quality 1 (stand-alone SPS) and 2 (DGPS)
+are excluded.
+
+TTFF is the first epoch that is RTK-fixed (GGA quality 4) *and* within 30 cm
+horizontally and 50 cm vertically (--ttff-h / --ttff-v).  It is measured from
+the first epoch of the file — --skip-epochs discards the convergence transient,
+which is exactly what TTFF measures, so it is not applied.
 
 Options
 -------
     --tolerance FLOAT   Tolerance for criterion A in metres (default 0.100)
+    --ttff-h FLOAT      TTFF horizontal bound in metres (default 0.30)
+    --ttff-v FLOAT      TTFF vertical bound in metres (default 0.50)
     --skip-epochs INT   Skip N initial epochs
     --use-3d            Evaluate pass/fail on 3D error instead of 2D horizontal
     --plot              Generate ENU error time-series plot
@@ -44,71 +61,18 @@ import os
 import sys
 
 import numpy as np
-from _geo import blh2xyz, nmea_to_deg, xyz2blh, xyz2enu  # noqa: E402
+from _geo import blh2xyz, xyz2blh, xyz2enu  # noqa: E402
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from compare_pos_abs import (  # noqa: E402
     _criterion,
     _parse_triplet,
     parse_f5,
+    parse_nmea,
     parse_sinex,
+    print_ttff,
     sinex_propagate,
 )
-
-
-def parse_nmea(filepath):
-    """Parse NMEA GGA sentences.
-
-    Recovers ellipsoidal height from the two GGA height fields:
-      field[9]  — MSL altitude (orthometric height)
-      field[11] — Geoid separation N
-      h_ell     = field[9] + field[11]
-
-    Args:
-        filepath: Path to NMEA file.
-
-    Returns:
-        Tuple (rows, geoid_ok) where:
-          rows     — list of (lat_deg, lon_deg, h_ell, quality) tuples in
-                     file order.  h_ell is the ellipsoidal height in metres.
-          geoid_ok — True if geoid separation was successfully read from
-                     at least one sentence; False if field[11] was absent
-                     or zero for all sentences (Up comparison unreliable).
-    """
-    geoid_ok = False
-    rows = []
-    with open(filepath) as fh:
-        for raw in fh:
-            line = raw.strip()
-            if not line:
-                continue
-            if "*" in line:
-                line = line[: line.index("*")]
-            fields = line.split(",")
-            if len(fields) < 10:
-                continue
-            if fields[0] not in ("$GPGGA", "$GNGGA"):
-                continue
-            try:
-                quality = int(fields[6])
-                if quality == 0 or not fields[2] or not fields[4]:
-                    continue
-                lat = nmea_to_deg(fields[2], fields[3])
-                lon = nmea_to_deg(fields[4], fields[5])
-                alt_msl = float(fields[9])
-                # Recover ellipsoidal height: h_ell = MSL + geoid_separation
-                geoid_sep = 0.0
-                if len(fields) > 11 and fields[11]:
-                    try:
-                        geoid_sep = float(fields[11])
-                    except ValueError:
-                        pass
-                if geoid_sep != 0.0:
-                    geoid_ok = True
-                rows.append((lat, lon, alt_msl + geoid_sep, quality))
-            except (ValueError, IndexError):
-                continue
-    return rows, geoid_ok
 
 
 # ---------------------------------------------------------------------------
@@ -123,9 +87,10 @@ def compute_abs_metrics(true_xyz, rows, skip_epochs=0):
 
     Args:
         true_xyz: np.array([X, Y, Z]) — true ECEF coordinate in metres.
-        rows: list of (lat, lon, h_ell, q) tuples from parse_nmea(), in
+        rows: list of (lat, lon, h_ell, q, ns) tuples from parse_nmea(), in
             file order. Storing epochs as a list avoids silent overwrites
             when HHMMSS.ss timestamps repeat across midnight boundaries.
+            q is the raw GGA quality indicator.
         skip_epochs: initial epochs to discard.
 
     Returns:
@@ -136,19 +101,24 @@ def compute_abs_metrics(true_xyz, rows, skip_epochs=0):
     if not rows:
         return None
 
-    enu_errors, q_list = [], []
-    for lat, lon, h_ell, q in rows:
+    enu_errors, q_list, ns_list = [], [], []
+    for lat, lon, h_ell, q, ns, _t in rows:
         test_xyz = blh2xyz(lat, lon, h_ell)
         dx = test_xyz - true_xyz
         enu = xyz2enu(dx, true_lat, true_lon)
         enu_errors.append(enu)
         q_list.append(q)
+        ns_list.append(ns)
 
     en = np.array(enu_errors)
     n = len(en)
 
     horiz = np.sqrt(en[:, 0] ** 2 + en[:, 1] ** 2)
     e3d = np.sqrt(en[:, 0] ** 2 + en[:, 1] ** 2 + en[:, 2] ** 2)
+
+    # GGA quality 4 = RTK fixed, 5 = float, 3 = PPP (nmea_solq[] in
+    # src/pos/mrtk_sol.c).  Quality 1 is stand-alone SPS, not a fix.
+    ns_precise = [ns for ns, q in zip(ns_list, q_list) if q in (3, 4, 5)]
 
     return {
         "n": n,
@@ -171,7 +141,12 @@ def compute_abs_metrics(true_xyz, rows, skip_epochs=0):
         "p95_3d": float(np.percentile(e3d, 95)),
         "max_3d": float(np.max(e3d)),
         "rms_u": float(np.sqrt(np.mean(en[:, 2] ** 2))),
-        "fix_rate": sum(1 for q in q_list if q in (1, 4)) / n * 100.0,
+        "fix_rate": sum(1 for q in q_list if q == 4) / n * 100.0,
+        # Satellite count over Fix/Float/PPP epochs
+        "n_precise": len(ns_precise),
+        "ns_mean": float(np.mean(ns_precise)) if ns_precise else 0.0,
+        "ns_min": int(np.min(ns_precise)) if ns_precise else 0,
+        "ns_max": int(np.max(ns_precise)) if ns_precise else 0,
     }
 
 
@@ -245,6 +220,18 @@ def main():  # noqa: D103
         type=float,
         default=0.100,
         help="Tolerance for criterion A in metres (default 0.100)",
+    )
+    p.add_argument(
+        "--ttff-h",
+        type=float,
+        default=0.30,
+        help="TTFF horizontal error bound in metres (default 0.30)",
+    )
+    p.add_argument(
+        "--ttff-v",
+        type=float,
+        default=0.50,
+        help="TTFF vertical error bound in metres (default 0.50)",
     )
     p.add_argument("--skip-epochs", type=int, default=0, help="Initial epochs to discard")
     p.add_argument(
@@ -368,8 +355,18 @@ def main():  # noqa: D103
     print(f"    1σ     : {m['p68_3d'] * 100:8.3f} cm")
     print(f"    95%    : {m['p95_3d'] * 100:8.3f} cm")
     print()
-    print(f"  Fix rate : {m['fix_rate']:.2f}%  (GGA quality = 1 or 4)")
+    print(f"  Fix rate : {m['fix_rate']:.2f}%  (GGA quality = 4: RTK fixed)")
     print(f"  Ref prec : {ref_precision * 100:.3f} cm  ({ref_label})")
+    print()
+    print(f"  Satellites over Fix/Float/PPP epochs  ({m['n_precise']} epochs):")
+    if m["n_precise"]:
+        print(f"    Mean   : {m['ns_mean']:8.2f}")
+        print(f"    Min    : {m['ns_min']:8d}")
+        print(f"    Max    : {m['ns_max']:8d}")
+    else:
+        print("    (none)")
+    print()
+    print_ttff(true_xyz, test_data, args.ttff_h, args.ttff_v, geoid_ok, fix_q=4)
     print()
 
     if args.plot:

--- a/scripts/tests/compare_nmea_abs.py
+++ b/scripts/tests/compare_nmea_abs.py
@@ -92,10 +92,11 @@ def compute_abs_metrics(true_xyz, rows, skip_epochs=0):
 
     Args:
         true_xyz: np.array([X, Y, Z]) — true ECEF coordinate in metres.
-        rows: list of (lat, lon, h_ell, q, ns) tuples from parse_nmea(), in
+        rows: list of (lat, lon, h_ell, q, ns, t) tuples from parse_nmea(), in
             file order. Storing epochs as a list avoids silent overwrites
             when HHMMSS.ss timestamps repeat across midnight boundaries.
-            q is the raw GGA quality indicator.
+            q is the raw GGA quality indicator and t the epoch time in
+            seconds; this function uses neither and discards t.
         skip_epochs: initial epochs to discard.
 
     Returns:

--- a/scripts/tests/compare_pos_abs.py
+++ b/scripts/tests/compare_pos_abs.py
@@ -43,12 +43,18 @@ Reported statistics
   state — Fix, Float or PPP (Q = 1, 2, 6); Single and DGPS epochs are excluded
   so the figure describes the epochs the accuracy statistics come from.
   TTFF — first epoch that is integer-fixed (Q=1, i.e. GGA quality 4) *and*
-  within 30 cm horizontally and 50 cm vertically (--ttff-h / --ttff-v).
-  Measured from the first epoch of the file: --skip-epochs discards the
-  convergence transient, which is what TTFF is about, so it is not applied.
-  PPP conv — the same bounds applied to the PPP state (Q=6, GGA quality 3),
-  reported as a reference convergence time.  Printed only when the solution
-  actually contains PPP epochs.
+  within 30 cm horizontally and 50 cm vertically (--ttff-h / --ttff-v), which
+  then has to hold for 5 minutes (--hold).  The time reported is the START of
+  the sustained run: the hold confirms the solution really had converged there,
+  it is not a delay added to the answer.  Measured from the first epoch of the
+  file — --skip-epochs discards the convergence transient, which is what this
+  is about, so it is not applied.
+  PPP conv — the same bounds and hold applied to the PPP state (Q=6, GGA
+  quality 3) *or better*: upgrading to an integer fix counts as maintaining
+  PPP, so it does not break the run.  A reference figure, printed only when the
+  solution actually contains PPP epochs.
+  A data gap longer than 3x the median epoch interval ends a run in both
+  cases — nothing is known about the missing time.
 
 Pass / Fail
 -----------
@@ -82,6 +88,7 @@ Options
     --tolerance FLOAT   Tolerance for criterion A in metres (default 0.030)
     --ttff-h FLOAT      TTFF horizontal bound in metres (default 0.30)
     --ttff-v FLOAT      TTFF vertical bound in metres (default 0.50)
+    --hold FLOAT        Seconds the TTFF / convergence criteria must hold (300)
     --skip-epochs INT   Skip N initial epochs (convergence transient)
     --use-2d            Evaluate pass/fail on 2D horizontal error (default: 3D)
     --plot              Generate ENU error time-series plot
@@ -546,13 +553,21 @@ def compute_abs_metrics(true_xyz, rows, skip_epochs=0):
     }
 
 
-def compute_ttff(true_xyz, rows, max_h=0.30, max_v=0.50, fix_q=1):
-    """Time to first fix: first epoch in the given state that is *also* accurate.
+def compute_ttff(true_xyz, rows, max_h=0.30, max_v=0.50, states=(1,), hold=0.0):
+    """First epoch in the given solution states that is *also* accurate.
 
-    An epoch qualifies when its solution status equals ``fix_q`` and both the
-    horizontal error and the absolute Up error are within the given bounds.
+    An epoch qualifies when its solution status is one of ``states`` and both
+    the horizontal error and the absolute Up error are within the given bounds.
+
+    With ``hold`` > 0 the epoch must additionally start an unbroken run of
+    qualifying epochs spanning at least that many seconds, and the reported
+    epoch is the *start* of that run: the hold is the confirmation that the
+    solution had really converged there, not a delay added to the answer.  A
+    data gap — an interval longer than 3x the median epoch interval — ends a
+    run, since nothing is known about the missing time.
+
     The search always starts at the first epoch of the file — skip_epochs
-    exists to drop the convergence transient, which is exactly what TTFF
+    exists to drop the convergence transient, which is exactly what this
     measures.
 
     Args:
@@ -560,8 +575,10 @@ def compute_ttff(true_xyz, rows, max_h=0.30, max_v=0.50, fix_q=1):
         rows: list of (lat, lon, h, q, ns, t) tuples in epoch order.
         max_h: horizontal error bound in metres.
         max_v: absolute vertical (Up) error bound in metres.
-        fix_q: quality value that means integer fix — 1 on the .pos scale,
-            4 for raw GGA quality.
+        states: accepted quality values.  A better state than the one asked
+            about counts as maintaining it, so PPP convergence passes
+            ``(PPP, fix)`` — upgrading to an integer fix must not break the run.
+        hold: seconds the criteria must hold from the reported epoch on.
 
     Returns:
         dict with keys ``ttff`` (seconds from the first epoch, None when the
@@ -571,28 +588,53 @@ def compute_ttff(true_xyz, rows, max_h=0.30, max_v=0.50, fix_q=1):
     if not rows:
         return None
     true_lat, true_lon, _ = xyz2blh(*true_xyz)
+    times = [r[5] for r in rows]
+    t0 = times[0]
 
-    for i, (lat, lon, h, q, _ns, t) in enumerate(rows):
-        if q != fix_q:
+    good = []
+    for lat, lon, h, q, _ns, _t in rows:
+        if q not in states:
+            good.append(False)
             continue
         enu = xyz2enu(blh2xyz(lat, lon, h) - true_xyz, true_lat, true_lon)
-        if math.hypot(enu[0], enu[1]) > max_h or abs(enu[2]) > max_v:
-            continue
-        t0 = rows[0][5]
+        good.append(math.hypot(enu[0], enu[1]) <= max_h and abs(enu[2]) <= max_v)
+
+    if hold <= 0:
+        i = next((k for k, g in enumerate(good) if g), None)
+        if i is None:
+            return None
         return {
-            "ttff": (t - t0) if (t is not None and t0 is not None) else None,
+            "ttff": (times[i] - t0) if (times[i] is not None and t0 is not None) else None,
             "index": i,
             "n": len(rows),
         }
+
+    if any(t is None for t in times):
+        return None  # the hold cannot be verified without epoch times
+
+    dts = [b - a for a, b in zip(times, times[1:])]
+    gap = 3.0 * float(np.median(dts)) if dts else float("inf")
+
+    start = None
+    for i, g in enumerate(good):
+        if not g:
+            start = None
+            continue
+        if start is None or times[i] - times[i - 1] > gap:
+            start = i
+        if times[i] - times[start] >= hold:
+            return {"ttff": times[start] - t0, "index": start, "n": len(rows)}
     return None
 
 
-def print_ttff(true_xyz, rows, max_h=0.30, max_v=0.50, geoid_ok=True, fix_q=1, ppp_q=6):
+def print_ttff(true_xyz, rows, max_h=0.30, max_v=0.50, geoid_ok=True, fix_q=1, ppp_q=6, hold=300.0):
     """Print the TTFF line, and the PPP convergence time when PPP epochs exist.
 
-    The PPP line applies the same accuracy bounds to the PPP solution state
-    instead of the integer fix.  It is a reference figure — a run that never
-    reports a PPP epoch (plain RTK) simply does not get the line.
+    Both lines require their criteria to hold for ``hold`` seconds and report
+    the start of that run.  The PPP line applies the same accuracy bounds to
+    the PPP state or better (an integer fix counts as maintaining PPP), and is
+    a reference figure — a run that never reports a PPP epoch (plain RTK)
+    simply does not get the line.
 
     Args:
         true_xyz: np.array([X, Y, Z]) — true ECEF coordinate in metres.
@@ -603,14 +645,20 @@ def print_ttff(true_xyz, rows, max_h=0.30, max_v=0.50, geoid_ok=True, fix_q=1, p
             which case the vertical criterion cannot be evaluated.
         fix_q: quality value that means integer fix.
         ppp_q: quality value that means PPP.
+        hold: seconds the criteria must hold from the reported epoch on.
     """
 
-    def line(label, state, q):
+    def line(label, state, qs, hold_s):
         crit = f"{state} & 2D<={max_h * 100:g}cm & Up<={max_v * 100:g}cm"
+        if hold_s > 0:
+            crit += f", held {hold_s / 60:.3g} min"
         if not geoid_ok:
             print(f"  {label} : n/a  (no geoid separation, Up unevaluable; {crit})")
             return
-        r = compute_ttff(true_xyz, rows, max_h, max_v, q)
+        if hold_s > 0 and any(r[5] is None for r in rows):
+            print(f"  {label} : n/a  (no usable time stamps; {crit})")
+            return
+        r = compute_ttff(true_xyz, rows, max_h, max_v, qs, hold_s)
         if r is None:
             print(f"  {label} : not reached in {len(rows)} epochs  ({crit})")
         elif r["ttff"] is None:
@@ -618,9 +666,9 @@ def print_ttff(true_xyz, rows, max_h=0.30, max_v=0.50, geoid_ok=True, fix_q=1, p
         else:
             print(f"  {label} : {r['ttff']:.1f} s  (epoch {r['index'] + 1}/{r['n']}; {crit})")
 
-    line("TTFF    ", "fix", fix_q)
+    line("TTFF    ", "fix", (fix_q,), hold)
     if any(r[3] == ppp_q for r in rows):
-        line("PPP conv", "PPP", ppp_q)
+        line("PPP conv", "PPP or better", (ppp_q, fix_q), hold)
 
 
 # ---------------------------------------------------------------------------
@@ -819,6 +867,12 @@ def main():  # noqa: D103
         help="TTFF vertical error bound in metres (default 0.50)",
     )
     p.add_argument(
+        "--hold",
+        type=float,
+        default=300.0,
+        help="Seconds the TTFF / convergence criteria must hold (default 300)",
+    )
+    p.add_argument(
         "--format",
         choices=["auto", "pos", "nmea"],
         default="auto",
@@ -975,7 +1029,7 @@ def main():  # noqa: D103
     else:
         print("    (none)")
     print()
-    print_ttff(true_xyz, rows, args.ttff_h, args.ttff_v, geoid_ok)
+    print_ttff(true_xyz, rows, args.ttff_h, args.ttff_v, geoid_ok, hold=args.hold)
     print()
 
     if args.plot:

--- a/scripts/tests/compare_pos_abs.py
+++ b/scripts/tests/compare_pos_abs.py
@@ -756,9 +756,14 @@ def plot_results(m, ref_label, output_path="abs_compare.png"):
     ax2q = ax2.twinx()
     ax2q.scatter(idx, m["q_list"], s=8, alpha=0.5, color="C3")
     ax2q.set_ylabel("Q flag", color="C3")
-    ax2q.set_yticks([1, 2, 3, 4, 5, 6])
-    ax2q.set_yticklabels(["1:Fix", "2:Float", "3:SBAS", "4:DGPS", "5:Single", "6:PPP"])
-    ax2q.set_ylim(0.5, 6.5)
+    # Q=7 (dead reckoning) is reachable from NMEA input via _GGA_TO_SOLQ, and
+    # Q=0 marks a quality indicator this scale has no slot for; both must stay
+    # on the axis or the plot silently disagrees with the parser.
+    ax2q.set_yticks([0, 1, 2, 3, 4, 5, 6, 7])
+    ax2q.set_yticklabels(
+        ["0:None", "1:Fix", "2:Float", "3:SBAS", "4:DGPS", "5:Single", "6:PPP", "7:DR"]
+    )
+    ax2q.set_ylim(-0.5, 7.5)
     ax2q.tick_params(axis="y", labelcolor="C3")
     if formatter:
         # ax1 shares this axis

--- a/scripts/tests/compare_pos_abs.py
+++ b/scripts/tests/compare_pos_abs.py
@@ -46,6 +46,9 @@ Reported statistics
   within 30 cm horizontally and 50 cm vertically (--ttff-h / --ttff-v).
   Measured from the first epoch of the file: --skip-epochs discards the
   convergence transient, which is what TTFF is about, so it is not applied.
+  PPP conv — the same bounds applied to the PPP state (Q=6, GGA quality 3),
+  reported as a reference convergence time.  Printed only when the solution
+  actually contains PPP epochs.
 
 Pass / Fail
 -----------
@@ -474,8 +477,8 @@ def compute_abs_metrics(true_xyz, rows, skip_epochs=0):
 
     Args:
         true_xyz: np.array([X, Y, Z]) — true ECEF coordinate in metres.
-        rows: list of (lat, lon, h, Q, ns) tuples from load_solution(), in epoch
-            order.  Q follows the RTKLIB .pos convention.
+        rows: list of (lat, lon, h, Q, ns, t) tuples from load_solution(), in
+            epoch order.  Q follows the RTKLIB .pos convention.
         skip_epochs: number of initial epochs to discard.
 
     Returns:
@@ -486,14 +489,15 @@ def compute_abs_metrics(true_xyz, rows, skip_epochs=0):
     if not rows:
         return None
 
-    errors_3d, enu_errors, q_list, ns_list = [], [], [], []
-    for lat, lon, h, q, ns, _t in rows:
+    errors_3d, enu_errors, q_list, ns_list, t_list = [], [], [], [], []
+    for lat, lon, h, q, ns, t in rows:
         dx = blh2xyz(lat, lon, h) - true_xyz
         enu = xyz2enu(dx, true_lat, true_lon)
         enu_errors.append(enu)
         errors_3d.append(float(np.linalg.norm(enu)))
         q_list.append(q)
         ns_list.append(ns)
+        t_list.append(t)
 
     e3 = np.array(errors_3d)
     en = np.array(enu_errors)
@@ -510,6 +514,8 @@ def compute_abs_metrics(true_xyz, rows, skip_epochs=0):
         "errors_3d": e3,
         "enu_errors": en,
         "q_list": q_list,
+        "ns_list": ns_list,
+        "t_list": t_list,
         "true_lat": true_lat,
         "true_lon": true_lon,
         # ENU components
@@ -541,9 +547,9 @@ def compute_abs_metrics(true_xyz, rows, skip_epochs=0):
 
 
 def compute_ttff(true_xyz, rows, max_h=0.30, max_v=0.50, fix_q=1):
-    """Time to first fix: first epoch that is fixed *and* accurate.
+    """Time to first fix: first epoch in the given state that is *also* accurate.
 
-    An epoch qualifies when its solution status is an integer fix and both the
+    An epoch qualifies when its solution status equals ``fix_q`` and both the
     horizontal error and the absolute Up error are within the given bounds.
     The search always starts at the first epoch of the file — skip_epochs
     exists to drop the convergence transient, which is exactly what TTFF
@@ -581,8 +587,12 @@ def compute_ttff(true_xyz, rows, max_h=0.30, max_v=0.50, fix_q=1):
     return None
 
 
-def print_ttff(true_xyz, rows, max_h=0.30, max_v=0.50, geoid_ok=True, fix_q=1):
-    """Print the TTFF line for a solution.
+def print_ttff(true_xyz, rows, max_h=0.30, max_v=0.50, geoid_ok=True, fix_q=1, ppp_q=6):
+    """Print the TTFF line, and the PPP convergence time when PPP epochs exist.
+
+    The PPP line applies the same accuracy bounds to the PPP solution state
+    instead of the integer fix.  It is a reference figure — a run that never
+    reports a PPP epoch (plain RTK) simply does not get the line.
 
     Args:
         true_xyz: np.array([X, Y, Z]) — true ECEF coordinate in metres.
@@ -592,33 +602,80 @@ def print_ttff(true_xyz, rows, max_h=0.30, max_v=0.50, geoid_ok=True, fix_q=1):
         geoid_ok: False when the input is NMEA without geoid separation, in
             which case the vertical criterion cannot be evaluated.
         fix_q: quality value that means integer fix.
+        ppp_q: quality value that means PPP.
     """
-    crit = f"fix & 2D<={max_h * 100:g}cm & Up<={max_v * 100:g}cm"
-    if not geoid_ok:
-        print(f"  TTFF     : n/a  (no geoid separation, Up unevaluable; {crit})")
-        return
 
-    r = compute_ttff(true_xyz, rows, max_h, max_v, fix_q)
-    if r is None:
-        print(f"  TTFF     : not reached in {len(rows)} epochs  ({crit})")
-    elif r["ttff"] is None:
-        print(f"  TTFF     : epoch {r['index'] + 1}/{r['n']}, time unknown  ({crit})")
-    else:
-        print(f"  TTFF     : {r['ttff']:.1f} s  (epoch {r['index'] + 1}/{r['n']}; {crit})")
+    def line(label, state, q):
+        crit = f"{state} & 2D<={max_h * 100:g}cm & Up<={max_v * 100:g}cm"
+        if not geoid_ok:
+            print(f"  {label} : n/a  (no geoid separation, Up unevaluable; {crit})")
+            return
+        r = compute_ttff(true_xyz, rows, max_h, max_v, q)
+        if r is None:
+            print(f"  {label} : not reached in {len(rows)} epochs  ({crit})")
+        elif r["ttff"] is None:
+            print(f"  {label} : epoch {r['index'] + 1}/{r['n']}, time unknown  ({crit})")
+        else:
+            print(f"  {label} : {r['ttff']:.1f} s  (epoch {r['index'] + 1}/{r['n']}; {crit})")
+
+    line("TTFF    ", "fix", fix_q)
+    if any(r[3] == ppp_q for r in rows):
+        line("PPP conv", "PPP", ppp_q)
 
 
 # ---------------------------------------------------------------------------
 # Plot
 # ---------------------------------------------------------------------------
+def _time_axis(m):
+    """Build the shared x axis of the plots.
+
+    Args:
+        m: metrics dict from compute_abs_metrics().
+
+    Returns:
+        Tuple (x, label, formatter, ticks, xlim): elapsed seconds from the first
+        epoch with an HH:MM tick formatter and ticks on round clock times when
+        every epoch carries a time stamp, else the epoch index with none of
+        them.  Elapsed seconds keep the axis monotonic across midnight, which a
+        seconds-of-day axis would not.
+    """
+    t_list = m.get("t_list") or []
+    if len(t_list) != m["n"] or any(t is None for t in t_list):
+        return np.arange(m["n"]), "Epoch", None, None, None
+
+    t0, t1 = t_list[0], t_list[-1]
+
+    def hhmm(x, _pos):
+        sod = (t0 + x) % 86400
+        return f"{int(sod // 3600):02d}:{int(sod % 3600 // 60):02d}"
+
+    # Tick on round clock times rather than on round elapsed seconds: pick the
+    # smallest step that keeps the count under ~10.
+    span = max(t1 - t0, 1.0)
+    step = next(
+        (s for s in (60, 120, 300, 600, 900, 1800, 3600, 7200, 21600, 43200) if span / s <= 9),
+        86400,
+    )
+    # Pad the view so a tick landing on the first or last epoch still has room
+    # for its label instead of being clipped against the frame.
+    pad = 0.02 * span
+    first = math.ceil((t0 - pad) / step) * step
+    ticks = np.arange(first, t1 + pad + step, step) - t0
+    ticks = ticks[(ticks >= -pad) & (ticks <= span + pad)]
+
+    return np.array(t_list) - t0, "Time [HH:MM]", hhmm, ticks, (-pad, span + pad)
+
+
 def plot_results(m, ref_label, output_path="abs_compare.png"):
     """Generate ENU error time-series and Q-flag plot."""
     import matplotlib
 
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
+    from matplotlib.ticker import FuncFormatter
 
     en = m["enu_errors"] * 100  # m → cm
-    idx = np.arange(m["n"])
+    idx, xlabel, formatter, ticks, xlim = _time_axis(m)
 
     fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 7), sharex=True)
     for col, lbl in zip(range(3), ("East", "North", "Up")):
@@ -634,13 +691,32 @@ def plot_results(m, ref_label, output_path="abs_compare.png"):
     ax1.legend()
     ax1.grid(True, alpha=0.3)
 
-    ax2.scatter(idx, m["q_list"], s=8, alpha=0.6)
-    ax2.set_ylabel("Q flag")
-    ax2.set_xlabel("Epoch")
-    ax2.set_title(f"Q flag  (fix rate {m['fix_rate']:.1f}%)")
-    ax2.set_yticks([1, 2, 3, 4, 5, 6])
-    ax2.set_yticklabels(["1:Fix", "2:Float", "3:SBAS", "4:DGPS", "5:Single", "6:PPP"])
+    # Satellite count on the left axis, Q flag on the right.  The count starts
+    # at 0 so the bar-like trace is read against an absolute scale, which also
+    # keeps it clear of the Q markers anchored at the bottom of the right scale.
+    ax2.plot(idx, m["ns_list"], color="C0", linewidth=0.8, alpha=0.9)
+    ax2.set_ylim(0, max(m["ns_list"]) + 1)
+    ax2.set_ylabel("Satellites", color="C0")
+    ax2.tick_params(axis="y", labelcolor="C0")
+    ax2.set_xlabel(xlabel)
+    ax2.set_title(
+        f"Satellites  (mean {m['ns_mean']:.1f} over Fix/Float/PPP)"
+        f"   |   Q flag  (fix rate {m['fix_rate']:.1f}%)"
+    )
     ax2.grid(True, alpha=0.3)
+
+    ax2q = ax2.twinx()
+    ax2q.scatter(idx, m["q_list"], s=8, alpha=0.5, color="C3")
+    ax2q.set_ylabel("Q flag", color="C3")
+    ax2q.set_yticks([1, 2, 3, 4, 5, 6])
+    ax2q.set_yticklabels(["1:Fix", "2:Float", "3:SBAS", "4:DGPS", "5:Single", "6:PPP"])
+    ax2q.set_ylim(0.5, 6.5)
+    ax2q.tick_params(axis="y", labelcolor="C3")
+    if formatter:
+        # ax1 shares this axis
+        ax2.set_xticks(ticks)
+        ax2.set_xlim(*xlim)
+        ax2.xaxis.set_major_formatter(FuncFormatter(formatter))
 
     plt.tight_layout()
     plt.savefig(output_path, dpi=150)

--- a/scripts/tests/compare_pos_abs.py
+++ b/scripts/tests/compare_pos_abs.py
@@ -1,9 +1,22 @@
 #!/usr/bin/env python3
 """compare_pos_abs.py - Absolute accuracy check against geodetic truth.
 
-Compares a RTKLIB .pos file against a true reference coordinate derived from
-either an IGS SINEX file (for IGS/CORS stations such as MIZU) or a GSI F5
-daily coordinate file (for GEONET stations).
+Compares a solution file — RTKLIB .pos or NMEA GGA — against a true reference
+coordinate derived from either an IGS SINEX file (for IGS/CORS stations such as
+MIZU) or a GSI F5 daily coordinate file (for GEONET stations).
+
+Input formats
+-------------
+The format is sniffed from the file content (a leading ``$`` sentence means
+NMEA); ``--format pos|nmea`` overrides the detection.  NMEA input is normalised
+onto the .pos convention so every metric below is format-independent:
+
+  Position  ellipsoidal height is recovered as GGA field[9] (MSL) + field[11]
+            (geoid separation N).  When field[11] is absent or zero the Up
+            component cannot be recovered — the run then requires --use-2d.
+  Q flag    GGA quality is mapped to the RTKLIB solution status (the inverse
+            of nmea_solq[] in src/pos/mrtk_sol.c), so Q=1 is an integer fix and
+            Q=6 is PPP for both formats.
 
 Reference derivation
 --------------------
@@ -26,6 +39,13 @@ Reported statistics
 -------------------
   1σ   — 68th percentile of per-epoch 3D errors  (≈ 1 standard deviation)
   95%  — 95th percentile of per-epoch 3D errors
+  Satellite count (mean / min / max) over the epochs in a precise solution
+  state — Fix, Float or PPP (Q = 1, 2, 6); Single and DGPS epochs are excluded
+  so the figure describes the epochs the accuracy statistics come from.
+  TTFF — first epoch that is integer-fixed (Q=1, i.e. GGA quality 4) *and*
+  within 30 cm horizontally and 50 cm vertically (--ttff-h / --ttff-v).
+  Measured from the first epoch of the file: --skip-epochs discards the
+  convergence transient, which is what TTFF is about, so it is not applied.
 
 Pass / Fail
 -----------
@@ -45,17 +65,20 @@ individually pass.
 Usage
 -----
     compare_pos_abs.py --sinex FILE.SNX[.gz] --station CODE [--epoch YYYY/MM/DD]
-                       [options] test.pos
+                       [options] test.pos|test.nmea
     compare_pos_abs.py --f5 FILE --date YYYY/MM/DD
-                       [options] test.pos
+                       [options] test.pos|test.nmea
     compare_pos_abs.py --llh LAT,LON,H [--ref-precision FLOAT]
-                       [options] test.pos
+                       [options] test.pos|test.nmea
     compare_pos_abs.py --ecef X,Y,Z [--ref-precision FLOAT]
-                       [options] test.pos
+                       [options] test.pos|test.nmea
 
 Options
 -------
+    --format FMT        Input format: auto (default), pos, or nmea
     --tolerance FLOAT   Tolerance for criterion A in metres (default 0.030)
+    --ttff-h FLOAT      TTFF horizontal bound in metres (default 0.30)
+    --ttff-v FLOAT      TTFF vertical bound in metres (default 0.50)
     --skip-epochs INT   Skip N initial epochs (convergence transient)
     --use-2d            Evaluate pass/fail on 2D horizontal error (default: 3D)
     --plot              Generate ENU error time-series plot
@@ -74,7 +97,7 @@ import sys
 from datetime import datetime, timedelta
 
 import numpy as np
-from _geo import blh2xyz, xyz2blh, xyz2enu  # noqa: E402
+from _geo import blh2xyz, nmea_to_deg, xyz2blh, xyz2enu  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -245,13 +268,62 @@ def parse_f5(filepath, eval_date_str):
 
 
 # ---------------------------------------------------------------------------
-# .pos file parser  (same logic as compare_pos.py)
+# Solution file parsers  (.pos — same logic as compare_pos.py — and NMEA GGA)
 # ---------------------------------------------------------------------------
+# NMEA GGA quality indicator → RTKLIB solution status Q.  Inverse of
+# nmea_solq[] in src/pos/mrtk_sol.c: 1=single, 2=DGPS, 3=PPP, 4=fix, 5=float,
+# 6=dead reckoning.  Note that PPP rides on quality 3, not 6.
+_GGA_TO_SOLQ = {1: 5, 2: 4, 3: 6, 4: 1, 5: 2, 6: 7}
+
+_UNIX_EPOCH = datetime(1970, 1, 1)
+
+
+def _pos_seconds(date_field, time_field):
+    """Convert a .pos time stamp to seconds on a monotonic scale.
+
+    Handles both output formats: calendar ``YYYY/MM/DD HH:MM:SS.sss`` and GPS
+    ``week tow``.  Only differences are used downstream, so the origin of the
+    calendar scale (Unix epoch, naive) does not matter.
+
+    Args:
+        date_field: First whitespace field (date or GPS week).
+        time_field: Second field (time of day or time of week).
+
+    Returns:
+        Seconds as float, or None if the stamp is not parsable.
+    """
+    try:
+        if "/" in date_field:
+            day = datetime.strptime(date_field, "%Y/%m/%d")
+            hh, mm, ss = time_field.split(":")
+            return (day - _UNIX_EPOCH).total_seconds() + int(hh) * 3600 + int(mm) * 60 + float(ss)
+        return int(date_field) * 604800 + float(time_field)
+    except ValueError:
+        return None
+
+
+def _gga_seconds(hhmmss):
+    """Convert a GGA HHMMSS.ss field to seconds of day.
+
+    Args:
+        hhmmss: GGA field[1].
+
+    Returns:
+        Seconds of day as float, or None if the field is malformed.
+    """
+    try:
+        return int(hhmmss[0:2]) * 3600 + int(hhmmss[2:4]) * 60 + float(hhmmss[4:])
+    except (ValueError, IndexError):
+        return None
+
+
 def parse_pos(filepath):
     """Parse an RTKLIB .pos file.
 
     Returns:
-        dict mapping time-key string to (lat, lon, h, Q).
+        dict mapping time-key string to (lat, lon, h, Q, ns, t), where ns is the
+        satellite count of the epoch (0 when the file has no ns column) and t is
+        the epoch time in seconds (None if the time stamp is not parsable).
     """
     data = {}
     with open(filepath) as fh:
@@ -263,43 +335,175 @@ def parse_pos(filepath):
             if len(parts) < 6:
                 continue
             key = parts[0] + " " + parts[1]
-            data[key] = (float(parts[2]), float(parts[3]), float(parts[4]), int(parts[5]))
+            data[key] = (
+                float(parts[2]),
+                float(parts[3]),
+                float(parts[4]),
+                int(parts[5]),
+                int(parts[6]) if len(parts) > 6 else 0,
+                _pos_seconds(parts[0], parts[1]),
+            )
     return data
+
+
+def parse_nmea(filepath):
+    """Parse NMEA GGA sentences.
+
+    Recovers ellipsoidal height from the two GGA height fields:
+      field[9]  — MSL altitude (orthometric height)
+      field[11] — Geoid separation N
+      h_ell     = field[9] + field[11]
+
+    Args:
+        filepath: Path to NMEA file.
+
+    Returns:
+        Tuple (rows, geoid_ok) where:
+          rows     — list of (lat_deg, lon_deg, h_ell, quality, nsat, t) tuples
+                     in file order.  h_ell is the ellipsoidal height in metres,
+                     quality is the raw GGA quality indicator, nsat is field[7]
+                     (satellites used) and t is the epoch time in seconds,
+                     unwrapped across midnight (GGA carries no date).
+          geoid_ok — True if geoid separation was successfully read from
+                     at least one sentence; False if field[11] was absent
+                     or zero for all sentences (Up comparison unreliable).
+    """
+    geoid_ok = False
+    rows = []
+    day_offset, prev_sod = 0.0, None
+    with open(filepath) as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line:
+                continue
+            if "*" in line:
+                line = line[: line.index("*")]
+            fields = line.split(",")
+            if len(fields) < 10:
+                continue
+            if fields[0] not in ("$GPGGA", "$GNGGA"):
+                continue
+            try:
+                quality = int(fields[6])
+                if quality == 0 or not fields[2] or not fields[4]:
+                    continue
+                lat = nmea_to_deg(fields[2], fields[3])
+                lon = nmea_to_deg(fields[4], fields[5])
+                nsat = int(fields[7]) if fields[7] else 0
+                alt_msl = float(fields[9])
+                # Recover ellipsoidal height: h_ell = MSL + geoid_separation
+                geoid_sep = 0.0
+                if len(fields) > 11 and fields[11]:
+                    try:
+                        geoid_sep = float(fields[11])
+                    except ValueError:
+                        pass
+                if geoid_sep != 0.0:
+                    geoid_ok = True
+                sod = _gga_seconds(fields[1])
+                if sod is None:
+                    t = None
+                else:
+                    if prev_sod is not None and sod < prev_sod:
+                        day_offset += 86400.0  # GGA has no date: unwrap midnight
+                    prev_sod = sod
+                    t = sod + day_offset
+                rows.append((lat, lon, alt_msl + geoid_sep, quality, nsat, t))
+            except (ValueError, IndexError):
+                continue
+    return rows, geoid_ok
+
+
+def detect_format(filepath):
+    """Sniff whether a solution file is NMEA or an RTKLIB .pos.
+
+    The extension is not trusted — only the content is inspected.
+
+    Args:
+        filepath: Path to the solution file.
+
+    Returns:
+        ``"nmea"`` if the first payload line is a NMEA sentence, else ``"pos"``.
+    """
+    with open(filepath, errors="replace") as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line or line.startswith("%"):
+                continue
+            return "nmea" if line.startswith("$") else "pos"
+    return "pos"
+
+
+def load_solution(filepath, fmt="auto"):
+    """Load a solution file as position rows in epoch order.
+
+    Args:
+        filepath: RTKLIB .pos or NMEA GGA file.
+        fmt: ``"pos"``, ``"nmea"``, or ``"auto"`` to sniff the content.
+
+    Returns:
+        Tuple (rows, fmt, geoid_ok) where:
+          rows     — list of (lat_deg, lon_deg, h_ell_m, Q, nsat, t) tuples.  Q
+                     is on the RTKLIB .pos scale for both input formats and t is
+                     the epoch time in seconds.
+          fmt      — format actually used.
+          geoid_ok — False only for NMEA input carrying no geoid separation,
+                     i.e. the ellipsoidal height (hence Up) is not recoverable.
+    """
+    if fmt == "auto":
+        fmt = detect_format(filepath)
+
+    if fmt == "nmea":
+        rows, geoid_ok = parse_nmea(filepath)
+        rows = [(lat, lon, h, _GGA_TO_SOLQ.get(q, 0), ns, t) for lat, lon, h, q, ns, t in rows]
+        return rows, fmt, geoid_ok
+
+    # .pos epochs are keyed by timestamp, so the dict also de-duplicates them.
+    # Order by the parsed epoch time, not the key: the GPS week/TOW output
+    # format would sort wrong as a string ("2320 99000" after "2320 100000").
+    data = parse_pos(filepath)
+    rows = sorted(data.values(), key=lambda r: (r[5] is None, r[5] or 0.0))
+    return rows, fmt, True
 
 
 # ---------------------------------------------------------------------------
 # Absolute accuracy metrics
 # ---------------------------------------------------------------------------
-def compute_abs_metrics(true_xyz, test_data, skip_epochs=0):
+def compute_abs_metrics(true_xyz, rows, skip_epochs=0):
     """Compute per-epoch 3D errors against a fixed true coordinate.
 
     Args:
         true_xyz: np.array([X, Y, Z]) — true ECEF coordinate in metres.
-        test_data: dict from parse_pos().
+        rows: list of (lat, lon, h, Q, ns) tuples from load_solution(), in epoch
+            order.  Q follows the RTKLIB .pos convention.
         skip_epochs: number of initial epochs to discard.
 
     Returns:
         dict of statistics, or None if no usable epochs.
     """
     true_lat, true_lon, _ = xyz2blh(*true_xyz)
-    epochs = sorted(test_data.keys())[skip_epochs:]
-    if not epochs:
+    rows = rows[skip_epochs:]
+    if not rows:
         return None
 
-    errors_3d, enu_errors, q_list = [], [], []
-    for key in epochs:
-        lat, lon, h, q = test_data[key]
+    errors_3d, enu_errors, q_list, ns_list = [], [], [], []
+    for lat, lon, h, q, ns, _t in rows:
         dx = blh2xyz(lat, lon, h) - true_xyz
         enu = xyz2enu(dx, true_lat, true_lon)
         enu_errors.append(enu)
         errors_3d.append(float(np.linalg.norm(enu)))
         q_list.append(q)
+        ns_list.append(ns)
 
     e3 = np.array(errors_3d)
     en = np.array(enu_errors)
     n = len(e3)
 
     horiz = np.sqrt(en[:, 0] ** 2 + en[:, 1] ** 2)
+
+    # Satellite count over precise-solution epochs only (Q=1 fix, 2 float,
+    # 6 PPP); Single/DGPS epochs would dilute the figure the user cares about.
+    ns_precise = [ns for ns, q in zip(ns_list, q_list) if q in (1, 2, 6)]
 
     return {
         "n": n,
@@ -328,7 +532,79 @@ def compute_abs_metrics(true_xyz, test_data, skip_epochs=0):
         # integer-fixed only (Q=1 = narrow-lane/RTK fix); excludes Q=6 PPP float.
         # Used by --min-fix-rate to assert PPP-AR actually resolves ambiguities.
         "fix_rate_int": sum(1 for q in q_list if q == 1) / n * 100.0,
+        # Satellite count over Fix/Float/PPP epochs
+        "n_precise": len(ns_precise),
+        "ns_mean": float(np.mean(ns_precise)) if ns_precise else 0.0,
+        "ns_min": int(np.min(ns_precise)) if ns_precise else 0,
+        "ns_max": int(np.max(ns_precise)) if ns_precise else 0,
     }
+
+
+def compute_ttff(true_xyz, rows, max_h=0.30, max_v=0.50, fix_q=1):
+    """Time to first fix: first epoch that is fixed *and* accurate.
+
+    An epoch qualifies when its solution status is an integer fix and both the
+    horizontal error and the absolute Up error are within the given bounds.
+    The search always starts at the first epoch of the file — skip_epochs
+    exists to drop the convergence transient, which is exactly what TTFF
+    measures.
+
+    Args:
+        true_xyz: np.array([X, Y, Z]) — true ECEF coordinate in metres.
+        rows: list of (lat, lon, h, q, ns, t) tuples in epoch order.
+        max_h: horizontal error bound in metres.
+        max_v: absolute vertical (Up) error bound in metres.
+        fix_q: quality value that means integer fix — 1 on the .pos scale,
+            4 for raw GGA quality.
+
+    Returns:
+        dict with keys ``ttff`` (seconds from the first epoch, None when the
+        epoch times are unusable), ``index`` (0-based epoch index) and
+        ``n`` (epochs scanned), or None if no epoch ever qualifies.
+    """
+    if not rows:
+        return None
+    true_lat, true_lon, _ = xyz2blh(*true_xyz)
+
+    for i, (lat, lon, h, q, _ns, t) in enumerate(rows):
+        if q != fix_q:
+            continue
+        enu = xyz2enu(blh2xyz(lat, lon, h) - true_xyz, true_lat, true_lon)
+        if math.hypot(enu[0], enu[1]) > max_h or abs(enu[2]) > max_v:
+            continue
+        t0 = rows[0][5]
+        return {
+            "ttff": (t - t0) if (t is not None and t0 is not None) else None,
+            "index": i,
+            "n": len(rows),
+        }
+    return None
+
+
+def print_ttff(true_xyz, rows, max_h=0.30, max_v=0.50, geoid_ok=True, fix_q=1):
+    """Print the TTFF line for a solution.
+
+    Args:
+        true_xyz: np.array([X, Y, Z]) — true ECEF coordinate in metres.
+        rows: list of (lat, lon, h, q, ns, t) tuples in epoch order.
+        max_h: horizontal error bound in metres.
+        max_v: absolute vertical (Up) error bound in metres.
+        geoid_ok: False when the input is NMEA without geoid separation, in
+            which case the vertical criterion cannot be evaluated.
+        fix_q: quality value that means integer fix.
+    """
+    crit = f"fix & 2D<={max_h * 100:g}cm & Up<={max_v * 100:g}cm"
+    if not geoid_ok:
+        print(f"  TTFF     : n/a  (no geoid separation, Up unevaluable; {crit})")
+        return
+
+    r = compute_ttff(true_xyz, rows, max_h, max_v, fix_q)
+    if r is None:
+        print(f"  TTFF     : not reached in {len(rows)} epochs  ({crit})")
+    elif r["ttff"] is None:
+        print(f"  TTFF     : epoch {r['index'] + 1}/{r['n']}, time unknown  ({crit})")
+    else:
+        print(f"  TTFF     : {r['ttff']:.1f} s  (epoch {r['index'] + 1}/{r['n']}; {crit})")
 
 
 # ---------------------------------------------------------------------------
@@ -454,8 +730,26 @@ def main():  # noqa: D103
         action="store_true",
         help="Evaluate pass/fail on 2D horizontal error (default: 3D)",
     )
+    p.add_argument(
+        "--ttff-h",
+        type=float,
+        default=0.30,
+        help="TTFF horizontal error bound in metres (default 0.30)",
+    )
+    p.add_argument(
+        "--ttff-v",
+        type=float,
+        default=0.50,
+        help="TTFF vertical error bound in metres (default 0.50)",
+    )
+    p.add_argument(
+        "--format",
+        choices=["auto", "pos", "nmea"],
+        default="auto",
+        help="Input format of the test file (default: auto-detect from content)",
+    )
     p.add_argument("--plot", action="store_true", help="Generate ENU error time-series plot")
-    p.add_argument("test", help="RTKLIB .pos file to evaluate")
+    p.add_argument("test", help="RTKLIB .pos or NMEA GGA file to evaluate")
     args = p.parse_args()
 
     import os
@@ -511,7 +805,7 @@ def main():  # noqa: D103
         ref_precision = args.ref_precision
         ref_label = "fixed LLH"
 
-        print(f"Reference : fixed LLH")
+        print("Reference : fixed LLH")
         print(f"Ref coord : {lat:.8f}°N  {lon:.8f}°E  {h:.4f} m")
         print(f"Ref prec  : {ref_precision * 1000:.2f} mm")
     else:
@@ -525,29 +819,47 @@ def main():  # noqa: D103
         ref_label = "fixed ECEF"
 
         lat, lon, h = xyz2blh(x, y, z)
-        print(f"Reference : fixed ECEF")
+        print("Reference : fixed ECEF")
         print(f"Ref coord : {lat:.8f}°N  {lon:.8f}°E  {h:.4f} m")
         print(f"Ref prec  : {ref_precision * 1000:.2f} mm")
 
-    # ── Parse test .pos ──────────────────────────────────────────────────────
+    # ── Parse test solution (.pos or NMEA) ───────────────────────────────────
     if not os.path.isfile(args.test):
         print(f"FAIL: test file not found: {args.test}", file=sys.stderr)
         return 1
 
+    rows, fmt, geoid_ok = load_solution(args.test, args.format)
+
     metric_label = "2D horizontal" if args.use_2d else "3D"
-    print(f"Test      : {args.test}")
+    fmt_note = f"{fmt.upper()}, auto-detected" if args.format == "auto" else fmt.upper()
+    print(f"Test      : {args.test}  ({fmt_note})")
     print(f"Tolerance : {args.tolerance * 100:.1f} cm  (evaluated on {metric_label} error)")
     if args.skip_epochs:
         print(f"Skip      : {args.skip_epochs} initial epochs")
     print()
 
-    test_data = parse_pos(args.test)
-    if not test_data:
-        print("FAIL: no data in test file", file=sys.stderr)
+    if not rows:
+        label = "GGA" if fmt == "nmea" else "position"
+        print(f"FAIL: no {label} data in test file", file=sys.stderr)
         return 1
 
+    if not geoid_ok:
+        # h_ell = MSL + N is unrecoverable, so Up is off by the undulation
+        # (~30-40 m in Japan).  Horizontal error is unaffected.
+        if not args.use_2d:
+            print(
+                "FAIL: GGA field[11] (geoid separation) is absent or zero in all epochs,\n"
+                "      so the ellipsoidal height cannot be recovered.  Re-run with\n"
+                "      --use-2d to evaluate horizontal accuracy only.",
+                file=sys.stderr,
+            )
+            return 1
+        print("WARNING: GGA field[11] (geoid separation) absent or zero in all epochs.")
+        print("         Up errors are meaningless; 2D horizontal pass/fail is used.")
+        print()
+
     # ── Compute metrics ──────────────────────────────────────────────────────
-    m = compute_abs_metrics(true_xyz, test_data, args.skip_epochs)
+    m = compute_abs_metrics(true_xyz, rows, args.skip_epochs)
     if m is None:
         print("FAIL: no usable epochs", file=sys.stderr)
         return 1
@@ -578,6 +890,16 @@ def main():  # noqa: D103
     print(f"  Sol rate : {m['fix_rate']:.2f}%  (Q=1/6: fixed or PPP-float)")
     print(f"  Fix rate : {m['fix_rate_int']:.2f}%  (Q=1: integer-fixed)")
     print(f"  Ref prec : {ref_precision * 100:.3f} cm  ({ref_label})")
+    print()
+    print(f"  Satellites over Fix/Float/PPP epochs  ({m['n_precise']} epochs):")
+    if m["n_precise"]:
+        print(f"    Mean  : {m['ns_mean']:8.2f}")
+        print(f"    Min   : {m['ns_min']:8d}")
+        print(f"    Max   : {m['ns_max']:8d}")
+    else:
+        print("    (none)")
+    print()
+    print_ttff(true_xyz, rows, args.ttff_h, args.ttff_v, geoid_ok)
     print()
 
     if args.plot:

--- a/scripts/tests/plot_track_2d.py
+++ b/scripts/tests/plot_track_2d.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""plot_track_2d.py - Side-by-side 2D tracks of several solutions, coloured by quality.
+
+One column per input solution, each showing the horizontal track in local
+East/North metres, every epoch coloured by its solution status.  All columns
+share one origin and one set of axis limits, so the tracks can be compared
+directly.  No accuracy statistics — see compare_pos_abs.py for those.
+
+Inputs are RTKLIB .pos or NMEA GGA files (format sniffed per file).
+
+Quality colours
+---------------
+    Single  red        Float   gold        Fix   green
+    PPP     blue       DGPS    orange      SBAS / DR  grey
+
+Usage
+-----
+    plot_track_2d.py [options] rtk.nmea clas.nmea madoca.nmea
+
+Options
+-------
+    --labels A,B,C      Column labels (default: derived from the file names)
+    --no-order          Keep the input order instead of RTK / CLAS / MADOCA
+    --title TEXT        Figure title
+    -s, --size FLOAT    Marker size (default 2)
+    --clip [PCT]        Clip the shared view to the central PCT% of epochs so a
+                        far outlier does not squash the tracks (bare = 99)
+    -o, --out FILE      Output PNG (default: track_2d.png)
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+from _geo import blh2xyz, xyz2enu  # noqa: E402
+from compare_pos_abs import load_solution  # noqa: E402
+
+# Solution status (.pos convention, what load_solution() normalises NMEA onto)
+_QUALITY = {
+    5: ("Single", "#d62728"),
+    2: ("Float", "#e8c007"),
+    1: ("Fix", "#2ca02c"),
+    6: ("PPP", "#1f77b4"),
+    4: ("DGPS", "#ff7f0e"),
+    3: ("SBAS", "#7f7f7f"),
+    7: ("DR", "#c7c7c7"),
+}
+_LEGEND_ORDER = [5, 4, 3, 2, 1, 6, 7]
+
+# Preferred column order and pretty names for the benchmark file naming
+_PRETTY = {"rtk": "RTK", "clas": "CLAS", "madoca": "MADOCA", "single": "Single", "ppp": "PPP"}
+_ORDER = ["RTK", "CLAS", "MADOCA"]
+
+
+def label_of(path):
+    """Derive a column label from a benchmark file name.
+
+    ``nagoya_run1_clas.nmea`` -> ``CLAS``.
+
+    Args:
+        path: Solution file path.
+
+    Returns:
+        Label string.
+    """
+    stem = Path(path).stem
+    tail = stem.rsplit("_", 1)[-1]
+    return _PRETTY.get(tail.lower(), tail.upper())
+
+
+def main():  # noqa: D103
+    p = argparse.ArgumentParser(description="Plot 2D tracks side by side, coloured by quality")
+    p.add_argument("--labels", help="Comma-separated column labels, in input order")
+    p.add_argument(
+        "--no-order", action="store_true", help="Keep input order instead of RTK/CLAS/MADOCA"
+    )
+    p.add_argument("--title", help="Figure title")
+    p.add_argument("-s", "--size", type=float, default=2.0, help="Marker size (default 2)")
+    p.add_argument(
+        "--clip",
+        type=float,
+        nargs="?",
+        const=99.0,
+        default=None,
+        metavar="PCT",
+        help="Clip the view to the central PCT%% of epochs, dropping outliers "
+        "from the axis range (bare --clip = 99)",
+    )
+    p.add_argument(
+        "--no-line",
+        action="store_true",
+        help="Drop the connecting line (it draws long straight jumps across outliers)",
+    )
+    p.add_argument("-o", "--out", default="track_2d.png", help="Output PNG")
+    p.add_argument("files", nargs="+", help="Solution files (.pos or NMEA)")
+    args = p.parse_args()
+
+    labels = (
+        [s.strip() for s in args.labels.split(",")]
+        if args.labels
+        else [label_of(f) for f in args.files]
+    )
+    if len(labels) < len(args.files):
+        labels += [label_of(f) for f in args.files[len(labels) :]]
+
+    tracks = []
+    for path, label in zip(args.files, labels):
+        rows, fmt, _geoid_ok = load_solution(path)
+        if not rows:
+            print(f"FAIL: no data in {path}", file=sys.stderr)
+            return 1
+        print(f"{label:8s} {path}  ({fmt.upper()}, {len(rows)} epochs)")
+        tracks.append((label, rows))
+
+    if not args.no_order:
+        tracks.sort(key=lambda t: (_ORDER.index(t[0]) if t[0] in _ORDER else len(_ORDER), t[0]))
+
+    # One local frame for every column: the mean position of all epochs.
+    lats = np.array([r[0] for _lbl, rows in tracks for r in rows])
+    lons = np.array([r[1] for _lbl, rows in tracks for r in rows])
+    hs = np.array([r[2] for _lbl, rows in tracks for r in rows])
+    olat, olon, oh = float(lats.mean()), float(lons.mean()), float(hs.mean())
+    origin = blh2xyz(olat, olon, oh)
+
+    def to_en(rows):
+        enu = np.array(
+            [xyz2enu(blh2xyz(lat, lon, h) - origin, olat, olon) for lat, lon, h, *_ in rows]
+        )
+        return enu[:, 0], enu[:, 1]
+
+    tracks = [(label, rows, *to_en(rows)) for label, rows in tracks]
+
+    fig, axes = plt.subplots(
+        1, len(tracks), figsize=(5.2 * len(tracks), 5.6), sharex=True, sharey=True
+    )
+    axes = np.atleast_1d(axes)
+
+    seen = set()
+    for ax, (label, rows, e, n) in zip(axes, tracks):
+        q = np.array([r[3] for r in rows])
+        if not args.no_line:
+            ax.plot(e, n, color="0.75", linewidth=0.3, alpha=0.6, zorder=1)
+        stats = []
+        for qv in _LEGEND_ORDER:
+            sel = q == qv
+            if not sel.any():
+                continue
+            name, color = _QUALITY[qv]
+            seen.add(qv)
+            stats.append((qv, int(sel.sum())))
+            ax.scatter(e[sel], n[sel], s=args.size, c=color, label=name, zorder=2)
+
+        # Share of each quality within this solution, in legend order.
+        for k, (qv, count) in enumerate(stats):
+            name, color = _QUALITY[qv]
+            ax.text(
+                0.02,
+                0.98 - 0.05 * k,
+                f"{name:<7s}{count / len(rows) * 100:5.1f}%",
+                transform=ax.transAxes,
+                va="top",
+                ha="left",
+                fontsize=8.5,
+                family="monospace",
+                color=color,
+                zorder=3,
+                bbox={"boxstyle": "square,pad=0.15", "fc": "white", "ec": "none", "alpha": 0.7},
+            )
+        ax.set_title(f"{label}  (n={len(rows)})")
+        ax.set_xlabel("East [m]")
+        ax.set_aspect("equal")
+        ax.grid(True, alpha=0.3)
+    axes[0].set_ylabel("North [m]")
+
+    # Optional percentile clip of the shared view: one far outlier otherwise
+    # stretches all three columns until the tracks collapse into a blob.  The
+    # points stay plotted (and counted in the percentages), they just fall
+    # outside the axes.
+    if args.clip:
+        lo, hi = (100.0 - args.clip) / 2.0, (100.0 + args.clip) / 2.0
+        all_e = np.concatenate([e for _lbl, _rows, e, _n in tracks])
+        all_n = np.concatenate([n for _lbl, _rows, _e, n in tracks])
+        e0, e1 = np.percentile(all_e, [lo, hi])
+        n0, n1 = np.percentile(all_n, [lo, hi])
+        pad = 0.05 * max(e1 - e0, n1 - n0, 1.0)
+        axes[0].set_xlim(e0 - pad, e1 + pad)
+        axes[0].set_ylim(n0 - pad, n1 + pad)
+        for label, rows, e, n in tracks:
+            outside = int(((e < e0 - pad) | (e > e1 + pad) | (n < n0 - pad) | (n > n1 + pad)).sum())
+            if outside:
+                print(f"{label:8s} {outside} epoch(s) outside the {args.clip:g}% view")
+
+    handles = [
+        plt.Line2D([], [], marker="o", linestyle="", color=_QUALITY[qv][1], label=_QUALITY[qv][0])
+        for qv in _LEGEND_ORDER
+        if qv in seen
+    ]
+    leg = fig.legend(handles=handles, loc="lower center", ncol=len(handles), frameon=False)
+    if args.title:
+        fig.suptitle(args.title)
+
+    # Reserve exactly the legend's height: a fixed fraction collides with the
+    # x label whenever the equal-aspect boxes reach the bottom of the figure.
+    fig.tight_layout()
+    fig.canvas.draw()
+    legend_frac = leg.get_window_extent().height / fig.bbox.height
+    fig.tight_layout(rect=(0, legend_frac + 0.02, 1, 1))
+    fig.savefig(args.out, dpi=150)
+    print(f"Plot saved: {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Benchmark harness work, ending with a fix for a silent correction dropout that invalidated three of the six PPC cases.

## The fix (31511dd)

`mrtk post` cannot read a *sequence* of hourly L6 archive files:

- it keeps only the **first** L6E file (`qzssl6e_file` is a single buffer, `src/pos/mrtk_postpos.c:1082`);
- it assigns each CLAS `.l6` file to a separate **transmit-pattern channel** (`src/pos/mrtk_postpos.c:1080`), so two time-disjoint hours of one PRN land in ch0/ch1 and reach the v0.7.7 dual-pattern merge as if they were simultaneous.

A run crossing a UTC hour boundary therefore lost every correction at the boundary — with no warning and no trace line. `run_benchmark.py` now concatenates the sessions of each stream into `<l6-dir>/merged/` first; the decoders resynchronise on the L6 preamble of every 250-byte record, so a joined stream decodes exactly like a continuous one. The underlying postpos limitation is tracked in #316.

### Effect

Three of the six PPC runs cross a boundary. Same config, same data, raw GGA quality counts:

| case | sessions | CLAS fix | CLAS SPP fallback | MADOCA epochs |
|---|---|---|---|---|
| tokyo_run3 | 205B, 205C | 14.0% → **58.5%** | 81.7% → **8.1%** | 2855 → **14430** |
| nagoya_run1 | 216I, 216J | 16.5% → **54.2%** | 74.0% → **10.5%** | 2028 → **6407** |
| nagoya_run3 | 216J, 216K | 13.7% → 14.7% | 44.5% → **10.2%** | 2813 → **4547** |
| tokyo_run1 | 205E | 32.7% (unchanged) | 10.5% | 3144 |
| tokyo_run2 | 205B | 48.4% (unchanged) | 10.1% | 8219 |
| nagoya_run2 | 202K | 34.4% (unchanged) | 11.1% | 7553 |

The three single-session runs are bit-identical, confirming the change is inert where no boundary is crossed. nagoya_run3 CLAS recovers from SPP fallback to float but not to fix — that residual is urban-canyon fix performance, not this bug.

The archive files were never at fault: each is a complete hour (3600 × 250-byte records, valid `0x1ACFFC1D` preamble throughout), and a trace confirms the L6E stream still decodes normally past the point where solutions stop.

### Also in this commit

`-ts`/`-te` are now passed as `"y/m/d" "h:m:s"` in GPST. rnx2rtkp discards a week/TOW pair (`epoch2time()` rejects month 0 and returns `t0`), so the requested time window was silently ignored and the whole observation file was processed. Practically a no-op for these cases — the observation files already match the run windows — but the flag now does what it says.

## Earlier commits on the branch

- `73bb3a9` — download MADOCA L6D (PRN 200/201) and fetch L6 sessions by UTC date; corrects the L6E PRN list to the ones the archive actually serves (204/205/206/207/209/210/211)
- `c959823`, `dae0a00`, `5d7ff70` — `compare_pos_abs` accepts NMEA; satellite count, TTFF and PPP convergence time on a time axis; TTFF/convergence require a *sustained* run rather than a single lucky epoch
- `f832df4`, `2786908` — `plot_track_2d.py` (side-by-side tracks coloured by solution quality), moved under `scripts/benchmark/`

## Follow-on commits

### `9152bab` — per-tier 30 cm accuracy rate

The table showed how often each mode reached an integer fix, never whether those fixes were right. A `<30cm` column now carries the fraction of *that row's own* N epochs within 30 cm 2D, so the FIX row answers "of the epochs that claimed a fix, how many were actually right" and its complement is the misfix rate (printed directly as `misfix=` on the per-case progress line). `compute_metrics()` gains `acc_threshold_2d` (default 0.30), kept separate from the existing `threshold_2d`, which is nan for the AR modes and also selects the single-row display path. Existing dict keys are untouched, so `run_gsdc_benchmark.py` is unaffected.

This immediately surfaced a real defect: tokyo_run2 RTK holds a 1.3 cm 1-sigma on fixed epochs while its 95th percentile is 240 m — ~11% wrong fixes, previously invisible behind a healthy-looking 18.3% fix rate.

### `db7e425` — v0.7.7 results in the docs

A single full re-run of all six cases x three modes, with the exact binary, platform, BLAS and command recorded. The shared tier/column legend moves out of the v0.3.3 section so every results section can reference it; no historical section is modified.

The notes state what the numbers do and do not mean:

- Part of the CLAS/MADOCA gain on the three boundary-crossing runs is *this PR's harness fix*, not an algorithm gain.
- MADOCA on the three unaffected runs reproduces the v0.3.3 / v0.4.2 record to the millimetre (tokyo_run1 1.825 -> 1.825 m, nagoya_run2 39.299 -> 39.302 m), which is what makes the other comparisons meaningful.
- CLAS fixed-epoch accuracy in Nagoya is long-standing, not a regression — v0.3.3 already recorded 1-sigma 0.402 m / 0.717 m there.
- RTK carries a warning admonition: regressed against the v0.4.1 record on all six cases, with tokyo_run2 having lost the false-fix elimination v0.4.0 achieved (0.079 -> 77.658 m RMS on fixed epochs) and nagoya_run3 fix availability down 10.1% -> 0.5%. Tracked in #318, labelled as under investigation rather than as achievable performance.

## Testing

Benchmark and docs only; no library code touched, so the CTest suite is unaffected. Verified by running the full benchmark (6 cases × 3 modes) before and after, plus a control: concatenating the sessions by hand outside the script reproduces the same recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

