### PR TITLE
fix(spp): give the pntpos TDCP snapshot its own ssat_t slots (#318)

### DIFF
--- a/docs/reference/benchmark.md
+++ b/docs/reference/benchmark.md
@@ -750,18 +750,54 @@ and 0.717 m on those runs against 0.648 m and 0.486 m today — the same regime.
 RTK on the same data holds 0.112 m and 0.083 m, so this is specific to the CLAS
 path in that area.
 
-!!! warning "RTK is under investigation — do not read these numbers as achievable performance"
+!!! note "The RTK rows above carry the #318 regression — see the corrected table below"
 
-    Kinematic RTK has regressed against the v0.4.1 record on all six cases, and
-    the fixed-tier *tail* rather than its median: tokyo_run2 keeps a 1.3 cm 1σ
-    while its 95th percentile is 240 m, i.e. ~11% of the epochs reporting Q=4
-    are wrong fixes.  This is the same false-fix mode that v0.4.0 eliminated
-    (17.993 m → 0.095 m) and v0.4.1 held at 0.079 m.  Integer-fix availability
-    has also dropped sharply on nagoya_run3 (10.1% → 0.5%) and nagoya_run2
-    (28.3% → 7.4%).  Tracked in
-    [#318](https://github.com/h-shiono/MRTKLIB/issues/318); the three RTK
-    parameters v0.4.0 introduced were verified to survive the TOML migration, so
-    the cause is not that config drift.
+    The RTK numbers in the v0.7.7 tables were produced with rover-side
+    cycle-slip detection silently disabled: since v0.6.10 the SPP TDCP
+    snapshot in `pntpos()` overwrote the `ssat` previous-phase bookkeeping
+    every epoch, so `detslp_ll()` / `detslp_dop()` skipped every rover
+    satellite (`timediff < DTTOL`).  Undetected slips carried integer-cycle
+    phase-bias errors into fix-and-hold — the tokyo_run2 false-fix tail
+    (1.3 cm 1σ / 240 m 95%) is the same mode v0.4.0 eliminated, returned.
+    Root cause and fix in
+    [#318](https://github.com/h-shiono/MRTKLIB/issues/318).  CLAS and
+    MADOCA never read those slots in the affected way and are unaffected
+    (verified metric-identical with the fix).  The corrected RTK results
+    follow.
+
+### RTK re-run after the #318 slip-detection fix
+
+Same environment, data and configuration as the v0.7.7 run above; binary is
+develop plus the #318 fix (`ver.0.7.7 git v0.7.7-13-g2a052cf`).  CLAS and
+MADOCA rows are unchanged by the fix (NMEA differences are the known
+Accelerate last-digit noise only), so only RTK is re-recorded.  All six cases
+return to the v0.4.1 record; nagoya_run2 / nagoya_run3 / tokyo_run1 match it
+to the millimetre, and the tokyo_run2 fixed tier is again clean (misfix
+11.1% → 0.6%, 95% 240.8 m → 0.15 m).  The remaining tokyo_run2 RMS 2D of
+6.27 m comes from ~11 residual misfix epochs that the v0.4.1 *tag rebuilt on
+this machine* also produces (20.4% / 6.27 m) — the 0.079 m in the recorded
+v0.4.1 table is single-run Accelerate luck, not a remaining engine gap.
+
+| Case | Mode | Tier | N | nSV | Rate% | `<30cm` | RMS 2D | 1σ (68%) | 95% | TTFF (s) |
+|------|------|------|--:|----:|------:|--------:|-------:|---------:|----:|---------:|
+| nagoya_run1 | RTK | FIX |  1 992 | 18.6 | 27.4% | 95.7% |  0.404 m | 0.112 m |  0.169 m |  797 |
+|             |     | FF  |  7 210 | 16.8 | 99.0% | 67.2% |  4.231 m | 0.365 m |  2.457 m |    — |
+|             |     | ALL |  7 283 | 16.7 |     — | 66.5% | 12.112 m | 0.389 m |  2.470 m |    — |
+| nagoya_run2 | RTK | FIX |  2 643 | 16.7 | 28.3% | 72.9% |  1.014 m | 0.175 m |  0.928 m |    0 |
+|             |     | FF  |  9 288 | 15.3 | 99.4% | 51.9% |  3.538 m | 0.793 m | 12.510 m |    — |
+|             |     | ALL |  9 342 | 15.2 |     — | 51.6% |  3.534 m | 0.805 m | 12.507 m |    — |
+| nagoya_run3 | RTK | FIX |    520 | 16.5 | 10.1% | 75.6% |  0.716 m | 0.135 m |  1.488 m |   74 |
+|             |     | FF  |  5 095 | 13.2 | 99.1% | 24.9% |  4.174 m | 3.679 m |  8.893 m |    — |
+|             |     | ALL |  5 139 | 13.1 |     — | 24.7% |  4.187 m | 3.694 m |  8.873 m |    — |
+| tokyo_run1  | RTK | FIX |    342 | 15.6 |  2.9% | 97.4% |  0.555 m | 0.026 m |  0.277 m | 1841 |
+|             |     | FF  | 11 280 | 16.0 | 95.8% |  5.7% | 10.802 m | 7.112 m | 20.569 m |    — |
+|             |     | ALL | 11 779 | 15.4 |     — |  5.6% | 15.121 m | 7.227 m | 21.025 m |    — |
+| tokyo_run2  | RTK | FIX |  1 835 | 22.5 | 20.4% | 99.4% |  6.271 m | 0.014 m |  0.153 m |  804 |
+|             |     | FF  |  8 481 | 18.5 | 94.3% | 44.5% | 18.985 m | 3.070 m | 50.452 m |    — |
+|             |     | ALL |  8 990 | 17.6 |     — | 45.0% | 27.204 m | 2.744 m | 50.448 m |    — |
+| tokyo_run3  | RTK | FIX |  4 183 | 25.5 | 27.7% | 99.9% |  0.084 m | 0.013 m |  0.038 m |  658 |
+|             |     | FF  | 14 641 | 21.7 | 97.0% | 54.3% |  7.168 m | 2.619 m | 14.304 m |    — |
+|             |     | ALL | 15 097 | 21.1 |     — | 53.4% |  8.014 m | 2.776 m | 14.367 m |    — |
 
 ---
 

--- a/include/mrtklib/mrtk_sol.h
+++ b/include/mrtklib/mrtk_sol.h
@@ -115,6 +115,10 @@ typedef struct {                /* satellite status type */
     double phw;                 /* phase windup (cycle) */
     gtime_t pt[2][NFREQ];       /* previous carrier-phase time */
     double ph[2][NFREQ];        /* previous carrier-phase observable (cycle) */
+    gtime_t spt[NFREQ];         /* SPP TDCP: previous carrier-phase time (pntpos-private;
+                                 * pt[0] belongs to the engines' slip detectors and must
+                                 * not be written by pntpos — see issue #318) */
+    double sph[NFREQ];          /* SPP TDCP: previous carrier-phase observable (cycle) */
     int discont[NFREQ];         /* SSR phase bias discontinuity counter */
     double ionc;                /* ionospheric delay by carrier phase (m) */
     uint8_t code[NFREQ];        /* observation code indicator (CODE_???) */

--- a/src/pos/mrtk_spp.c
+++ b/src/pos/mrtk_spp.c
@@ -699,7 +699,10 @@ static int raim_fde(const obsd_t* obs, int n, const double* rs, const double* dt
  * disagrees with the Doppler beyond thresdop after removing the common-mode
  * (receiver clock) offset — the single-receiver detector from demo5/detslp_dop,
  * kept SPP-local so PPP/RTK are untouched. ssat holds the previous epoch's
- * phase (pt/ph), populated by pntpos at the end of each epoch. */
+ * phase in the pntpos-private spt/sph slots, populated at the end of each
+ * pntpos call. pt[0]/ph[0] must NOT be used here: they belong to the engines'
+ * own slip detectors (detslp_ll/detslp_dop), and overwriting them from pntpos
+ * silently disabled rover slip detection in relative RTK (issue #318). */
 static void spp_detslp(const obsd_t* obs, int n, const ssat_t* ssat, double thresdop, int* slip) {
     double dph, dpt, tt, mean = 0.0, dif[MAXOBS] = {0};
     int i, sat, ndop = 0, valid[MAXOBS] = {0};
@@ -707,15 +710,15 @@ static void spp_detslp(const obsd_t* obs, int n, const ssat_t* ssat, double thre
     for (i = 0; i < n && i < MAXOBS; i++) {
         slip[i] = (obs[i].LLI[0] & 1) ? 1 : 0; /* loss-of-lock indicator */
         sat = obs[i].sat;
-        if (thresdop <= 0.0 || obs[i].L[0] == 0.0 || obs[i].D[0] == 0.0 || ssat[sat - 1].ph[0][0] == 0.0) {
+        if (thresdop <= 0.0 || obs[i].L[0] == 0.0 || obs[i].D[0] == 0.0 || ssat[sat - 1].sph[0] == 0.0) {
             continue;
         }
-        tt = timediff(obs[i].time, ssat[sat - 1].pt[0][0]);
+        tt = timediff(obs[i].time, ssat[sat - 1].spt[0]);
         if (fabs(tt) < DTTOL || fabs(tt) > 3.0) {
             continue;
         }
-        dph = (obs[i].L[0] - ssat[sat - 1].ph[0][0]) / tt; /* phase rate (cyc/s) */
-        dpt = -obs[i].D[0];                                /* Doppler-predicted rate */
+        dph = (obs[i].L[0] - ssat[sat - 1].sph[0]) / tt; /* phase rate (cyc/s) */
+        dpt = -obs[i].D[0];                              /* Doppler-predicted rate */
         dif[i] = dph - dpt;
         valid[i] = 1; /* explicit validity — dif can legitimately be 0.0 */
         if (fabs(dif[i]) < 3.0 * thresdop) {
@@ -759,11 +762,11 @@ static int resdop(const obsd_t* obs, int n, const double* rs, const double* dts,
         /* measured range rate (cyc/s) and its Std (m/s): TDCP primary, Doppler fallback */
         use = 0;
         meas = sig = 0.0;
-        if (tdcp && ssat && slip && !slip[i] && obs[i].L[0] != 0.0 && ssat[sat - 1].ph[0][0] != 0.0) {
-            tt = timediff(obs[i].time, ssat[sat - 1].pt[0][0]);
+        if (tdcp && ssat && slip && !slip[i] && obs[i].L[0] != 0.0 && ssat[sat - 1].sph[0] != 0.0) {
+            tt = timediff(obs[i].time, ssat[sat - 1].spt[0]);
             if (fabs(tt) >= DTTOL && fabs(tt) <= 3.0) {
-                meas = (obs[i].L[0] - ssat[sat - 1].ph[0][0]) / tt; /* == dph (cyc/s) */
-                sig = ERR_TDCP;                                     /* phase-rate Std (m/s) */
+                meas = (obs[i].L[0] - ssat[sat - 1].sph[0]) / tt; /* == dph (cyc/s) */
+                sig = ERR_TDCP;                                   /* phase-rate Std (m/s) */
                 use = 1;
             }
         }
@@ -957,10 +960,14 @@ int pntpos(mrtk_ctx_t* ctx, const obsd_t* obs, int n, const nav_t* nav, const pr
             ssat[obs[i].sat - 1].azel[1] = azel_[1 + i * 2];
             ssat[obs[i].sat - 1].snr[0] = obs[i].SNR[0];
             /* #116 P4: store carrier phase for next-epoch TDCP / slip detection
-             * (unconditional — keep continuity even for this epoch's unused sats) */
+             * (unconditional — keep continuity even for this epoch's unused sats).
+             * Private spt/sph slots: writing pt[0]/ph[0] here clobbered the
+             * engines' previous-phase bookkeeping every epoch, disabling rover
+             * detslp_ll/detslp_dop in relative RTK and detslp_dop in PPP
+             * (issue #318). */
             for (f = 0; f < NFREQ; f++) {
-                ssat[obs[i].sat - 1].ph[0][f] = obs[i].L[f];
-                ssat[obs[i].sat - 1].pt[0][f] = obs[i].time;
+                ssat[obs[i].sat - 1].sph[f] = obs[i].L[f];
+                ssat[obs[i].sat - 1].spt[f] = obs[i].time;
             }
             if (!vsat[i]) {
                 continue;


### PR DESCRIPTION
## Summary

Fixes the kinematic-RTK benchmark regression reported in #318.

**Root cause (bisected to v0.6.10):** the #116 P4 TDCP work made `pntpos()` unconditionally overwrite `ssat[].ph[0][f]` / `pt[0][f]` with the *current* epoch's carrier phase and time. `rtkpos()` passes `rtk->ssat` to `pntpos()` for the rover SPP seed, so when `relpos()` later ran its cycle-slip detectors the "previous" phase time was already the current epoch: `detslp_ll()` and `detslp_dop()` hit the `timediff < DTTOL` guard and skipped **every rover satellite**. Rover-side LLI and Doppler slip detection have been silently disabled in relative RTK since v0.6.10 (only `detslp_gf` survived; the base side was unaffected). Undetected slips carry integer-cycle phase-bias errors into fix-and-hold — the returned tokyo_run2 false-fix tail (1.3 cm 1σ / 240 m 95%) and the nagoya_run3 fix-availability collapse. `pppos()`'s `detslp_dop()` reads the same slots and was equally dead for PPP configs with `[slip_detection] doppler > 0` (the benchmark MADOCA config does not set it, which is why MADOCA stayed bit-identical).

**Fix:** move the SPP TDCP previous-phase snapshot to pntpos-private `spt[]` / `sph[]` fields in `ssat_t`. The TDCP seed (including the CLAS `enhanced_spp_seed` profile) reads the same values from its own slots, so SPP/seed behaviour is unchanged; the engines' `ph`/`pt` bookkeeping is no longer touched by `pntpos()`. `ssat_t` is not binary-serialized anywhere, so the added fields are layout-safe.

Also replaces the v0.7.7 RTK warning in `docs/reference/benchmark.md` with the root-cause note and the corrected RTK table.

## Bisect

tokyo_run2 RTK, per-tag build + run: v0.4.1 = v0.6.0 = v0.6.7 = v0.6.8 = **v0.6.9** all metric-identical (Fix 20.4%, RMS_2D(fix) 6.27 m, misfix 0.6%); **v0.6.10** = v0.6.12 = v0.6.14 = v0.7.3 = develop all at the regressed values (18.3%, 77.66 m, 11.1%). Single step change, unchanged since.

## Validation (PPC-Dataset, 6 cases × 3 modes)

RTK — all six cases restored to the v0.4.1 record:

| case | Fix% (v0.4.1 → regressed → fixed) | RMS_2D(fix) (v0.4.1 → regressed → fixed) |
|---|---|---|
| nagoya_run1 | 27.4 → 28.9 → **27.4** | 0.425 → 1.002 → **0.404** |
| nagoya_run2 | 28.3 → 7.4 → **28.3** | 1.014 → 1.849 → **1.014** |
| nagoya_run3 | 10.1 → 0.5 → **10.1** | 0.716 → 2.049 → **0.716** |
| tokyo_run1 | 2.9 → 3.4 → **2.9** | 0.555 → 2.068 → **0.555** |
| tokyo_run2 | 22.1 → 18.3 → **20.4** | 0.079 → 77.658 → **6.271** † |
| tokyo_run3 | 27.7 → 17.3 → **27.7** | 0.095 → 1.867 → **0.084** |

† the v0.4.1 *tag rebuilt on this machine* also gives 20.4% / 6.27 m — the recorded 0.079 m was single-run Accelerate luck (~11 flip epochs), not a remaining engine gap. Post-fix tokyo_run2 fixed tier: 1σ 0.014 m, 95% 0.153 m, `<30cm` 99.4%.

CLAS (all 6) and MADOCA (all 6): metric-identical to develop; NMEA diffs are the known Accelerate last-digit noise (≈0.2 mm) only. Structurally, PPP-RTK uses `ppp_rtk_pos()`'s own detectors and VRS `detslp_ll` is LLI-only — neither reads `ph[0]`/`pt[0]`.

## Tests

`ctest` 120 tests: failures limited to the two documented environment failures (`rtkrcv_rt` headless RT replay, `madocalib_pppar_ion_check` LAPACK tolerance). All claslib parity / absolute-accuracy / merge-sensitive tests pass; the RT CLAS trio (`rtkrcv_rt_clas`, `_2ch`, `_2ch_merge` + nsat check) passes 6/6 in isolation. No test tolerances changed.

Closes #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)