### PR TITLE
perf(rtcm): lazily heap-allocate lclblock_t in rtcm_t (#295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- perf(rtcm): lazy heap allocation of `lclblock_t` — `rtcm_t` shrinks
+  ~314 MB → ~7.5 MB (`rtksvr_t` ~972 MB → ~51 MB), reducing `mrtk run` RSS
+  ([#295](https://github.com/h-shiono/MRTKLIB/issues/295)).
+
 ## [v0.7.8] - 2026-08-04
 
 **Kinematic RTK: rover cycle-slip detection restored (regression since

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Focus areas, in priority order:
 Hard rules. No exceptions, no matter how reasonable an action seems in context.
 
 - **NEVER alter GNSS algorithms, matrix operations, or physical constants** during structural / refactoring work unless explicitly instructed.
-- **NEVER create `rtcm_t` on the stack or in static arrays** — it is ~103 MB. Always heap-allocate with `calloc`. See §7.1 for the size table of other large structs.
+- **NEVER create `rtcm_t` on the stack or in static arrays** — it is ~7.5 MB (its ~307 MB `lclblock_t` is now lazily heap-allocated). Always heap-allocate with `calloc`. See §7.1 for the size table of other large structs.
 - **NEVER mark a task complete without running `ctest --output-on-failure`** and confirming all tests pass.
 - **NEVER assume upstream library behavior** — read the actual source when integrating.
 - **NEVER silently swallow a test tolerance change** — flag it to the user with the numerical delta.
@@ -190,11 +190,14 @@ Run `./build/mrtk --help` for the current full list and per-subcommand help via 
 
 | Type | Approximate size |
 |------|-----------------|
-| `rtksvr_t` | ~972 MB |
-| `rtcm_t` | ~103 MB |
+| `rtksvr_t` | ~51 MB |
+| `rtcm_t` | ~7.5 MB |
+| `lclblock_t` | ~307 MB (lazily heap-allocated inside `rtcm_t` only when RTCM3 local-correction messages 2001–2016 are processed) |
 | `has_t` | ~1.6 MB |
 | `osb_t` | ~700 KB |
 | `clas_corr_t` | ~352 KB |
+
+Sizes measured with the default preset (NFREQ=5, NEXOBS=5, all constellations, MAXSAT=221).
 
 Never stack-allocate or place these in static arrays. Use `calloc()` and pass by pointer. For multiple instances, use an array of pointers (not an array of structs).
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,18 @@ add_test(NAME utest_has_mt1 COMMAND utest_has_mt1
          WORKING_DIRECTORY ${_UTEST_DIR})
 set_tests_properties(utest_has_mt1 PROPERTIES LABELS "utest")
 
+# RTCM local-correction lazy-allocation test (issue #295). Drives the public
+# rtcm_lclblk()/encode/decode path for RTCM3 types 2001-2016 (no regression
+# test feeds these messages); same explicit registration as utest_has_rs
+# (source name is utest_lclblk.c, not t_*.c).
+add_executable(utest_lclblk ${_UTEST_DIR}/utest_lclblk.c)
+# Override global -ansi (=C90): this test uses C11 (P-01).
+target_compile_options(utest_lclblk PRIVATE -std=c11)
+target_link_libraries(utest_lclblk PRIVATE mrtklib)
+add_test(NAME utest_lclblk COMMAND utest_lclblk
+         WORKING_DIRECTORY ${_UTEST_DIR})
+set_tests_properties(utest_lclblk PROPERTIES LABELS "utest")
+
 # NTRIP v2 chunked codec test (header-only, no library dependency)
 add_executable(t_ntrip ${_UTEST_DIR}/t_ntrip.c)
 # Override global -ansi (=C90) for this target, same as mrtklib target.

--- a/apps/cssr2rtcm3/cssr2rtcm3.c
+++ b/apps/cssr2rtcm3/cssr2rtcm3.c
@@ -1373,7 +1373,7 @@ int mrtk_cssr2rtcm3(int argc, char** argv) {
     /* ── Allocate large structures ── */
     clas = (clas_ctx_t*)calloc(1, sizeof(clas_ctx_t));
     nav = (nav_t*)calloc(1, sizeof(nav_t));
-    rtcm = (rtcm_t*)calloc(1, sizeof(rtcm_t)); /* ~103MB */
+    rtcm = (rtcm_t*)calloc(1, sizeof(rtcm_t)); /* ~7.5MB; large structs stay heap-allocated */
     obsdata = (obsd_t*)calloc(MAXOBS, sizeof(obsd_t));
     osr = (clas_osrd_t*)calloc(MAXOBS, sizeof(clas_osrd_t));
     if (!clas || !nav || !rtcm || !obsdata || !osr) {

--- a/apps/recvbias/recvbias.c
+++ b/apps/recvbias/recvbias.c
@@ -52,7 +52,7 @@ static int nsysrb, nsysrbmax;
 static rawbias_t* satrb;
 static rawbias_t* sysrb;
 static gtime_t st = {0}, et = {0};
-static rtcm_t* rtcm;      /* rtcm control struct (heap, ~103MB) */
+static rtcm_t* rtcm;      /* rtcm control struct (heap per policy, ~7.5MB) */
 static int selsiggps = 0; /* 0:L1C/A-L2P,1:L1C/A-L2C,2:L1C/A-L5 */
 static int selsigqzs = 0; /* 0:L1C-L5,1:L1C/A-L2C */
 static int selsigcmp = 0; /* 0:B1-B3,1:B1C-B2a */
@@ -862,7 +862,7 @@ int mrtk_bias(int argc, char** argv) {
     char staname[32] = "";
     mrtk_ctx_t* ctx;
 
-    /* Allocate rtcm_t on heap (~103MB) to avoid bloating BSS */
+    /* Allocate rtcm_t on heap (~7.5MB) to avoid bloating BSS */
     rtcm = (rtcm_t*)calloc(1, sizeof(rtcm_t));
     if (!rtcm) {
         fprintf(stderr, "error: rtcm_t allocation failed\n");

--- a/apps/rtkrcv/rtkrcv.c
+++ b/apps/rtkrcv/rtkrcv.c
@@ -2143,7 +2143,7 @@ int mrtk_run(int argc, char** argv) {
         }
     }
 
-    /* heap-allocate rtksvr_t (~972 MB) to avoid BSS bloat */
+    /* heap-allocate rtksvr_t (~51 MB) to avoid BSS bloat */
     svr = (rtksvr_t*)calloc(1, sizeof(rtksvr_t));
     if (!svr) {
         fprintf(stderr, "error: rtksvr_t allocation failed\n");

--- a/docs/dev/pitfalls-public.md
+++ b/docs/dev/pitfalls-public.md
@@ -82,8 +82,9 @@ Several core types are too large for the stack or for static arrays:
 
 | Type | Approximate size |
 |------|-----------------|
-| `rtksvr_t` | ~972 MB |
-| `rtcm_t` | ~103 MB |
+| `rtksvr_t` | ~51 MB |
+| `rtcm_t` | ~7.5 MB |
+| `lclblock_t` | ~307 MB (lazily heap-allocated inside `rtcm_t`; see P-13) |
 | `osb_t` | ~700 KB |
 | `clas_corr_t` | ~352 KB |
 
@@ -123,6 +124,29 @@ When iterating satellites for `satpos()` / `ephpos()` calls, gate the loop
 against the constellation allow-list you actually use. For example,
 CLAS-based code paths process only GPS / GAL / QZS; passing a stale or
 corrupted GLONASS satellite through `ephpos()` is unnecessary and risky.
+
+### P-13 — `rtcm_t.lclblk` is a lazily-allocated pointer; upstream embeds it by value
+
+MRTKLIB stores the RTCM3 local-correction block as a pointer member
+(`lclblock_t* lclblk`) inside `rtcm_t`, allocated on first use: the block is
+~307 MB while the rest of `rtcm_t` is ~7.5 MB, and most workloads never
+process the local-correction messages (2001–2016) that populate it. Upstream
+MALIB (`rtklib.h`) still embeds `lclblock_t lclblk;` by value, so upstream
+code in `rtcm3lcl.c`, `lclcmn.c`, and `lclcmbcmn.c` accesses members as
+`rtcm->lclblk.`.
+
+When cherry-picking hunks from those files during an upstream sync, adapt
+them mechanically:
+
+- `rtcm->lclblk.` → `rtcm->lclblk->`
+- On write/decode paths, call `rtcm_lclblk(rtcm)` first — it allocates the
+  block on first use and returns NULL on allocation failure.
+- On read paths, guard with a NULL check: an unallocated block simply means
+  no local-correction message has been decoded yet.
+
+An unadapted hunk fails to compile (member access on a pointer), but a hunk
+rewritten only `.` → `->` compiles cleanly and dereferences NULL at runtime
+on read paths.
 
 ---
 

--- a/include/mrtklib/mrtk_rtcm.h
+++ b/include/mrtklib/mrtk_rtcm.h
@@ -77,7 +77,7 @@ typedef struct {                            /* RTCM control struct type */
     uint32_t nmsg2[100];                    /* message count of RTCM 2 (1-99:1-99,0:other) */
     uint32_t nmsg3[400];                    /* message count of RTCM 3 (1-299:1001-1299,300-329:4070-4099,0:ohter) */
     char opt[256];                          /* RTCM dependent options */
-    lclblock_t lclblk;                      /* output of iono/trop corrections */
+    lclblock_t* lclblk;                     /* iono/trop corrections; lazily allocated (RTCM3 msgs 2001-2016) */
 } rtcm_t;
 
 /*============================================================================
@@ -96,6 +96,13 @@ int init_rtcm(rtcm_t* rtcm);
  * @param[in,out] rtcm  RTCM control struct
  */
 void free_rtcm(rtcm_t* rtcm);
+
+/**
+ * @brief Get the local correction block, lazily allocating it on first use.
+ * @param[in,out] rtcm  RTCM control struct
+ * @return Local correction block (NULL: memory allocation error).
+ */
+lclblock_t* rtcm_lclblk(rtcm_t* rtcm);
 
 /**
  * @brief Input RTCM 2 message from stream (byte-by-byte).

--- a/src/madoca/mrtk_madoca_local_comb.c
+++ b/src/madoca/mrtk_madoca_local_comb.c
@@ -579,6 +579,9 @@ extern void sta_sel_iono(const gtime_t gt, const stat_t* stat, lclblock_t* lslbl
 extern void output_lclcmb(rtcm_t* rtcm, int btype, struct stream_tag* ostr) {
     int i, j, basemt;
 
+    if (!rtcm->lclblk) {
+        return;
+    }
     if (btype == BTYPE_GRID) {
         basemt = 2001;
     } else if (btype == BTYPE_STA) {
@@ -587,14 +590,14 @@ extern void output_lclcmb(rtcm_t* rtcm, int btype, struct stream_tag* ostr) {
         return;
     }
 
-    for (i = 0; i < rtcm->lclblk.tnum; i++) {
-        rtcm->lclblk.outtn = i;
+    for (i = 0; i < rtcm->lclblk->tnum; i++) {
+        rtcm->lclblk->outtn = i;
         gen_rtcm3(rtcm, basemt, 0, 0);
         strwrite(ostr, rtcm->buff, rtcm->nbyte);
     }
 
-    for (i = 0; i < rtcm->lclblk.inum; i++) {
-        rtcm->lclblk.outin = i;
+    for (i = 0; i < rtcm->lclblk->inum; i++) {
+        rtcm->lclblk->outin = i;
         for (j = basemt + 1; j <= basemt + 5; j++) {
             gen_rtcm3(rtcm, j, 0, 0);
             strwrite(ostr, rtcm->buff, rtcm->nbyte);

--- a/src/madoca/mrtk_madoca_local_corr.c
+++ b/src/madoca/mrtk_madoca_local_corr.c
@@ -414,20 +414,23 @@ extern int block2stat(rtcm_t* rtcm, stat_t* stat) {
     int i, j, k, gp;
     double d;
 
-    if (rtcm->lclblk.tnum == 0 && rtcm->lclblk.inum == 0) {
+    if (!rtcm->lclblk) {
+        return 0;
+    }
+    if (rtcm->lclblk->tnum == 0 && rtcm->lclblk->inum == 0) {
         return 0;
     }
 
     /* convert trop corrections */
-    for (i = 0; i < rtcm->lclblk.tnum; i++) {
-        for (j = 0; j < rtcm->lclblk.tblkinf[i].n; j++) {
-            if (rtcm->lclblk.tblkinf[i].btype == BTYPE_GRID) {
-                gp = rtcm->lclblk.tblkinf[i].gp[j];
+    for (i = 0; i < rtcm->lclblk->tnum; i++) {
+        for (j = 0; j < rtcm->lclblk->tblkinf[i].n; j++) {
+            if (rtcm->lclblk->tblkinf[i].btype == BTYPE_GRID) {
+                gp = rtcm->lclblk->tblkinf[i].gp[j];
             } else {
                 gp = j;
             }
             for (k = 0; k < stat->nst; k++) {
-                d = posdist(rtcm->lclblk.tstat[i][gp].site.ecef, stat->strp[k].site.ecef);
+                d = posdist(rtcm->lclblk->tstat[i][gp].site.ecef, stat->strp[k].site.ecef);
                 if (d < 0.1) {
                     break;
                 }
@@ -436,20 +439,20 @@ extern int block2stat(rtcm_t* rtcm, stat_t* stat) {
                 stat->nst++;
             }
             memcpy(&stat->time[k], &rtcm->time, sizeof(gtime_t));
-            memcpy(&stat->strp[k], &rtcm->lclblk.tstat[i][gp], sizeof(sitetrp_t));
+            memcpy(&stat->strp[k], &rtcm->lclblk->tstat[i][gp], sizeof(sitetrp_t));
         }
     }
     /* update iono corrections */
-    for (i = 0; i < rtcm->lclblk.inum; i++) {
-        for (j = 0; j < rtcm->lclblk.iblkinf[i].n; j++) {
-            gp = rtcm->lclblk.iblkinf[i].gp[j];
-            if (rtcm->lclblk.iblkinf[i].btype == BTYPE_GRID) {
-                gp = rtcm->lclblk.iblkinf[i].gp[j];
+    for (i = 0; i < rtcm->lclblk->inum; i++) {
+        for (j = 0; j < rtcm->lclblk->iblkinf[i].n; j++) {
+            gp = rtcm->lclblk->iblkinf[i].gp[j];
+            if (rtcm->lclblk->iblkinf[i].btype == BTYPE_GRID) {
+                gp = rtcm->lclblk->iblkinf[i].gp[j];
             } else {
                 gp = j;
             }
             for (k = 0; k < stat->nsi; k++) {
-                d = posdist(rtcm->lclblk.istat[i][gp].site.ecef, stat->sion[k].site.ecef);
+                d = posdist(rtcm->lclblk->istat[i][gp].site.ecef, stat->sion[k].site.ecef);
                 if (d < 0.1) {
                     break;
                 }
@@ -458,7 +461,7 @@ extern int block2stat(rtcm_t* rtcm, stat_t* stat) {
                 stat->nsi++;
             }
             memcpy(&stat->time[k], &rtcm->time, sizeof(gtime_t));
-            memcpy(&stat->sion[k], &rtcm->lclblk.istat[i][gp], sizeof(siteion_t));
+            memcpy(&stat->sion[k], &rtcm->lclblk->istat[i][gp], sizeof(siteion_t));
         }
     }
     return 1;

--- a/src/rtcm/mrtk_rtcm.c
+++ b/src/rtcm/mrtk_rtcm.c
@@ -84,6 +84,11 @@ int init_rtcm(rtcm_t* rtcm) {
     rtcm->nav.geph = NULL;
     rtcm->nav.pppiono = NULL;
 
+    /* lclblk is deliberately left untouched: the struct must be zero-initialized
+     * before the first init_rtcm() call (all callers use calloc/memset), and an
+     * existing allocation is preserved across re-init to match the legacy
+     * embedded-array semantics (init_rtcm never cleared lclblk) */
+
     /* reallocate memory for observation and ephemeris buffer */
     if (!(rtcm->obs.data = (obsd_t*)malloc(sizeof(obsd_t) * MAXOBS)) ||
         !(rtcm->nav.eph = (eph_t*)malloc(sizeof(eph_t) * MAXSAT * 2)) ||
@@ -123,6 +128,19 @@ void free_rtcm(rtcm_t* rtcm) {
     free(rtcm->nav.geph);
     rtcm->nav.geph = NULL;
     rtcm->nav.ng = 0;
+    free(rtcm->lclblk);
+    rtcm->lclblk = NULL;
+}
+/* get local correction block --------------------------------------------------
+ * return the local correction block, lazily allocating it on first use
+ * args   : rtcm_t *rtcm     IO  rtcm control struct
+ * return : local correction block (NULL: memory allocation error)
+ *-----------------------------------------------------------------------------*/
+lclblock_t* rtcm_lclblk(rtcm_t* rtcm) {
+    if (!rtcm->lclblk) {
+        rtcm->lclblk = (lclblock_t*)calloc(1, sizeof(lclblock_t));
+    }
+    return rtcm->lclblk;
 }
 /* input RTCM 2 message from stream --------------------------------------------
  * fetch next RTCM 2 message and input a message from byte stream

--- a/src/rtcm/mrtk_rtcm3_local_corr.c
+++ b/src/rtcm/mrtk_rtcm3_local_corr.c
@@ -190,20 +190,24 @@ int decode_lcltrop(rtcm_t* rtcm, int type) {
     blkinf_t *blkinf, tmpblkinf = {0};
     sitetrp_t* strp;
 
+    if (!rtcm_lclblk(rtcm)) {
+        trace(NULL, 1, "decode_lcltrop: lclblk malloc error\n");
+        return -1;
+    }
     p = decode_lclhead(rtcm, type, &tmpblkinf);
     trace(NULL, 3, "decode_lcltrop : %s,bn=%4d,btype=%d,gp=%d,gnum=%d\n", time_str(rtcm->time, 0), tmpblkinf.bn,
           tmpblkinf.btype, tmpblkinf.gpitch, tmpblkinf.n);
-    for (i = 0; i < rtcm->lclblk.tnum; i++) {
-        if (rtcm->lclblk.tblkinf[i].bn == tmpblkinf.bn) {
+    for (i = 0; i < rtcm->lclblk->tnum; i++) {
+        if (rtcm->lclblk->tblkinf[i].bn == tmpblkinf.bn) {
             break;
         }
     }
     ctnum = i;
-    if (i == rtcm->lclblk.tnum) {
-        rtcm->lclblk.tnum++;
+    if (i == rtcm->lclblk->tnum) {
+        rtcm->lclblk->tnum++;
     }
-    memcpy(&rtcm->lclblk.tblkinf[i], &tmpblkinf, sizeof(blkinf_t));
-    blkinf = &rtcm->lclblk.tblkinf[i];
+    memcpy(&rtcm->lclblk->tblkinf[i], &tmpblkinf, sizeof(blkinf_t));
+    blkinf = &rtcm->lclblk->tblkinf[i];
 
     base = getbitu(rtcm->buff, p, 6) * TRP_BAS_LSB;
     p += 6;
@@ -223,7 +227,7 @@ int decode_lcltrop(rtcm_t* rtcm, int type) {
             tp = i;
         }
 
-        strp = &rtcm->lclblk.tstat[ctnum][tp];
+        strp = &rtcm->lclblk->tstat[ctnum][tp];
         trp = getbitu(rtcm->buff, p, 9) * TRP_DET_LSB;
         p += 9;
         ind = getbitu(rtcm->buff, p, 3);
@@ -261,6 +265,10 @@ int decode_lcliono(rtcm_t* rtcm, int type) {
     blkinf_t *blkinf, tmpblkinf = {0};
     ion_t* ionp;
 
+    if (!rtcm_lclblk(rtcm)) {
+        trace(NULL, 1, "decode_lcliono: lclblk malloc error\n");
+        return -1;
+    }
     switch (type) {
         case 2002:
             msys = SYS_GPS;
@@ -319,17 +327,17 @@ int decode_lcliono(rtcm_t* rtcm, int type) {
     p = decode_lclhead(rtcm, type, &tmpblkinf);
     trace(NULL, 3, "decode_lcliono : %s,bn=%4d,btype=%d,gp=%d\n", time_str(rtcm->time, 0), tmpblkinf.bn,
           tmpblkinf.btype, tmpblkinf.gpitch);
-    for (i = 0; i < rtcm->lclblk.inum; i++) {
-        if (rtcm->lclblk.iblkinf[i].bn == tmpblkinf.bn) {
+    for (i = 0; i < rtcm->lclblk->inum; i++) {
+        if (rtcm->lclblk->iblkinf[i].bn == tmpblkinf.bn) {
             break;
         }
     }
-    if (i >= rtcm->lclblk.inum) {
-        rtcm->lclblk.inum++;
+    if (i >= rtcm->lclblk->inum) {
+        rtcm->lclblk->inum++;
     }
     cinum = i;
-    memcpy(&rtcm->lclblk.iblkinf[cinum], &tmpblkinf, sizeof(blkinf_t));
-    blkinf = &rtcm->lclblk.iblkinf[cinum];
+    memcpy(&rtcm->lclblk->iblkinf[cinum], &tmpblkinf, sizeof(blkinf_t));
+    blkinf = &rtcm->lclblk->iblkinf[cinum];
 
     if (nsat > 32) {
         smask[0] = getbitu(rtcm->buff, p, 32);
@@ -373,12 +381,12 @@ int decode_lcliono(rtcm_t* rtcm, int type) {
             tp = i;
         }
         for (j = ssat - 1; j < ssat + nsat - 1; j++) {
-            ionp = &rtcm->lclblk.istat[cinum][tp].iond[j];
+            ionp = &rtcm->lclblk->istat[cinum][tp].iond[j];
             ionp->ion = 0.0;
             ionp->std = 0.0;
         }
         pos2ecef(blkinf->grid[i], ecef);
-        memcpy(rtcm->lclblk.istat[cinum][tp].site.ecef, ecef, sizeof(rtcm->lclblk.istat[cinum][tp].site.ecef));
+        memcpy(rtcm->lclblk->istat[cinum][tp].site.ecef, ecef, sizeof(rtcm->lclblk->istat[cinum][tp].site.ecef));
     }
 
     for (i = 0; i < ns; i++) {
@@ -394,7 +402,7 @@ int decode_lcliono(rtcm_t* rtcm, int type) {
             } else if (2012 <= type && type <= 2016) {
                 tp = j;
             }
-            ionp = &rtcm->lclblk.istat[cinum][tp].iond[sat - 1];
+            ionp = &rtcm->lclblk->istat[cinum][tp].iond[sat - 1];
             ion = getbitu(rtcm->buff, p, 9) * ION_DET_LSB;
             p += 9;
             ind = getbitu(rtcm->buff, p, 3);
@@ -476,7 +484,10 @@ int encode_lcltrop(rtcm_t* rtcm, int type) {
     trp_t* trpp;
     blkinf_t* blkinf;
 
-    blkinf = &rtcm->lclblk.tblkinf[rtcm->lclblk.outtn];
+    if (!rtcm->lclblk) {
+        return 0;
+    }
+    blkinf = &rtcm->lclblk->tblkinf[rtcm->lclblk->outtn];
     /* base value */
     for (i = 0, base = -1; i < blkinf->n; i++) {
         if (type == 2001) {
@@ -484,7 +495,7 @@ int encode_lcltrop(rtcm_t* rtcm, int type) {
         } else if (type == 2011) {
             tp = i;
         }
-        trpp = &rtcm->lclblk.tstat[rtcm->lclblk.outtn][tp].trpd;
+        trpp = &rtcm->lclblk->tstat[rtcm->lclblk->outtn][tp].trpd;
         if (timediff(rtcm->time, trpp->time) > 0 || trpp->time.time == 0) {
             continue;
         }
@@ -513,7 +524,7 @@ int encode_lcltrop(rtcm_t* rtcm, int type) {
         } else if (type == 2011) {
             tp = i;
         }
-        trpp = &rtcm->lclblk.tstat[rtcm->lclblk.outtn][tp].trpd;
+        trpp = &rtcm->lclblk->tstat[rtcm->lclblk->outtn][tp].trpd;
         if (trpp->std[0] == 0) {
             continue;
         }
@@ -570,6 +581,9 @@ int encode_lcliono(rtcm_t* rtcm, int type) {
     ion_t* ionp;
     blkinf_t* blkinf;
 
+    if (!rtcm->lclblk) {
+        return 0;
+    }
     switch (type) {
         case 2002:
             msys = SYS_GPS;
@@ -626,7 +640,7 @@ int encode_lcliono(rtcm_t* rtcm, int type) {
     }
 
     ssat = satno(msys, minprn);
-    blkinf = &rtcm->lclblk.iblkinf[rtcm->lclblk.outin];
+    blkinf = &rtcm->lclblk->iblkinf[rtcm->lclblk->outin];
     /* search base value */
     for (i = 0; i < nsat; i++) {
         base[i] = -1;
@@ -638,7 +652,7 @@ int encode_lcliono(rtcm_t* rtcm, int type) {
             tp = i;
         }
         for (j = ssat - 1; j < ssat + nsat - 1; j++) {
-            ionp = &rtcm->lclblk.istat[rtcm->lclblk.outin][tp].iond[j];
+            ionp = &rtcm->lclblk->istat[rtcm->lclblk->outin][tp].iond[j];
             sys = satsys(j + 1, &prn);
             prn -= minprn;
             if (ionp->ion <= 0.0) {

--- a/src/stream/mrtk_streamsvr.c
+++ b/src/stream/mrtk_streamsvr.c
@@ -75,7 +75,8 @@ extern strconv_t* strconvnew(int itype, int otype, const char* msgs, int staid, 
     char buff[1024], *p;
     int msg;
 
-    if (!(conv = (strconv_t*)malloc(sizeof(strconv_t)))) return NULL;
+    /* zero-init is required by the rtcm_t.lclblk ownership contract */
+    if (!(conv = (strconv_t*)calloc(1, sizeof(strconv_t)))) return NULL;
 
     conv->nmsg = 0;
     if (!msgs || strlen(msgs) >= sizeof(buff)) {

--- a/tests/utest/utest_lclblk.c
+++ b/tests/utest/utest_lclblk.c
@@ -48,17 +48,22 @@ static int fails = 0;
 
 /* (1) fresh-struct invariants ---------------------------------------------- */
 static void test_fresh_struct(void) {
-    rtcm_t* r = (rtcm_t*)calloc(1, sizeof(rtcm_t));    /* never stack-allocate rtcm_t (~103 MB) */
+    rtcm_t* r = (rtcm_t*)calloc(1, sizeof(rtcm_t));    /* never stack-allocate rtcm_t (~7.5 MB) */
     stat_t* stat = (stat_t*)calloc(1, sizeof(stat_t)); /* stat_t ~4.8 MB: heap too */
     lclblock_t* blk;
+    int ok;
 
     printf("--- test_fresh_struct\n");
     if (!r || !stat) {
         printf("FAIL: calloc rtcm_t/stat_t\n");
         fails++;
-        return;
+        goto cleanup;
     }
-    CHECK(init_rtcm(r) == 1, "init_rtcm succeeds");
+    ok = init_rtcm(r);
+    CHECK(ok == 1, "init_rtcm succeeds");
+    if (ok != 1) {
+        goto cleanup;
+    }
     CHECK(r->lclblk == NULL, "init_rtcm leaves lclblk NULL");
     CHECK(block2stat(r, stat) == 0, "block2stat with NULL lclblk returns 0");
     CHECK(encode_lcltrop(r, 2001) == 0, "encode_lcltrop with NULL lclblk returns 0");
@@ -74,6 +79,7 @@ static void test_fresh_struct(void) {
     free_rtcm(r); /* double-free safety: all pointers were NULLed above */
     CHECK(r->lclblk == NULL, "second free_rtcm is safe");
 
+cleanup:
     free(stat);
     free(r);
 }
@@ -93,15 +99,19 @@ static void test_trop_roundtrip(void) {
     sitetrp_t* st;
     trp_t* dtrp;
     double zhd, trp_in;
-    int i, ret = 0, mid_ok = 1;
+    int i, ret = 0, mid_ok = 1, ok;
 
     printf("--- test_trop_roundtrip\n");
     if (!enc || !dec || !stat) {
         printf("FAIL: calloc rtcm_t/stat_t\n");
         fails++;
-        return;
+        goto cleanup;
     }
-    CHECK(init_rtcm(enc) == 1 && init_rtcm(dec) == 1, "init_rtcm enc+dec");
+    ok = init_rtcm(enc) == 1 && init_rtcm(dec) == 1;
+    CHECK(ok, "init_rtcm enc+dec");
+    if (!ok) {
+        goto cleanup;
+    }
     enc->time = t0;
 
     /* build a minimal valid trop block: grid type, bn=1204 (38N/136E),
@@ -163,8 +173,12 @@ static void test_trop_roundtrip(void) {
     CHECK(fabs(stat->strp[0].trpd.trp[0] - trp_in) < 2.0 * TRP_DET_LSB, "block2stat trop value matches");
 
 cleanup:
-    free_rtcm(enc);
-    free_rtcm(dec);
+    if (enc) {
+        free_rtcm(enc);
+    }
+    if (dec) {
+        free_rtcm(dec);
+    }
     free(stat);
     free(enc);
     free(dec);

--- a/tests/utest/utest_lclblk.c
+++ b/tests/utest/utest_lclblk.c
@@ -1,0 +1,183 @@
+/*------------------------------------------------------------------------------
+ * unit test : RTCM local correction block lazy allocation (issue #295)
+ *
+ * rtcm_t.lclblk is a lazily-allocated lclblock_t* (previously an embedded
+ * array). No regression test feeds RTCM3 types 2001-2016, so this test is the
+ * direct coverage of the active path. Coverage:
+ *
+ *   (1) fresh-struct invariants: init_rtcm() leaves lclblk NULL; the
+ *       NULL-guarded consumers (block2stat, encode_lcltrop, encode_lcliono)
+ *       return 0 without crashing; rtcm_lclblk() allocates on first use and
+ *       is idempotent; free_rtcm() frees + NULLs lclblk and a second
+ *       free_rtcm() call is safe.
+ *   (2) encode->decode round-trip of a local tropospheric correction grid
+ *       message (RTCM3 type 2001) through gen_rtcm3()/input_rtcm3(): the
+ *       decoder side allocates lclblk lazily on the first message, and block
+ *       number / trop value / std round-trip within the encoding
+ *       quantization. block2stat() is then exercised on the decoded block
+ *       (non-NULL path).
+ *
+ * Note: the single-grid-point setup (mask[0]=0x1 so n=1 and gp[0]==0) is
+ * load-bearing: encode_lcltrop() reads blkinf->grid[gp[i]] (mask-bit index)
+ * while initblkinf()/decode_lcltrop() fill/read grid[] compactly (0..n-1);
+ * the two indexings only coincide when gp[i]==i.
+ *
+ * Explicit CHECK macro (not assert) so it is robust under -DNDEBUG.
+ *-----------------------------------------------------------------------------*/
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "mrtklib/rtklib.h"
+
+static int fails = 0;
+
+#define CHECK(cond, msg)                 \
+    do {                                 \
+        if (!(cond)) {                   \
+            printf("FAIL: %s\n", (msg)); \
+            fails++;                     \
+        } else {                         \
+            printf("ok  : %s\n", (msg)); \
+        }                                \
+    } while (0)
+
+/* encoding constants (mirror src/rtcm/mrtk_rtcm3_local_corr.c) */
+#define TRP_BLKSIZE 4.0   /* troposphere block size (deg) */
+#define TRP_DET_LSB 0.002 /* tropospheric delay detail value resolution (m) */
+
+/* (1) fresh-struct invariants ---------------------------------------------- */
+static void test_fresh_struct(void) {
+    rtcm_t* r = (rtcm_t*)calloc(1, sizeof(rtcm_t));    /* never stack-allocate rtcm_t (~103 MB) */
+    stat_t* stat = (stat_t*)calloc(1, sizeof(stat_t)); /* stat_t ~4.8 MB: heap too */
+    lclblock_t* blk;
+
+    printf("--- test_fresh_struct\n");
+    if (!r || !stat) {
+        printf("FAIL: calloc rtcm_t/stat_t\n");
+        fails++;
+        return;
+    }
+    CHECK(init_rtcm(r) == 1, "init_rtcm succeeds");
+    CHECK(r->lclblk == NULL, "init_rtcm leaves lclblk NULL");
+    CHECK(block2stat(r, stat) == 0, "block2stat with NULL lclblk returns 0");
+    CHECK(encode_lcltrop(r, 2001) == 0, "encode_lcltrop with NULL lclblk returns 0");
+    CHECK(encode_lcliono(r, 2002) == 0, "encode_lcliono with NULL lclblk returns 0");
+
+    blk = rtcm_lclblk(r);
+    CHECK(blk != NULL, "rtcm_lclblk allocates on first use");
+    CHECK(r->lclblk == blk, "rtcm_lclblk stores the allocation in rtcm->lclblk");
+    CHECK(rtcm_lclblk(r) == blk, "second rtcm_lclblk call returns the same pointer");
+
+    free_rtcm(r);
+    CHECK(r->lclblk == NULL, "free_rtcm resets lclblk to NULL");
+    free_rtcm(r); /* double-free safety: all pointers were NULLed above */
+    CHECK(r->lclblk == NULL, "second free_rtcm is safe");
+
+    free(stat);
+    free(r);
+}
+
+/* (2) trop (2001) encode->decode round-trip -------------------------------- */
+static void test_trop_roundtrip(void) {
+    rtcm_t* enc = (rtcm_t*)calloc(1, sizeof(rtcm_t));
+    rtcm_t* dec = (rtcm_t*)calloc(1, sizeof(rtcm_t));
+    stat_t* stat = (stat_t*)calloc(1, sizeof(stat_t));
+    /* Sunday 2026-08-16, tow=60 s: a 30 s multiple so the 15-bit epoch field
+     * (LSB 30 s) round-trips the time exactly */
+    double ep[] = {2026, 8, 16, 0, 1, 0.0};
+    double zazel[] = {0.0, PI / 2.0};
+    gtime_t t0 = epoch2time(ep);
+    lclblock_t* lcl;
+    blkinf_t* bi;
+    sitetrp_t* st;
+    trp_t* dtrp;
+    double zhd, trp_in;
+    int i, ret = 0, mid_ok = 1;
+
+    printf("--- test_trop_roundtrip\n");
+    if (!enc || !dec || !stat) {
+        printf("FAIL: calloc rtcm_t/stat_t\n");
+        fails++;
+        return;
+    }
+    CHECK(init_rtcm(enc) == 1 && init_rtcm(dec) == 1, "init_rtcm enc+dec");
+    enc->time = t0;
+
+    /* build a minimal valid trop block: grid type, bn=1204 (38N/136E),
+     * 16-grid pitch, single grid point (mask bit 0) */
+    lcl = rtcm_lclblk(enc);
+    CHECK(lcl != NULL, "encoder rtcm_lclblk");
+    bi = &lcl->tblkinf[0];
+    bi->btype = 0; /* BTYPE_GRID */
+    bi->bn = 1204;
+    bi->bs = TRP_BLKSIZE;
+    bi->gpitch = 0;
+    bi->mask[0] = 0x1;
+    initblkinf(bi);
+    CHECK(bi->n == 1 && bi->gp[0] == 0, "initblkinf: single grid point, gp[0]==0");
+    lcl->tnum = 1;
+    lcl->outtn = 0;
+
+    /* trop value: zhd + 15 cm zenith wet delay; std 0.010 quantizes to std
+     * index 2 -> 0.008 (deliberately off the log2 integer boundary) */
+    zhd = tropmodel(t0, bi->grid[0], zazel, 0.0);
+    st = &lcl->tstat[0][0];
+    st->trpd.time = t0;
+    st->trpd.trp[0] = zhd + 0.15;
+    st->trpd.std[0] = 0.010;
+    trp_in = st->trpd.trp[0];
+
+    CHECK(gen_rtcm3(enc, 2001, 0, 0) == 1, "gen_rtcm3 type 2001 succeeds");
+    CHECK(enc->nbyte == enc->len + 3, "framed length: nbyte == len + parity");
+    CHECK(enc->buff[0] == 0xD3, "frame starts with RTCM3 preamble");
+    CHECK(getbitu(enc->buff, 24, 12) == 2001, "message number field is 2001");
+
+    /* feed byte-by-byte into a fresh decoder */
+    dec->time = t0; /* approximate time to resolve the epoch week */
+    CHECK(dec->lclblk == NULL, "decoder lclblk NULL before first byte");
+    for (i = 0; i < enc->nbyte; i++) {
+        ret = input_rtcm3(dec, enc->buff[i]);
+        if (i + 1 < enc->nbyte && ret != 0) {
+            mid_ok = 0;
+        }
+    }
+    CHECK(mid_ok, "no decode result before the final byte");
+    CHECK(ret == 12, "final byte completes the message (ret==12)");
+    CHECK(dec->lclblk != NULL, "decoder allocated lclblk lazily");
+    if (!dec->lclblk) {
+        goto cleanup; /* remaining checks dereference dec->lclblk */
+    }
+    CHECK(dec->lclblk->tnum == 1, "decoded tnum == 1");
+    CHECK(dec->lclblk->tblkinf[0].bn == 1204, "block number round-trips");
+    CHECK(dec->lclblk->tblkinf[0].n == 1, "decoded grid point count == 1");
+
+    dtrp = &dec->lclblk->tstat[0][0].trpd;
+    CHECK(fabs(timediff(dtrp->time, t0)) < 1e-9, "epoch time round-trips exactly");
+    CHECK(fabs(dtrp->trp[0] - trp_in) < 2.0 * TRP_DET_LSB, "trop delay round-trips within quantization");
+    CHECK(fabs(dtrp->std[0] - 0.008) < 1e-12, "trop std quantizes to index 2 (0.008)");
+
+    /* block2stat non-NULL path on the decoded block */
+    CHECK(block2stat(dec, stat) == 1, "block2stat on decoded block returns 1");
+    CHECK(stat->nst == 1, "block2stat filled one trop station");
+    CHECK(fabs(stat->strp[0].trpd.trp[0] - trp_in) < 2.0 * TRP_DET_LSB, "block2stat trop value matches");
+
+cleanup:
+    free_rtcm(enc);
+    free_rtcm(dec);
+    free(stat);
+    free(enc);
+    free(dec);
+}
+
+int main(void) {
+    test_fresh_struct();
+    test_trop_roundtrip();
+
+    if (fails) {
+        printf("utest_lclblk: %d check(s) FAILED\n", fails);
+        return 1;
+    }
+    printf("utest_lclblk: all checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Converts the ~307 MB by-value `lclblock_t lclblk` member of `rtcm_t` into a lazily heap-allocated pointer, allocated only when RTCM3 local-correction messages (types 2001–2016) are actually processed. Closes #295.

| Struct | Before | After |
|---|---:|---:|
| `rtcm_t` | 314.36 MB | **7.48 MB** |
| `rtksvr_t` | 971.68 MB | **51.05 MB** |
| `strconv_t` | 635.82 MB | **22.06 MB** |
| **`mrtk run` startup peak RSS (RT replay, measured)** | **808 MiB** | **84 MiB (−89.5%)** |

(sizeof measured with the default preset: NFREQ=5, all constellations, MAXSAT=221)

## Design

- `rtcm_lclblk()` allocates on demand (calloc); decoders (`decode_lcltrop`/`decode_lcliono`) allocate at entry; encoders, `block2stat`, `output_lclcmb` NULL-guard and return the legacy empty-block result. `free_rtcm` frees; `init_rtcm` intentionally leaves the pointer untouched (documented ownership contract, matches legacy no-clear semantics).
- `strconvnew` malloc → calloc: required by the pointer contract, and fixes latent UB — `strconvfree` → `free_rtcm(&conv->out)` freed an uninitialized pointer.
- 46 mechanical `.`→`->` migrations across 3 consumer files; a reverse-rewrite diff (`->` back to `.`) is byte-identical to the original except the inserted guards — zero algorithmic change.

## Verification

- ctest: 121/121 registered, 120 pass; sole failure is the known env failure `madocalib_pppar_ion_check` (LAPACK tolerance, reproduces on clean develop). RT CLAS tests pass in isolation at their recorded 371 s.
- New `utest_lclblk` (30 checks): fresh-struct invariants + type-2001 encode→decode round-trip proving lazy allocation — no pre-existing test fed types 2001–2016.
- `mrtk post` output equivalence: before/after `.pos` deltas are indistinguishable from same-binary rerun noise (known Accelerate FP nondeterminism); code-level identity is established by the reverse-rewrite diff above.

## Reviewer sign-off items

1. **Behavior delta:** decoded local-correction blocks no longer survive a server restart (`free_rtcm` at thread exit). Legacy kept the stale array and `block2stat` re-stamped stale blocks with the current time — arguably a defect.
2. **Pre-existing, flagged not fixed:** `encode_lcltrop` indexes `grid[gp[i]]` while `initgridsta`/`decode_lcltrop` fill `grid[]` compactly; the utest pins `gp[0]==0` to sidestep it.
3. **Upstream sync note (docs/dev/pitfalls-public.md P-13):** upstream MALIB `rtklib.h` still embeds `lclblk` by value — future sync hunks from `rtcm3lcl.c`/`lclcmn.c`/`lclcmbcmn.c` need `.`→`->` adaptation plus the allocation guard. A `.`→`->`-only rewrite compiles but NULL-derefs.
4. External embedders of `rtcm_t` must rebuild (struct layout change, noted in CHANGELOG).

Follow-up candidate (not in this PR): the smaller related `nav_t.stat` (4.79 MB) lazy-allocation mentioned in #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)